### PR TITLE
Update GolangCI to 1.45.2

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -13,7 +13,7 @@ else
   else
     DEPLOY_PATH=${GOPATH}/bin
   fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.44.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.45.2
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.45.2

Similar to:
https://github.com/test-network-function/cnf-certification-test/pull/92
https://github.com/test-network-function/test-network-function/pull/660
https://github.com/test-network-function/test-network-function-claim/pull/41