### PR TITLE
Adaptations for new tnf repo

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,4 +9,4 @@ general:
   tnf_config_dir: "/tmp/tnf_config"
   tnf_report_dir: "/tmp/tnf_report"
   tnf_image: "quay.io/testnetworkfunction/cnf-certification-test"
-  tnf_image_tag: "latest"
+  tnf_image_tag: "unstable"

--- a/tests/affiliatedcertification/affiliatedcerthelper/affiliatedcerthelper.go
+++ b/tests/affiliatedcertification/affiliatedcerthelper/affiliatedcerthelper.go
@@ -34,9 +34,7 @@ func SetUpAndRunContainerCertTest(tcName string, containersInfo []string, expect
 
 	err = globalhelper.LaunchTests(
 		affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-		tcName,
-		affiliatedcertparameters.TestCaseContainerSkipRegEx,
-	)
+		tcName)
 
 	if strings.Contains(expectedResult, globalparameters.TestCaseFailed) && err == nil {
 		return fmt.Errorf("error running %s test",
@@ -78,9 +76,7 @@ func SetUpAndRunOperatorCertTest(tcName string, operatorsInfo []string, expected
 
 	err = globalhelper.LaunchTests(
 		affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-		tcName,
-		affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-	)
+		tcName)
 
 	if strings.Contains(expectedResult, globalparameters.TestCaseFailed) && err == nil {
 		return fmt.Errorf("error running %s test",

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -210,9 +210,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 			err = globalhelper.LaunchTests(
 				affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-				globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-				affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-			)
+				globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 			Expect(err).To(HaveOccurred(), "Error running "+
 				affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -247,9 +245,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err = globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -277,9 +273,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err = globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -314,9 +308,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err = globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -345,9 +337,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err = globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -382,9 +372,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err = globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 
@@ -403,9 +391,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		err := globalhelper.LaunchTests(
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			affiliatedcertparameters.TestCaseOperatorSkipRegEx,
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			affiliatedcertparameters.AffiliatedCertificationTestSuiteName+" test")
 

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/container"
 )
 
-func LaunchTests(testCaseName string, tcNameForReport string, skipRegEx string) error {
+func LaunchTests(testCaseName string, tcNameForReport string) error {
 	containerEngine, err := container.SelectEngine()
 	if err != nil {
 		return err
@@ -27,11 +27,6 @@ func LaunchTests(testCaseName string, tcNameForReport string, skipRegEx string) 
 		"-t", Configuration.General.TnfConfigDir,
 		"-o", Configuration.General.TnfReportDir,
 		"-i", fmt.Sprintf("%s:%s", Configuration.General.TnfImage, Configuration.General.TnfImageTag),
-	}
-
-	if skipRegEx != "" {
-		testArgs = append(testArgs, []string{"-s", skipRegEx}...)
-		glog.V(5).Info(fmt.Sprintf("set skip regex to %s", skipRegEx))
 	}
 
 	if len(testCaseName) > 0 {

--- a/tests/lifecycle/lifehelper/lifehelper.go
+++ b/tests/lifecycle/lifehelper/lifehelper.go
@@ -34,10 +34,10 @@ func DefineDeployment(replica int32, containers int, name string) (*v1.Deploymen
 			deployment.DefineDeployment(
 				name,
 				lifeparameters.LifecycleNamespace,
-				globalhelper.Configuration.General.TnfImage,
+				globalhelper.Configuration.General.TestImage,
 				lifeparameters.TestDeploymentLabels), replica),
 		containers-1,
-		globalhelper.Configuration.General.TnfImage)
+		globalhelper.Configuration.General.TestImage)
 
 	return deploymentStruct, nil
 }
@@ -50,20 +50,20 @@ func RemoveterminationGracePeriod(deploymentStruct *v1.Deployment) *v1.Deploymen
 func DefineReplicaSet(name string) *v1.ReplicaSet {
 	return replicaset.DefineReplicaSet(name,
 		lifeparameters.LifecycleNamespace,
-		globalhelper.Configuration.General.TnfImage,
+		globalhelper.Configuration.General.TestImage,
 		lifeparameters.TestDeploymentLabels)
 }
 
 func DefineStatefulSet(name string) *v1.StatefulSet {
 	return statefulset.DefineStatefulSet(name,
 		lifeparameters.LifecycleNamespace,
-		globalhelper.Configuration.General.TnfImage,
+		globalhelper.Configuration.General.TestImage,
 		lifeparameters.TestDeploymentLabels)
 }
 
 func DefinePod(name string) *corev1.Pod {
 	return pod.DefinePod(name, lifeparameters.LifecycleNamespace,
-		globalhelper.Configuration.General.TnfImage)
+		globalhelper.Configuration.General.TestImage)
 }
 
 // CreateAndWaitUntilStatefulSetIsReady creates statefulset and wait until all replicas are ready.

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -14,9 +14,6 @@ import (
 
 var _ = Describe("lifecycle-deployment-scaling", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfDeploymentScalingTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -43,9 +40,8 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 
 		By("Start lifecycle-deployment-scaling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfDeploymentScalingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -14,8 +14,6 @@ import (
 )
 
 var _ = Describe("lifecycle-image-pull-policy", func() {
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfImagePullPolicyTcName)
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
@@ -37,9 +35,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -79,9 +76,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -96,16 +92,15 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSet with ifNotPresent as ImagePullPolicy")
 		daemonSet := lifehelper.DefineDaemonSetWithImagePullPolicy(
-			"lifecycleds", globalhelper.Configuration.General.TnfImage, v1.PullIfNotPresent)
+			"lifecycleds", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -120,28 +115,27 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSets with ifNotPresent as ImagePullPolicy")
 		daemonSeta := lifehelper.DefineDaemonSetWithImagePullPolicy(
-			"lifecycledsa", globalhelper.Configuration.General.TnfImage, v1.PullIfNotPresent)
+			"lifecycledsa", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetb := lifehelper.DefineDaemonSetWithImagePullPolicy(
-			"lifecycledsb", globalhelper.Configuration.General.TnfImage, v1.PullIfNotPresent)
+			"lifecycledsb", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetc := lifehelper.DefineDaemonSetWithImagePullPolicy(
-			"lifecycledsc", globalhelper.Configuration.General.TnfImage, v1.PullIfNotPresent)
+			"lifecycledsc", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -167,9 +161,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -195,9 +188,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -221,9 +213,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -256,9 +247,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -273,7 +263,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSet with Never as ImagePullPolicy")
 		daemonSet := lifehelper.DefineDaemonSetWithImagePullPolicy(
-			"lifecycleds", globalhelper.Configuration.General.TnfImage, v1.PullNever)
+			"lifecycleds", globalhelper.Configuration.General.TestImage, v1.PullNever)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -289,9 +279,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfImagePullPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -16,9 +16,6 @@ import (
 
 var _ = Describe("lifecycle-liveness", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfLivenessTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -40,9 +37,8 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -72,9 +68,8 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -94,9 +89,8 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -116,9 +110,8 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -132,16 +125,15 @@ var _ = Describe("lifecycle-liveness", func() {
 	It("One daemonSet without a liveness probe [negative]", func() {
 		By("Define daemonSet without a liveness probe")
 		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
-			globalhelper.Configuration.General.TnfImage,
+			globalhelper.Configuration.General.TestImage,
 			lifeparameters.TestDeploymentLabels, "lifecyclesds")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -170,9 +162,8 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfLivenessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -15,9 +15,6 @@ import (
 
 var _ = Describe("lifecycle-pod-high-availability", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfPodHighAvailabilityTcName)
-
 	execute.BeforeAll(func() {
 		By("Make masters schedulable")
 		err := lifehelper.EnableMasterScheduling(true)
@@ -53,9 +50,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodHighAvailabilityTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -94,9 +90,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodHighAvailabilityTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -124,9 +119,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodHighAvailabilityTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -161,9 +155,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodHighAvailabilityTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -193,9 +186,8 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodHighAvailabilityTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -14,8 +14,6 @@ import (
 
 var _ = Describe("lifecycle-pod-owner-type", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases, lifeparameters.TnfPodOwnerTypeTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -36,9 +34,8 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodOwnerTypeTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -66,9 +63,8 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodOwnerTypeTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -88,9 +84,8 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodOwnerTypeTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -111,9 +106,8 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodOwnerTypeTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -147,9 +141,8 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodOwnerTypeTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -17,8 +17,6 @@ import (
 
 var _ = Describe("lifecycle-pod-recreation", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases, lifeparameters.TnfPodRecreationTcName)
-
 	execute.BeforeAll(func() {
 		By("Make masters schedulable")
 		err := lifehelper.EnableMasterScheduling(true)
@@ -59,9 +57,8 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodRecreationTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -101,9 +98,8 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodRecreationTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -133,9 +129,8 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodRecreationTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -177,9 +172,8 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodRecreationTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -23,8 +23,6 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		glog.Fatal(fmt.Errorf("can not load config file"))
 	}
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases, lifeparameters.TnfPodSchedulingTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -46,9 +44,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodSchedulingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -74,9 +71,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodSchedulingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -100,9 +96,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodSchedulingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -134,9 +129,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodSchedulingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -157,7 +151,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, globalhelper.Configuration.General.TnfImage,
+		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
+			globalhelper.Configuration.General.TestImage,
 			lifeparameters.TestDeploymentLabels, "lifecycleds")
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
@@ -165,9 +160,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfPodSchedulingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -16,9 +16,6 @@ import (
 
 var _ = Describe("lifecycle-readiness", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfReadinessTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -40,9 +37,8 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -72,9 +68,8 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -94,9 +89,8 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -116,9 +110,8 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -132,16 +125,15 @@ var _ = Describe("lifecycle-readiness", func() {
 	It("One daemonSet without a readiness probe [negative]", func() {
 		By("Define daemonSet without a readiness probe")
 		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
-			globalhelper.Configuration.General.TnfImage,
+			globalhelper.Configuration.General.TestImage,
 			lifeparameters.TestDeploymentLabels, "lifecycleds")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -170,9 +162,8 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfReadinessTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_shutdown.go
@@ -13,8 +13,6 @@ import (
 
 var _ = Describe("lifecycle-container-shutdown", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases, lifeparameters.TnfShutdownTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -40,9 +38,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -64,9 +61,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -92,9 +88,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -131,9 +126,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -160,9 +154,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -193,9 +186,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfShutdownTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -14,9 +14,6 @@ import (
 
 var _ = Describe("lifecycle-statefulset-scaling", func() {
 
-	stringOfSkipTc := globalhelper.GetStringOfSkipTcs(lifeparameters.TnfTestCases,
-		lifeparameters.TnfStatefulSetScalingTcName)
-
 	BeforeEach(func() {
 		err := lifehelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
@@ -39,9 +36,8 @@ var _ = Describe("lifecycle-statefulset-scaling", func() {
 
 		By("start lifecycle-statefulset-scaling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.LifecycleTestSuiteName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			stringOfSkipTc)
+			lifeparameters.TnfStatefulSetScalingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -54,9 +54,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfDefaultNetworkTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -86,9 +84,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfDefaultNetworkTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -120,9 +116,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfDefaultNetworkTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -147,9 +141,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfDefaultNetworkTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -186,9 +178,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfDefaultNetworkTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -65,9 +65,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -97,9 +95,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -134,9 +130,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -160,9 +154,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -200,9 +192,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -241,9 +231,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -268,9 +256,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -300,9 +286,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -332,9 +316,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -364,9 +346,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -397,9 +377,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -441,9 +419,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -486,9 +462,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfMultusIpv4TcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/networking/tests/networking_nodeport_service.go
+++ b/tests/networking/tests/networking_nodeport_service.go
@@ -47,9 +47,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfNodePortTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -74,9 +72,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfNodePortTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -104,9 +100,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfNodePortTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -130,9 +124,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfNodePortTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -160,9 +152,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			netparameters.TnfNodePortTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText),
-			"",
-		)
+			globalhelper.ConvertSpecNameToFileName(CurrentGinkgoTestDescription().FullTestText))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")


### PR DESCRIPTION
This PR contains adaptations in all of the suites, to work with the LaunchTests func after 
deleting the skipRegex. 

also, it includes one more fix in the lifecycle - using globalhelper.Configuration.General.TestImage.