### PR TITLE
Fix several lifecycle issues

### DIFF
--- a/tests/lifecycle/lifehelper/lifehelper.go
+++ b/tests/lifecycle/lifehelper/lifehelper.go
@@ -2,6 +2,7 @@ package lifehelper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,7 +24,11 @@ import (
 )
 
 // DefineDeployment defines a deployment.
-func DefineDeployment(replica int32, containersToAppend int, name string) *v1.Deployment {
+func DefineDeployment(replica int32, containers int, name string) (*v1.Deployment, error) {
+	if containers < 1 {
+		return nil, errors.New("invalid containers number")
+	}
+
 	deploymentStruct := globalhelper.AppendContainersToDeployment(
 		deployment.RedefineWithReplicaNumber(
 			deployment.DefineDeployment(
@@ -31,10 +36,10 @@ func DefineDeployment(replica int32, containersToAppend int, name string) *v1.De
 				lifeparameters.LifecycleNamespace,
 				globalhelper.Configuration.General.TnfImage,
 				lifeparameters.TestDeploymentLabels), replica),
-		containersToAppend,
+		containers-1,
 		globalhelper.Configuration.General.TnfImage)
 
-	return deploymentStruct
+	return deploymentStruct, nil
 }
 
 // RemoveterminationGracePeriod removes terminationGracePeriodSeconds field in a deployment.

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -34,9 +34,11 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 	It("One deployment, one pod, one container, scale in and out", func() {
 
 		By("Define Deployment")
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"),
-			lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
+			deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-deployment-scaling test")

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -27,10 +27,12 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One deployment with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deployment := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"), v1.PullIfNotPresent)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
@@ -51,20 +53,26 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("Several deployments with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define deployments with ifNotPresent as ImagePullPolicy")
-		deploymenta := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleputa"), v1.PullIfNotPresent)
-
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleputb"), v1.PullIfNotPresent)
+		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithImagePullPolicy(deploymentb, v1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentc := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleputc"), v1.PullIfNotPresent)
+		deploymentc, err := lifehelper.DefineDeployment(1, 1, "lifecycleputc")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentc = deployment.RedefineWithImagePullPolicy(deploymentc, v1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentc, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -203,10 +211,12 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One deployment with Always as ImagePullPolicy [negative]", func() {
 
 		By("Define deployment with 'Always' as ImagePullPolicy")
-		deployment := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"), v1.PullAlways)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullAlways)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
@@ -227,17 +237,19 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("Two deployments one with Never other with ifNotPresent as ImagePullPolicy [negative]", func() {
 
 		By("Define deployment with Never as ImagePullPolicy")
-		deploymenta := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"),
-			v1.PullNever)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullNever)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deploymentb := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleputb"),
-			v1.PullIfNotPresent)
+		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithImagePullPolicy(deploymentb, v1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -267,11 +279,12 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deploymentb := deployment.RedefineWithImagePullPolicy(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"),
-			v1.PullIfNotPresent)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -31,9 +31,11 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50053
 	It("One deployment, one pod with a liveness probe", func() {
 		By("Define deployment with a liveness probe")
-		deployment := deployment.RedefineWithLivenessProbe(
-			lifehelper.DefineDeployment(1, 1, "lifecycledp"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
@@ -53,14 +55,18 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50054
 	It("Two deployments, multiple pods each, all have a liveness probe", func() {
 		By("Define first deployment with a liveness probe")
-		deploymenta := deployment.RedefineWithLivenessProbe(
-			lifehelper.DefineDeployment(3, 1, "lifecycledpa"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(3, 1, "lifecycledpa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with a liveness probe")
-		deploymentb := deployment.RedefineWithLivenessProbe(
-			lifehelper.DefineDeployment(3, 1, "lifecycledpb"))
+		deploymentb, err := lifehelper.DefineDeployment(3, 1, "lifecycledpb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithLivenessProbe(deploymentb)
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,13 +154,17 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50058
 	It("Two deployments, one pod each, one without a liveness probe [negative]", func() {
 		By("Define first deployment with a liveness probe")
-		deploymenta := deployment.RedefineWithLivenessProbe(
-			lifehelper.DefineDeployment(1, 1, "lifecycledpa"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment without a liveness probe")
-		deploymentb := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		Expect(err).ToNot(HaveOccurred())
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -43,11 +43,12 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deployment := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(2, 1, "lifecycleput"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
@@ -74,17 +75,19 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create first deployment")
-		deploymenta := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(2, 1, "lifecycleputone"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(2, 1, "lifecycleputtwo"),
-			lifeparameters.TestDeploymentLabels)
+		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -113,7 +116,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deployment := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		deployment, err := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -142,13 +146,15 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create first deployment")
-		deploymenta := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb := lifehelper.DefineDeployment(2, 1, "lifecycleputtwo")
+		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputtwo")
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -177,11 +183,12 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deployment := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(1, 1, "lifecycleputone"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleputone")
+		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -52,11 +52,15 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("Two deployments, several pods", func() {
 
 		By("Define deployments")
-		deploymenta := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb := lifehelper.DefineDeployment(2, 1, "lifecycleputtwo")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -123,11 +127,15 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("Two deployments, one pod not related to any resource [negative]", func() {
 
 		By("Define deployments")
-		deploymenta := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb := lifehelper.DefineDeployment(2, 1, "lifecycleputtwo")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -49,11 +49,12 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		// at least one "clean of any resource" worker is needed.
 		maxPodsPerDeployment := schedulableNodes - 1
 		By("Define & create deployment")
-		deployment := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleput"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
@@ -81,17 +82,19 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		// at least one "clean of any resource" worker is needed.
 		maxPodsPerDeployment := (schedulableNodes / 2) - 1
 		By("Define & create first deployment")
-		deploymenta := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputone"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputtwo"),
-			lifeparameters.TestDeploymentLabels)
+		deploymentb, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -120,11 +123,12 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		}
 
 		By("Define & create deployment")
-		deployment := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(schedulableNodes, 1, "lifecycleput"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(schedulableNodes, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
@@ -154,17 +158,19 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		maxPodsPerDeploymentPerSecondDeployment := schedulableNodes - maxPodsPerDeploymentPerFirstDeployment
 
 		By("Define & create first deployment")
-		deploymenta := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(maxPodsPerDeploymentPerFirstDeployment, 1, "lifecycleputone"),
-			lifeparameters.TestDeploymentLabels)
+		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeploymentPerFirstDeployment, 1, "lifecycleputa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb := deployment.RedefineWithPodAntiAffinity(
-			lifehelper.DefineDeployment(maxPodsPerDeploymentPerSecondDeployment, 1, "lifecycleputtwo"),
-			lifeparameters.TestDeploymentLabels)
+		deploymentb, err := lifehelper.DefineDeployment(maxPodsPerDeploymentPerSecondDeployment, 1, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -35,19 +35,13 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	})
 
 	// 48120
-	It("One deployment, one daemonSet, no nodeSelector nor nodeAffinity", func() {
+	It("One deployment, no nodeSelector nor nodeAffinity", func() {
 
 		By("Define Deployment")
-		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")
-
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Define DaemonSet")
-		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
-			lifeparameters.TestDeploymentLabels, "lifecycleds")
-
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
@@ -68,10 +62,14 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment with nodeSelector [negative]", func() {
 
 		By("Define Deployment with nodeSelector")
-		deployment := deployment.RedefineWithNodeSelector(lifehelper.DefineDeployment(1, 1, "lifecycledp"),
-			map[string]string{configSuite.General.CnfNodeLabel: ""})
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithNodeSelector(deploymenta,
+			map[string]string{configSuite.General.CnfNodeLabel: ""})
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
@@ -92,10 +90,12 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment with nodeAffinity [negative]", func() {
 
 		By("Define Deployment with nodeAffinity")
-		deployment := deployment.RedefineWithNodeAffinity(lifehelper.DefineDeployment(1, 1, "lifecycledp"),
-			configSuite.General.CnfNodeLabel)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineWithNodeAffinity(deploymenta, configSuite.General.CnfNodeLabel)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
@@ -116,13 +116,17 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("Two deployments, one pod each, one pod with nodeAffinity [negative]", func() {
 
 		By("Define Deployment without nodeAffinity")
-		deploymenta := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define Deployment with nodeAffinity")
-		deploymentb := deployment.RedefineWithNodeAffinity(lifehelper.DefineDeployment(1, 1, "lifecycledpb"),
+		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithNodeAffinity(deploymentb,
 			configSuite.General.CnfNodeLabel)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
@@ -143,18 +147,18 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	})
 
 	// 48472
-	It("One deployment, one daemonSet with nodeSelector [negative]", func() {
+	It("One deployment, one daemonSet [negative]", func() {
 
 		By("Define Deployment without nodeAffinity/ nodeSelector")
-		deployment := lifehelper.DefineDeployment(1, 1, "lifecycledp")
-
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Define daemonSet with nodeSelector")
-		daemonSet := daemonset.RedefineDaemonSetWithNodeSelector(
-			daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
-				lifeparameters.TestDeploymentLabels, "lifecycleds"), map[string]string{configSuite.General.CnfNodeLabel: ""})
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Define daemonSet")
+		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
+			lifeparameters.TestDeploymentLabels, "lifecycleds")
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -31,9 +31,11 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50145
 	It("One deployment, one pod with a readiness probe", func() {
 		By("Define deployment with a readiness probe")
-		deployment := deployment.RedefineWithReadinessProbe(
-			lifehelper.DefineDeployment(1, 1, "lifecycledp"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
@@ -53,14 +55,18 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50146
 	It("Two deployments, multiple pods each, all have a readiness probe", func() {
 		By("Define first deployment with a readiness probe")
-		deploymenta := deployment.RedefineWithReadinessProbe(
-			lifehelper.DefineDeployment(3, 1, "lifecycledpa"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(3, 1, "lifecycledpa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with a readiness probe")
-		deploymentb := deployment.RedefineWithReadinessProbe(
-			lifehelper.DefineDeployment(3, 1, "lifecycledpb"))
+		deploymentb, err := lifehelper.DefineDeployment(3, 1, "lifecycledpb")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineWithReadinessProbe(deploymentb)
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,13 +154,17 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50150
 	It("Two deployments, one pod each, one without a readiness probe [negative]", func() {
 		By("Define first deployment with a readiness probe")
-		deploymenta := deployment.RedefineWithReadinessProbe(
-			lifehelper.DefineDeployment(1, 1, "lifecycledpa"))
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment without a readiness probe")
-		deploymentb := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		Expect(err).ToNot(HaveOccurred())
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_shutdown.go
@@ -25,14 +25,17 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	})
 
 	// 47311
-	It("One deployment, one pod, with one container that has preStop field configured", func() {
+	It("One deployment, one pod with preStop field configured", func() {
 
 		By("Define deployment with preStop field configured")
-		deployment, err := deployment.RedefineAllContainersWithPreStopSpec(
-			lifehelper.DefineDeployment(1, 1, "lifecycleput"), lifeparameters.PreStopCommand)
+
+		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
+			deploymenta, lifeparameters.PreStopCommand)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
@@ -50,12 +53,13 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	})
 
 	// 47315
-	It("One deployment, one pod, with one container that does not have preStop field configured [negative]", func() {
+	It("One deployment, one pod without preStop field configured [negative]", func() {
 
 		By("Define deployment without prestop field configured")
-		deployment := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
@@ -76,12 +80,14 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("One deployment, several pods, several containers that have preStop field configured", func() {
 
 		By("Define deployment with preStop field configured")
-		deployment, err := deployment.RedefineAllContainersWithPreStopSpec(
-			lifehelper.DefineDeployment(3, 2, "lifecycleput"), lifeparameters.PreStopCommand)
+		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
+		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
+			deploymenta, lifeparameters.PreStopCommand)
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deployment, lifeparameters.WaitingTime)
+			deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
@@ -102,18 +108,22 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("Two deployments, several pods, several containers that have preStop field configured", func() {
 
 		By("Define first deployment with preStop field configured")
-		deploymenta, err := deployment.RedefineAllContainersWithPreStopSpec(
-			lifehelper.DefineDeployment(3, 2, "lifecycleputone"), lifeparameters.PreStopCommand)
+		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
+			deploymenta, lifeparameters.PreStopCommand)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
 			deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with preStop field configured")
-		deploymentb, err := deployment.RedefineAllContainersWithPreStopSpec(
-			lifehelper.DefineDeployment(3, 2, "lifecycleputtwo"), lifeparameters.PreStopCommand)
+		deploymentb, err := lifehelper.DefineDeployment(3, 2, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
+
+		deploymentb = deployment.RedefineAllContainersWithPreStopSpec(
+			deploymentb, lifeparameters.PreStopCommand)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
 			deploymentb, lifeparameters.WaitingTime)
@@ -137,12 +147,15 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("One deployment, several pods, several containers one without preStop field configured [negative]", func() {
 
 		By("Define deployment with preStop field configured")
-		deployment, err := deployment.RedefineFirstContainerWithPreStopSpec(
-			lifehelper.DefineDeployment(3, 2, "lifecycleput"), lifeparameters.PreStopCommand)
+		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleput")
+		Expect(err).ToNot(HaveOccurred())
+
+		deploymenta, err = deployment.RedefineFirstContainerWithPreStopSpec(
+			deploymenta, lifeparameters.PreStopCommand)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deployment, lifeparameters.WaitingTime)
+			deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
@@ -163,13 +176,19 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("Two deployments, several pods, several containers that don't have preStop field configured [negative]", func() {
 
 		By("Define & create first deployment")
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			lifehelper.DefineDeployment(3, 2, "lifecycleputone"), lifeparameters.WaitingTime)
+		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleputa")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
+			deploymenta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
+		deploymentb, err := lifehelper.DefineDeployment(3, 2, "lifecycleputb")
+		Expect(err).ToNot(HaveOccurred())
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			lifehelper.DefineDeployment(3, 2, "lifecycleputtwo"), lifeparameters.WaitingTime)
+			deploymentb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -46,7 +46,7 @@ func DefineDeployment(deploymentName string, namespace string, image string, lab
 }
 
 // RedefineAllContainersWithPreStopSpec redefines deployment with requested lifecycle/preStop spec.
-func RedefineAllContainersWithPreStopSpec(deployment *v1.Deployment, command []string) (*v1.Deployment, error) {
+func RedefineAllContainersWithPreStopSpec(deployment *v1.Deployment, command []string) *v1.Deployment {
 	for index := range deployment.Spec.Template.Spec.Containers {
 		deployment.Spec.Template.Spec.Containers[index].Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.Handler{
@@ -55,11 +55,9 @@ func RedefineAllContainersWithPreStopSpec(deployment *v1.Deployment, command []s
 				},
 			},
 		}
-
-		return deployment, nil
 	}
 
-	return nil, fmt.Errorf("deployment %s does not have any containers", deployment.Name)
+	return deployment
 }
 
 // RedefineWithContainersSecurityContextAll redefines deployment with extended permissions.


### PR DESCRIPTION
This PR contains the following fixes: 

1. Fix container appending on lifehelper/DefineDeployment
2. Fix number 1 ^^ influenced almost all of the suite, but now it's more accurate and has better readability.
3. pod-scheduling -  daemonSet test is not relevant, since a daemonSet by nature has podAffinity spec, edited it to be relevant.
4. pod-scheduling - same has 3, but on a negative tc.
5. container-shutdown - Fixed RedefineAllContainersWithPreStopSpec, returned from the function before it iterated on all the containers.

This PR was tested 48/48 passed.