### PR TITLE
Bump GolangCI-lint to v1.44.0

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -13,7 +13,7 @@ else
   else
     DEPLOY_PATH=${GOPATH}/bin
   fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.43.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.44.0
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 
 // NewConfig returns instance Config type.
 func NewConfig() (*Config, error) {
-	var c Config
+	var conf Config
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filepath.Dir(filepath.Join(filepath.Dir(filename), "..")))
@@ -48,37 +48,37 @@ func NewConfig() (*Config, error) {
 		glog.Fatal(err)
 	}
 
-	err = readFile(&c, confFile)
+	err = readFile(&conf, confFile)
 
 	if err != nil {
 		return nil, err
 	}
 
-	c.General.ReportDirAbsPath = filepath.Join(baseDir, c.General.ReportDirAbsPath)
+	conf.General.ReportDirAbsPath = filepath.Join(baseDir, conf.General.ReportDirAbsPath)
 
-	err = readEnv(&c)
+	err = readEnv(&conf)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.deployTnfConfigDir(confFile)
+	err = conf.deployTnfConfigDir(confFile)
 
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.deployTnfReportDir(confFile)
+	err = conf.deployTnfReportDir(confFile)
 	if err != nil {
 		return nil, err
 	}
 
-	c.General.TnfRepoPath, err = c.defineTnfRepoPath()
+	conf.General.TnfRepoPath, err = conf.defineTnfRepoPath()
 
 	if err != nil {
 		glog.Fatal(err)
 	}
 
-	return &c, nil
+	return &conf, nil
 }
 
 func readFile(cfg *Config, cfgFile string) error {


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.0

```
INFO [runner] linters took 10.659234125s with stages: goanalysis_metalinter: 10.652175941s 
tests/utils/config/config.go:41:6: variable name 'c' is too short for the scope of its usage (varnamelen)
        var c Config
```