### PR TITLE
Upgrade to v3 checkout action

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.17.9
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run lint
         run: make lint


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/204 

https://github.com/actions/checkout/releases/tag/v3.0.2

`checkout` v3 is the latest available.