### PR TITLE
Change timeout param from 5 to 10 minutes

### DIFF
--- a/tests/affiliatedcertification/affiliatedcertparameters/parameters.go
+++ b/tests/affiliatedcertification/affiliatedcertparameters/parameters.go
@@ -19,7 +19,7 @@ type (
 )
 
 const (
-	Timeout         = 5 * time.Minute
+	Timeout         = 10 * time.Minute
 	PollingInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
On some CI runs, the k10-kasten operator successfully installs after the timeout of the Eventually() checking for it. 