### PR TITLE
Update Go to 1.17.6

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Go 1.17.6 is now available.

https://twitter.com/golang/status/1479199301352013829

From their release page:
```
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the Go 1.17.6 milestone on our issue tracker for details.
```