### PR TITLE
Bump GolangCI-lint to v1.44.1

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -13,7 +13,7 @@ else
   else
     DEPLOY_PATH=${GOPATH}/bin
   fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.44.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.44.1
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.1

No code changes found/needed.