### PR TITLE
Fix container shutdown file name, fix It block description to match polarion, change tc polarion number

### DIFF
--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -165,8 +165,8 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	// 47385
-	It("Two deployments, several pods, several containers that don't have preStop field configured [negative]", func() {
+	// 50761
+	It("Two deployments, several pods, several containers that do not have preStop field configured [negative]", func() {
 
 		By("Define & create first deployment")
 		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleputa")


### PR DESCRIPTION
The xml report was generated with a wrong tc description because of the " ' ", thus I had to change the
test name.