### PR TITLE
Operator cert skip cases

### DIFF
--- a/tests/affiliatedcertification/affiliatedcertparameters/parameters.go
+++ b/tests/affiliatedcertification/affiliatedcertparameters/parameters.go
@@ -49,8 +49,5 @@ var (
 	ExistingOperatorNamespace          = "tnf"
 	CertifiedOperatorPrefixPostgres    = "postgresoperator"
 	CertifiedOperatorPrefixDatadog     = "datadog-operator"
-	CertifiedOperatorKubeturbo         = "kubeturbo-certified/certified-operators"
 	UncertifiedOperatorBarFoo          = "bar/foo"
-	OperatorNameOnlyKubeturbo          = "kubeturbo-certified"
-	OperatorOrgOnlyCertifiedOperators  = "certified-operators"
 )

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -274,10 +274,23 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 	})
 
 	// 46698
-	It("certifiedoperatorinfo field exists in tnf_config but has no value [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunOperatorCertTest(
-			[]string{""}, globalparameters.TestCaseSkipped)
-		Expect(err).ToNot(HaveOccurred())
+	It("no operators are labeled for testing [skip]", func() {
+		// no operators labeled to be tested, just need to run the test
+		By("Start test")
+
+		err := globalhelper.LaunchTests(
+			[]string{affiliatedcertparameters.AffiliatedCertificationTestSuiteName},
+			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
+		)
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
+			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
+
+		By("Verify test case status in Junit and Claim reports")
+
+		err = globalhelper.ValidateIfReportsAreValid(
+			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			globalparameters.TestCaseSkipped)
+		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
 
 	// 46700

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -67,7 +67,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 	// 46699
 	It("one operator to test, operator does not belong to certified-operators organization in Red Hat catalog [skip]",
 		func() {
-			// operator is already installed
+			// operator is already installed.
 			// not deleting csv yet because it is also used in the next test case
 
 			By("Label operator to be certified")

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -300,18 +300,4 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	// 46702
-	It("name field in certifiedoperatorinfo field is populated but organization field is not [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunOperatorCertTest(
-			[]string{affiliatedcertparameters.OperatorNameOnlyKubeturbo}, globalparameters.TestCaseSkipped)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	// 46704
-	It("organization field in certifiedoperatorinfo field is populated but name field is not [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunOperatorCertTest(
-			[]string{affiliatedcertparameters.OperatorOrgOnlyCertifiedOperators}, globalparameters.TestCaseSkipped)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
 })

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -275,7 +275,6 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 	// 46698
 	It("no operators are labeled for testing [skip]", func() {
-		// no operators labeled to be tested, just need to run the test
 		By("Start test")
 
 		err := globalhelper.LaunchTests(


### PR DESCRIPTION
Updated case where there are no operators to be certified and removed outdated skip cases that are no longer relevant. 