### PR TITLE
Automate lifecycle-pod-scheduling tests

### DIFF
--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -1,0 +1,175 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+)
+
+var _ = Describe("lifecycle-pod-scheduling", func() {
+
+	configSuite, err := config.NewConfig()
+	if err != nil {
+		glog.Fatal(fmt.Errorf("can not load config file"))
+	}
+
+	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases, lifeparameters.TnfPodSchedulingTcName)
+
+	BeforeEach(func() {
+		err := lifehelper.WaitUntilClusterIsStable()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Clean namespace before each test")
+		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 48120
+	It("One deployment, one daemonSet, no nodeselector nor node affinity", func() {
+
+		By("Define Deployment")
+		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Define DaemonSet")
+		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
+			lifeparameters.TestDeploymentLabels, "lifecycleds")
+
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle lifecycle-pod-scheduling test")
+		err = globalhelper.LaunchTests(
+			lifeparameters.LifecycleTestSuiteName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
+			stringOfSkipTc)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			lifeparameters.TnfPodSchedulingTcName,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 48458
+	It("One deployment with nodeSelector [negative]", func() {
+
+		By("Define Deployment with nodeSelector")
+		deployment := deployment.RedefineWithNodeSelector(lifehelper.DefineDeployment(1, 1, "lifecycledp"),
+			map[string]string{configSuite.General.CnfNodeLabel: ""})
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle lifecycle-pod-scheduling test")
+		err = globalhelper.LaunchTests(
+			lifeparameters.LifecycleTestSuiteName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
+			stringOfSkipTc)
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			lifeparameters.TnfPodSchedulingTcName,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 48470
+	It("One deployment with nodeAffinity [negative]", func() {
+
+		By("Define Deployment with nodeAffinity")
+		deployment := deployment.RedefineWithNodeAffinity(lifehelper.DefineDeployment(1, 1, "lifecycledp"),
+			configSuite.General.CnfNodeLabel)
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle lifecycle-pod-scheduling test")
+		err = globalhelper.LaunchTests(
+			lifeparameters.LifecycleTestSuiteName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
+			stringOfSkipTc)
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			lifeparameters.TnfPodSchedulingTcName,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 48471
+	It("Two deployments, one pod each, one pod with nodeAffinity [negative]", func() {
+
+		By("Define Deployment without nodeAffinity")
+		deploymenta := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Define Deployment with nodeAffinity")
+		deploymentb := deployment.RedefineWithNodeAffinity(lifehelper.DefineDeployment(1, 1, "lifecycledpb"),
+			configSuite.General.CnfNodeLabel)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle lifecycle-pod-scheduling test")
+		err = globalhelper.LaunchTests(
+			lifeparameters.LifecycleTestSuiteName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
+			stringOfSkipTc)
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			lifeparameters.TnfPodSchedulingTcName,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 48472
+	It("One deployment, one daemonSet, one pod with nodeAffinity [negative]", func() {
+
+		By("Define Deployment without nodeAffinity/ nodeSelector")
+		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Define daemonSet with nodeSelector")
+		daemonSet := daemonset.RedefineDaemonSetWithNodeSelector(
+			daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
+				lifeparameters.TestDeploymentLabels, "lifecycleds"), map[string]string{configSuite.General.CnfNodeLabel: ""})
+
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle lifecycle-pod-scheduling test")
+		err = globalhelper.LaunchTests(
+			lifeparameters.LifecycleTestSuiteName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
+			stringOfSkipTc)
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			lifeparameters.TnfPodSchedulingTcName,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -35,7 +35,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	})
 
 	// 48120
-	It("One deployment, one daemonSet, no nodeselector nor node affinity", func() {
+	It("One deployment, one daemonSet, no nodeSelector nor nodeAffinity", func() {
 
 		By("Define Deployment")
 		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")
@@ -143,7 +143,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	})
 
 	// 48472
-	It("One deployment, one daemonSet, one pod with nodeAffinity [negative]", func() {
+	It("One deployment, one daemonSet with nodeSelector [negative]", func() {
 
 		By("Define Deployment without nodeAffinity/ nodeSelector")
 		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -165,3 +165,29 @@ func RedefineWithImagePullPolicy(deployment *v1.Deployment, pullPolicy corev1.Pu
 
 	return deployment
 }
+
+func RedefineWithNodeSelector(deployment *v1.Deployment, nodeSelector map[string]string) *v1.Deployment {
+	deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+
+	return deployment
+}
+
+func RedefineWithNodeAffinity(deployment *v1.Deployment, key string) *v1.Deployment {
+	deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      key,
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+		}}
+
+	return deployment
+}


### PR DESCRIPTION
This PR contains 5 lifecycle-pod-scheduling test cases (48120, 48458, 48470, 48471, 48472).