### PR TITLE
Upgrade to v3 setup-go action

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.9
 


### PR DESCRIPTION
https://github.com/actions/setup-go/releases/tag/v3.0.0

v3 is the latest available release of `setup-go`.

Similar to: https://github.com/test-network-function/cnf-certification-test/pull/205