### PR TITLE
Removed prefixes of local test suites' helpers/params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,21 @@ The project uses a development method - forking workflow
     ├── scripts                        # Makefile Scripts 
     ├── tests                          # Test cases directory
     │   ├── networking                 # Networking test cases directory
-    │   │   ├── nethelper       # Networking common test function
-    │   │   ├── netparameters   # Networking constants and parameters 
+    │   │   ├── helper                 # Networking common test function
+    │   │   ├── parameters             # Networking constants and parameters 
     │   │   └── tests                  # Networking test suite directory
     |   ├── affiliatedcertification    # Affiliated Certification test cases directory   
-    |   |   ├── affiliatedcerthelper         # Affiliated Certification common test function
-    |   |   ├── affiliatedcertparameters     # Affiliated Certification constants and parameters 
-    |   |   └── tests                        # Affiliated Certification test suite directory
+    |   |   ├── helper                 # Affiliated Certification common test function
+    |   |   ├── parameters             # Affiliated Certification constants and parameters 
+    |   |   └── tests                  # Affiliated Certification test suite directory
     │   ├── platform                   # Platform test cases directory
-    │   │   ├── platformhelper         # Platform common test function
-    │   │   ├── platformparameters     # Platform constants and parameters
+    │   │   ├── helper                 # Platform common test function
+    │   │   ├── parameters             # Platform constants and parameters
     │   │   └── tests                  # Platform test suite directory
-    │   ├── observability                    # Observability test cases directory
-    │   │   ├── observabilityhelper          # Observability common test function
-    │   │   ├── observabilityparameters      # Observability constant and parameters
-    │   │   └── tests                        # Observability test suite directory
+    │   ├── observability              # Observability test cases directory
+    │   │   ├── helper                 # Observability common test function
+    │   │   ├── parameters             # Observability constant and parameters
+    │   │   └── tests                  # Observability test suite directory
     │   ├── globalhelper               # Common test test function
     │   ├── globalparameters           # Common test function
     │   └── utils                      # Common utils functions. These utils are based on Kubernetes api calls

--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -11,10 +11,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/tests"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
 func TestAffiliatedCertification(t *testing.T) {
@@ -30,17 +31,17 @@ func TestAffiliatedCertification(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("Create namespace")
-	err := namespaces.Create(affiliatedcertparameters.TestCertificationNameSpace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.TestCertificationNameSpace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
 })
 
 var _ = AfterSuite(func() {
 
-	By(fmt.Sprintf("Remove %s namespace", affiliatedcertparameters.TestCertificationNameSpace))
+	By(fmt.Sprintf("Remove %s namespace", tsparams.TestCertificationNameSpace))
 	err := namespaces.DeleteAndWait(
 		globalhelper.APIClient,
-		affiliatedcertparameters.TestCertificationNameSpace,
-		affiliatedcertparameters.Timeout,
+		tsparams.TestCertificationNameSpace,
+		tsparams.Timeout,
 	)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/affiliatedcertification/helper/helper.go
+++ b/tests/affiliatedcertification/helper/helper.go
@@ -1,4 +1,4 @@
-package affiliatedcerthelper
+package helper
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	utils "github.com/test-network-function/cnfcert-tests-verification/tests/utils/operator"
@@ -21,8 +21,8 @@ func SetUpAndRunContainerCertTest(tcName string, containersInfo []string, expect
 	ginkgo.By("Add container information to " + globalparameters.DefaultTnfConfigFileName)
 
 	err = globalhelper.DefineTnfConfig(
-		[]string{affiliatedcertparameters.TestCertificationNameSpace},
-		[]string{affiliatedcertparameters.TestPodLabel},
+		[]string{tsparams.TestCertificationNameSpace},
+		[]string{tsparams.TestPodLabel},
 		containersInfo)
 
 	if err != nil {
@@ -32,24 +32,24 @@ func SetUpAndRunContainerCertTest(tcName string, containersInfo []string, expect
 	ginkgo.By("Start test")
 
 	err = globalhelper.LaunchTests(
-		affiliatedcertparameters.TestCaseContainerAffiliatedCertName,
+		tsparams.TestCaseContainerAffiliatedCertName,
 		tcName)
 
 	if strings.Contains(expectedResult, globalparameters.TestCaseFailed) && err == nil {
 		return fmt.Errorf("error running %s test",
-			affiliatedcertparameters.TestCaseContainerAffiliatedCertName)
+			tsparams.TestCaseContainerAffiliatedCertName)
 	}
 
 	if (strings.Contains(expectedResult, globalparameters.TestCasePassed) ||
 		strings.Contains(expectedResult, globalparameters.TestCaseSkipped)) && err != nil {
 		return fmt.Errorf("error running %s test: %w",
-			affiliatedcertparameters.TestCaseContainerAffiliatedCertName, err)
+			tsparams.TestCaseContainerAffiliatedCertName, err)
 	}
 
 	ginkgo.By("Verify test case status in Junit and Claim reports")
 
 	err = globalhelper.ValidateIfReportsAreValid(
-		affiliatedcertparameters.TestCaseContainerAffiliatedCertName,
+		tsparams.TestCaseContainerAffiliatedCertName,
 		expectedResult)
 
 	if err != nil {

--- a/tests/affiliatedcertification/helper/operator.go
+++ b/tests/affiliatedcertification/helper/operator.go
@@ -1,4 +1,4 @@
-package affiliatedcerthelper
+package helper
 
 import (
 	"context"
@@ -9,8 +9,6 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
-
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +17,8 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
 func DeployOperatorGroup(namespace string, operatorGroup *olmv1.OperatorGroup) error {
@@ -118,8 +118,8 @@ func DeployRHCertifiedOperatorSource(ocpVersion string) error {
 	err := globalhelper.APIClient.Create(context.TODO(),
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      affiliatedcertparameters.CertifiedOperatorGroup,
-				Namespace: affiliatedcertparameters.OperatorSourceNamespace,
+				Name:      tsparams.CertifiedOperatorGroup,
+				Namespace: tsparams.OperatorSourceNamespace,
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType:  "grpc",

--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -1,4 +1,4 @@
-package affiliatedcertparameters
+package parameters
 
 import (
 	"fmt"

--- a/tests/affiliatedcertification/tests/affiliated_certification_container.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container.go
@@ -3,11 +3,13 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcerthelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
 var _ = Describe("Affiliated-certification container certification,", func() {
@@ -22,41 +24,41 @@ var _ = Describe("Affiliated-certification container certification,", func() {
 
 	// 46562
 	It("one container to test, container is certified", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.CertifiedContainerCockroachDB}, globalparameters.TestCasePassed)
+			[]string{tsparams.CertifiedContainerCockroachDB}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46563
 	It("one container to test, container is not certified [negative]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.UncertifiedContainerNodeJs12}, globalparameters.TestCaseFailed)
+			[]string{tsparams.UncertifiedContainerNodeJs12}, globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46564
 	It("two containers to test, both are certified", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.CertifiedContainerCockroachDB,
-				affiliatedcertparameters.CertifiedContainer5gc}, globalparameters.TestCasePassed)
+			[]string{tsparams.CertifiedContainerCockroachDB,
+				tsparams.CertifiedContainer5gc}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46565
 	It("two containers to test, one is certified, one is not [negative]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.UncertifiedContainerNodeJs12,
-				affiliatedcertparameters.CertifiedContainerCockroachDB}, globalparameters.TestCaseFailed)
+			[]string{tsparams.UncertifiedContainerNodeJs12,
+				tsparams.CertifiedContainerCockroachDB}, globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46566
 	It("certifiedcontainerinfo field exists in tnf_config but has no value [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			[]string{""}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
@@ -64,7 +66,7 @@ var _ = Describe("Affiliated-certification container certification,", func() {
 
 	// 46567
 	It("certifiedcontainerinfo field does not exist in tnf_config [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			[]string{}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
@@ -72,35 +74,35 @@ var _ = Describe("Affiliated-certification container certification,", func() {
 
 	// 46578
 	It("name and repository fields exist in certifiedcontainerinfo field but are empty [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.EmptyFieldsContainer}, globalparameters.TestCaseSkipped)
+			[]string{tsparams.EmptyFieldsContainer}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46579
 	It("name field in certifiedcontainerinfo field is populated but repository field is not [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.ContainerNameOnlyCockroachDB}, globalparameters.TestCaseSkipped)
+			[]string{tsparams.ContainerNameOnlyCockroachDB}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46580
 	It("repository field in certifiedcontainerinfo field is populated but name field is not [skip]", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.ContainerRepoOnlyRedHatRegistry}, globalparameters.TestCaseSkipped)
+			[]string{tsparams.ContainerRepoOnlyRedHatRegistry}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46581
 	It("two containers listed in certifiedcontainerinfo field, one is certified, one has empty name and "+
 		"repository fields", func() {
-		err := affiliatedcerthelper.SetUpAndRunContainerCertTest(
+		err := tshelper.SetUpAndRunContainerCertTest(
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
-			[]string{affiliatedcertparameters.CertifiedContainer5gc,
-				affiliatedcertparameters.EmptyFieldsContainer}, globalparameters.TestCasePassed)
+			[]string{tsparams.CertifiedContainer5gc,
+				tsparams.EmptyFieldsContainer}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -5,18 +5,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcerthelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
 var _ = Describe("Affiliated-certification invalid operator certification,", func() {
 
 	var (
-		installedLabeledOperators []affiliatedcertparameters.OperatorLabelInfo
+		installedLabeledOperators []tsparams.OperatorLabelInfo
 	)
 
 	execute.BeforeAll(func() {
@@ -24,88 +26,88 @@ var _ = Describe("Affiliated-certification invalid operator certification,", fun
 
 		By("Deploy openshiftartifactoryha-operator for testing")
 		// openshiftartifactoryha-operator: in certified-operators group and version is certified
-		err := affiliatedcerthelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			"openshiftartifactoryha-operator",
 			"alpha",
-			affiliatedcertparameters.TestCertificationNameSpace,
-			affiliatedcertparameters.CertifiedOperatorGroup,
-			affiliatedcertparameters.OperatorSourceNamespace,
-			affiliatedcertparameters.CertifiedOperatorFullArtifactoryHa,
+			tsparams.TestCertificationNameSpace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorFullArtifactoryHa,
 			v1alpha1.ApprovalManual,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa)
+			tsparams.CertifiedOperatorPrefixArtifactoryHa)
 
-		approveInstallPlanWhenReady(affiliatedcertparameters.CertifiedOperatorFullArtifactoryHa,
-			affiliatedcertparameters.TestCertificationNameSpace)
+		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullArtifactoryHa,
+			tsparams.TestCertificationNameSpace)
 
-		err = waitUntilOperatorIsReady(affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-			affiliatedcertparameters.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixArtifactoryHa,
+			tsparams.TestCertificationNameSpace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixArtifactoryHa+
 			" is not ready")
 
 		// add openshiftartifactoryha operator info to array for cleanup in AfterEach
-		installedLabeledOperators = append(installedLabeledOperators, affiliatedcertparameters.OperatorLabelInfo{
-			OperatorPrefix: affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-			Namespace:      affiliatedcertparameters.TestCertificationNameSpace,
-			Label:          affiliatedcertparameters.OperatorLabel,
+		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
+			OperatorPrefix: tsparams.CertifiedOperatorPrefixArtifactoryHa,
+			Namespace:      tsparams.TestCertificationNameSpace,
+			Label:          tsparams.OperatorLabel,
 		})
 
 		// sriov-fec.v1.1.0 operator : in certified-operators group, version is not certified
 		By("Deploy alternate operator catalog source")
-		err = affiliatedcerthelper.DisableCatalogSource(affiliatedcertparameters.CertifiedOperatorGroup)
+		err = tshelper.DisableCatalogSource(tsparams.CertifiedOperatorGroup)
 		Expect(err).ToNot(HaveOccurred(), "Error disabling "+
-			affiliatedcertparameters.CertifiedOperatorGroup+" catalog source")
+			tsparams.CertifiedOperatorGroup+" catalog source")
 		Eventually(func() bool {
-			stillEnabled, err := affiliatedcerthelper.IsCatalogSourceEnabled(
-				affiliatedcertparameters.CertifiedOperatorGroup,
-				affiliatedcertparameters.OperatorSourceNamespace,
-				affiliatedcertparameters.CertifiedOperatorDisplayName)
+			stillEnabled, err := tshelper.IsCatalogSourceEnabled(
+				tsparams.CertifiedOperatorGroup,
+				tsparams.OperatorSourceNamespace,
+				tsparams.CertifiedOperatorDisplayName)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("can not collect catalogSource object due to %s", err))
 
 			return !stillEnabled
-		}, affiliatedcertparameters.Timeout, affiliatedcertparameters.PollingInterval).Should(Equal(true),
+		}, tsparams.Timeout, tsparams.PollingInterval).Should(Equal(true),
 			"Default catalog source is still enabled")
 
 		// Deploying certified operator with invalid catalog version is necessary in order to cover negative scenarios
-		err = affiliatedcerthelper.DeployRHCertifiedOperatorSource("4.5")
+		err = tshelper.DeployRHCertifiedOperatorSource("4.5")
 		Expect(err).ToNot(HaveOccurred(), "Error deploying catalog source")
 
 		By("Deploy sriov-fec operator with uncertified version")
-		err = affiliatedcerthelper.DeployOperatorSubscription(
-			affiliatedcertparameters.UncertifiedOperatorPrefixSriov,
+		err = tshelper.DeployOperatorSubscription(
+			tsparams.UncertifiedOperatorPrefixSriov,
 			"stable",
-			affiliatedcertparameters.TestCertificationNameSpace,
-			affiliatedcertparameters.CertifiedOperatorGroup,
-			affiliatedcertparameters.OperatorSourceNamespace,
-			affiliatedcertparameters.UncertifiedOperatorFullSriov,
+			tsparams.TestCertificationNameSpace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.UncertifiedOperatorFullSriov,
 			v1alpha1.ApprovalManual,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			affiliatedcertparameters.UncertifiedOperatorPrefixSriov)
+			tsparams.UncertifiedOperatorPrefixSriov)
 
-		approveInstallPlanWhenReady(affiliatedcertparameters.UncertifiedOperatorFullSriov,
-			affiliatedcertparameters.TestCertificationNameSpace)
+		approveInstallPlanWhenReady(tsparams.UncertifiedOperatorFullSriov,
+			tsparams.TestCertificationNameSpace)
 
-		err = waitUntilOperatorIsReady(affiliatedcertparameters.UncertifiedOperatorPrefixSriov,
-			affiliatedcertparameters.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+affiliatedcertparameters.UncertifiedOperatorPrefixSriov+
+		err = waitUntilOperatorIsReady(tsparams.UncertifiedOperatorPrefixSriov,
+			tsparams.TestCertificationNameSpace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.UncertifiedOperatorPrefixSriov+
 			" is not ready")
 
 		By("Re-enable default catalog source")
-		err = affiliatedcerthelper.DeleteCatalogSource(affiliatedcertparameters.CertifiedOperatorGroup,
-			affiliatedcertparameters.TestCertificationNameSpace,
+		err = tshelper.DeleteCatalogSource(tsparams.CertifiedOperatorGroup,
+			tsparams.TestCertificationNameSpace,
 			"redhat-certified")
 		Expect(err).ToNot(HaveOccurred(), "Error removing alternate catalog source")
 
-		err = affiliatedcerthelper.EnableCatalogSource(affiliatedcertparameters.CertifiedOperatorGroup)
+		err = tshelper.EnableCatalogSource(tsparams.CertifiedOperatorGroup)
 		Expect(err).ToNot(HaveOccurred(), "Error enabling default catalog source")
 
 		// add sriov-fec operator info to array for cleanup in AfterEach
-		installedLabeledOperators = append(installedLabeledOperators, affiliatedcertparameters.OperatorLabelInfo{
-			OperatorPrefix: affiliatedcertparameters.UncertifiedOperatorPrefixSriov,
-			Namespace:      affiliatedcertparameters.TestCertificationNameSpace,
-			Label:          affiliatedcertparameters.OperatorLabel,
+		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
+			OperatorPrefix: tsparams.UncertifiedOperatorPrefixSriov,
+			Namespace:      tsparams.TestCertificationNameSpace,
+			Label:          tsparams.OperatorLabel,
 		})
 
 	})
@@ -113,7 +115,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", fun
 	AfterEach(func() {
 		By("Remove labels from operators")
 		for _, info := range installedLabeledOperators {
-			err := affiliatedcerthelper.DeleteLabelFromInstalledCSV(
+			err := tshelper.DeleteLabelFromInstalledCSV(
 				info.OperatorPrefix,
 				info.Namespace,
 				info.Label)
@@ -127,23 +129,23 @@ var _ = Describe("Affiliated-certification invalid operator certification,", fun
 
 		By("Label operator to be certified")
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.UncertifiedOperatorPrefixSriov,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.UncertifiedOperatorPrefixSriov)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.UncertifiedOperatorPrefixSriov,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixSriov)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
@@ -154,31 +156,31 @@ var _ = Describe("Affiliated-certification invalid operator certification,", fun
 
 		By("Label operators to be certified")
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.UncertifiedOperatorPrefixSriov,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.UncertifiedOperatorPrefixSriov)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.UncertifiedOperatorPrefixSriov,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixSriov)
 
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixArtifactoryHa,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixArtifactoryHa)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -3,18 +3,20 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcerthelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
 var _ = Describe("Affiliated-certification operator certification,", func() {
 
 	var (
-		installedLabeledOperators []affiliatedcertparameters.OperatorLabelInfo
+		installedLabeledOperators []tsparams.OperatorLabelInfo
 	)
 
 	execute.BeforeAll(func() {
@@ -22,93 +24,93 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		By("Deploy falcon-operator for testing")
 		// falcon-operator: not in certified-operators group in catalog, for negative test cases
-		err := affiliatedcerthelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			"falcon-operator",
 			"alpha",
-			affiliatedcertparameters.TestCertificationNameSpace,
-			affiliatedcertparameters.CommunityOperatorGroup,
-			affiliatedcertparameters.OperatorSourceNamespace,
+			tsparams.TestCertificationNameSpace,
+			tsparams.CommunityOperatorGroup,
+			tsparams.OperatorSourceNamespace,
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			affiliatedcertparameters.UncertifiedOperatorPrefixFalcon)
+			tsparams.UncertifiedOperatorPrefixFalcon)
 
-		err = waitUntilOperatorIsReady(affiliatedcertparameters.UncertifiedOperatorPrefixFalcon,
-			affiliatedcertparameters.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+affiliatedcertparameters.UncertifiedOperatorPrefixFalcon+
+		err = waitUntilOperatorIsReady(tsparams.UncertifiedOperatorPrefixFalcon,
+			tsparams.TestCertificationNameSpace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.UncertifiedOperatorPrefixFalcon+
 			" is not ready")
 
 		// add falcon operator info to array for cleanup in AfterEach
-		installedLabeledOperators = append(installedLabeledOperators, affiliatedcertparameters.OperatorLabelInfo{
-			OperatorPrefix: affiliatedcertparameters.UncertifiedOperatorPrefixFalcon,
-			Namespace:      affiliatedcertparameters.TestCertificationNameSpace,
-			Label:          affiliatedcertparameters.OperatorLabel,
+		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
+			OperatorPrefix: tsparams.UncertifiedOperatorPrefixFalcon,
+			Namespace:      tsparams.TestCertificationNameSpace,
+			Label:          tsparams.OperatorLabel,
 		})
 
 		By("Deploy infinibox-operator for testing")
 		// infinibox-operator: in certified-operators group and version is certified
-		err = affiliatedcerthelper.DeployOperatorSubscription(
+		err = tshelper.DeployOperatorSubscription(
 			"infinibox-operator-certified",
 			"stable",
-			affiliatedcertparameters.TestCertificationNameSpace,
-			affiliatedcertparameters.CertifiedOperatorGroup,
-			affiliatedcertparameters.OperatorSourceNamespace,
-			affiliatedcertparameters.CertifiedOperatorFullInfinibox,
+			tsparams.TestCertificationNameSpace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorFullInfinibox,
 			v1alpha1.ApprovalManual,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			affiliatedcertparameters.CertifiedOperatorPrefixInfinibox)
+			tsparams.CertifiedOperatorPrefixInfinibox)
 
-		approveInstallPlanWhenReady(affiliatedcertparameters.CertifiedOperatorFullInfinibox,
-			affiliatedcertparameters.TestCertificationNameSpace)
+		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullInfinibox,
+			tsparams.TestCertificationNameSpace)
 
-		err = waitUntilOperatorIsReady(affiliatedcertparameters.CertifiedOperatorPrefixInfinibox,
-			affiliatedcertparameters.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+affiliatedcertparameters.CertifiedOperatorPrefixInfinibox+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixInfinibox,
+			tsparams.TestCertificationNameSpace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixInfinibox+
 			" is not ready")
 
 		// add infinibox operator info to array for cleanup in AfterEach
-		installedLabeledOperators = append(installedLabeledOperators, affiliatedcertparameters.OperatorLabelInfo{
-			OperatorPrefix: affiliatedcertparameters.CertifiedOperatorPrefixInfinibox,
-			Namespace:      affiliatedcertparameters.TestCertificationNameSpace,
-			Label:          affiliatedcertparameters.OperatorLabel,
+		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
+			OperatorPrefix: tsparams.CertifiedOperatorPrefixInfinibox,
+			Namespace:      tsparams.TestCertificationNameSpace,
+			Label:          tsparams.OperatorLabel,
 		})
 
 		By("Deploy openshiftartifactoryha-operator for testing")
 		// openshiftartifactoryha-operator: in certified-operators group and version is certified
-		err = affiliatedcerthelper.DeployOperatorSubscription(
+		err = tshelper.DeployOperatorSubscription(
 			"openshiftartifactoryha-operator",
 			"alpha",
-			affiliatedcertparameters.TestCertificationNameSpace,
-			affiliatedcertparameters.CertifiedOperatorGroup,
-			affiliatedcertparameters.OperatorSourceNamespace,
-			affiliatedcertparameters.CertifiedOperatorFullArtifactoryHa,
+			tsparams.TestCertificationNameSpace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorFullArtifactoryHa,
 			v1alpha1.ApprovalManual,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa)
+			tsparams.CertifiedOperatorPrefixArtifactoryHa)
 
-		approveInstallPlanWhenReady(affiliatedcertparameters.CertifiedOperatorFullArtifactoryHa,
-			affiliatedcertparameters.TestCertificationNameSpace)
+		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullArtifactoryHa,
+			tsparams.TestCertificationNameSpace)
 
-		err = waitUntilOperatorIsReady(affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-			affiliatedcertparameters.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixArtifactoryHa,
+			tsparams.TestCertificationNameSpace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixArtifactoryHa+
 			" is not ready")
 
 		// add openshiftartifactoryha operator info to array for cleanup in AfterEach
-		installedLabeledOperators = append(installedLabeledOperators, affiliatedcertparameters.OperatorLabelInfo{
-			OperatorPrefix: affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-			Namespace:      affiliatedcertparameters.TestCertificationNameSpace,
-			Label:          affiliatedcertparameters.OperatorLabel,
+		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
+			OperatorPrefix: tsparams.CertifiedOperatorPrefixArtifactoryHa,
+			Namespace:      tsparams.TestCertificationNameSpace,
+			Label:          tsparams.OperatorLabel,
 		})
 	})
 
 	AfterEach(func() {
 		By("Remove labels from operators")
 		for _, info := range installedLabeledOperators {
-			err := affiliatedcerthelper.DeleteLabelFromInstalledCSV(
+			err := tshelper.DeleteLabelFromInstalledCSV(
 				info.OperatorPrefix,
 				info.Namespace,
 				info.Label)
@@ -121,23 +123,23 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 		func() {
 			By("Label operator to be certified")
 			Eventually(func() error {
-				return affiliatedcerthelper.AddLabelToInstalledCSV(
-					affiliatedcertparameters.UncertifiedOperatorPrefixFalcon,
-					affiliatedcertparameters.TestCertificationNameSpace,
-					affiliatedcertparameters.OperatorLabel)
-			}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-				"Error labeling operator "+affiliatedcertparameters.UncertifiedOperatorPrefixFalcon)
+				return tshelper.AddLabelToInstalledCSV(
+					tsparams.UncertifiedOperatorPrefixFalcon,
+					tsparams.TestCertificationNameSpace,
+					tsparams.OperatorLabel)
+			}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+				"Error labeling operator "+tsparams.UncertifiedOperatorPrefixFalcon)
 
 			By("Start test")
 			err := globalhelper.LaunchTests(
-				affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+				tsparams.TestCaseOperatorAffiliatedCertName,
 				globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 			Expect(err).To(HaveOccurred(), "Error running "+
-				affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+				tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 			By("Verify test case status in Junit and Claim reports")
 			err = globalhelper.ValidateIfReportsAreValid(
-				affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+				tsparams.TestCaseOperatorAffiliatedCertName,
 				globalparameters.TestCaseFailed)
 			Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 		})
@@ -148,31 +150,31 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 		By("Label operators to be certified")
 
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.CertifiedOperatorPrefixInfinibox,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.CertifiedOperatorPrefixInfinibox)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixInfinibox,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInfinibox)
 
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.UncertifiedOperatorPrefixFalcon,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.UncertifiedOperatorPrefixFalcon)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.UncertifiedOperatorPrefixFalcon,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixFalcon)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
@@ -183,23 +185,23 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 		By("Label operator to be certified")
 
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixArtifactoryHa,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixArtifactoryHa)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
@@ -209,31 +211,31 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 		" versions are certified", func() {
 		By("Label operators to be certified")
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.CertifiedOperatorPrefixArtifactoryHa)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixArtifactoryHa,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixArtifactoryHa)
 
 		Eventually(func() error {
-			return affiliatedcerthelper.AddLabelToInstalledCSV(
-				affiliatedcertparameters.CertifiedOperatorPrefixInfinibox,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				affiliatedcertparameters.OperatorLabel)
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+affiliatedcertparameters.CertifiedOperatorPrefixInfinibox)
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixInfinibox,
+				tsparams.TestCertificationNameSpace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInfinibox)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
@@ -242,14 +244,14 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 	It("no operators are labeled for testing [skip]", func() {
 		By("Start test")
 		err := globalhelper.LaunchTests(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName+" test")
+			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			affiliatedcertparameters.TestCaseOperatorAffiliatedCertName,
+			tsparams.TestCaseOperatorAffiliatedCertName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})

--- a/tests/affiliatedcertification/tests/affiliated_common.go
+++ b/tests/affiliatedcertification/tests/affiliated_common.go
@@ -7,54 +7,56 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcerthelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/affiliatedcertparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 	utils "github.com/test-network-function/cnfcert-tests-verification/tests/utils/operator"
 )
 
 func preConfigureAffiliatedCertificationEnvironment() {
 	By("Clean test namespace")
 
-	err := namespaces.Clean(affiliatedcertparameters.TestCertificationNameSpace, globalhelper.APIClient)
+	err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred(),
-		"Error cleaning namespace "+affiliatedcertparameters.TestCertificationNameSpace)
+		"Error cleaning namespace "+tsparams.TestCertificationNameSpace)
 
 	By("Ensure default catalog source is enabled")
 
-	catalogEnabled, err := affiliatedcerthelper.IsCatalogSourceEnabled(
-		affiliatedcertparameters.CertifiedOperatorGroup,
-		affiliatedcertparameters.OperatorSourceNamespace,
-		affiliatedcertparameters.CertifiedOperatorDisplayName)
+	catalogEnabled, err := tshelper.IsCatalogSourceEnabled(
+		tsparams.CertifiedOperatorGroup,
+		tsparams.OperatorSourceNamespace,
+		tsparams.CertifiedOperatorDisplayName)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("can not collect catalogSource object due to %s", err))
 
 	if !catalogEnabled {
 		Expect(
-			affiliatedcerthelper.EnableCatalogSource(affiliatedcertparameters.CertifiedOperatorGroup)).ToNot(
+			tshelper.EnableCatalogSource(tsparams.CertifiedOperatorGroup)).ToNot(
 			HaveOccurred())
 		Eventually(func() bool {
-			catalogEnabled, err = affiliatedcerthelper.IsCatalogSourceEnabled(
-				affiliatedcertparameters.CertifiedOperatorGroup,
-				affiliatedcertparameters.OperatorSourceNamespace,
-				affiliatedcertparameters.CertifiedOperatorDisplayName)
+			catalogEnabled, err = tshelper.IsCatalogSourceEnabled(
+				tsparams.CertifiedOperatorGroup,
+				tsparams.OperatorSourceNamespace,
+				tsparams.CertifiedOperatorDisplayName)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("can not collect catalogSource object due to %s", err))
 
 			return catalogEnabled
-		}, affiliatedcertparameters.TimeoutLabelCsv, affiliatedcertparameters.PollingInterval).Should(BeTrue(),
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(BeTrue(),
 			fmt.Sprintf("Default catalog source %s is not enabled",
-				affiliatedcertparameters.CertifiedOperatorGroup))
+				tsparams.CertifiedOperatorGroup))
 	}
 
 	By("Deploy OperatorGroup if not already deployed")
 
-	if affiliatedcerthelper.IsOperatorGroupInstalled(affiliatedcertparameters.OperatorGroupName,
-		affiliatedcertparameters.TestCertificationNameSpace) != nil {
-		err = affiliatedcerthelper.DeployOperatorGroup(affiliatedcertparameters.TestCertificationNameSpace,
-			utils.DefineOperatorGroup(affiliatedcertparameters.OperatorGroupName,
-				affiliatedcertparameters.TestCertificationNameSpace,
-				[]string{affiliatedcertparameters.TestCertificationNameSpace}),
+	if tshelper.IsOperatorGroupInstalled(tsparams.OperatorGroupName,
+		tsparams.TestCertificationNameSpace) != nil {
+		err = tshelper.DeployOperatorGroup(tsparams.TestCertificationNameSpace,
+			utils.DefineOperatorGroup(tsparams.OperatorGroupName,
+				tsparams.TestCertificationNameSpace,
+				[]string{tsparams.TestCertificationNameSpace}),
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operatorgroup")
 	}
@@ -62,8 +64,8 @@ func preConfigureAffiliatedCertificationEnvironment() {
 	By("Define config file " + globalparameters.DefaultTnfConfigFileName)
 
 	err = globalhelper.DefineTnfConfig(
-		[]string{affiliatedcertparameters.TestCertificationNameSpace},
-		[]string{affiliatedcertparameters.TestPodLabel},
+		[]string{tsparams.TestCertificationNameSpace},
+		[]string{tsparams.TestPodLabel},
 		[]string{})
 	Expect(err).ToNot(HaveOccurred(), "Error defining tnf config file")
 }
@@ -74,7 +76,7 @@ func waitUntilOperatorIsReady(csvPrefix, namespace string) error {
 	var csv *v1alpha1.ClusterServiceVersion
 
 	Eventually(func() bool {
-		csv, err = affiliatedcerthelper.GetCsvByPrefix(csvPrefix, namespace)
+		csv, err = tshelper.GetCsvByPrefix(csvPrefix, namespace)
 		if csv != nil && csv.Status.Phase != v1alpha1.CSVPhaseNone {
 			return csv.Status.Phase != "InstallReady" &&
 				csv.Status.Phase != "Deleting" &&
@@ -83,7 +85,7 @@ func waitUntilOperatorIsReady(csvPrefix, namespace string) error {
 		}
 
 		return false
-	}, affiliatedcertparameters.Timeout, affiliatedcertparameters.PollingInterval).Should(Equal(true),
+	}, tsparams.Timeout, tsparams.PollingInterval).Should(Equal(true),
 		csvPrefix+" is not ready.")
 
 	return err
@@ -91,7 +93,7 @@ func waitUntilOperatorIsReady(csvPrefix, namespace string) error {
 
 func approveInstallPlanWhenReady(csvName, namespace string) {
 	Eventually(func() bool {
-		installPlan, err := affiliatedcerthelper.GetInstallPlanByCSV(namespace, csvName)
+		installPlan, err := tshelper.GetInstallPlanByCSV(namespace, csvName)
 		if err != nil {
 			return false
 		}
@@ -101,13 +103,13 @@ func approveInstallPlanWhenReady(csvName, namespace string) {
 		}
 
 		if installPlan.Status.Phase == v1alpha1.InstallPlanPhaseRequiresApproval {
-			err = affiliatedcerthelper.ApproveInstallPlan(affiliatedcertparameters.TestCertificationNameSpace,
+			err = tshelper.ApproveInstallPlan(tsparams.TestCertificationNameSpace,
 				installPlan)
 
 			return err == nil
 		}
 
 		return false
-	}, affiliatedcertparameters.Timeout, affiliatedcertparameters.PollingInterval).Should(Equal(true),
+	}, tsparams.Timeout, tsparams.PollingInterval).Should(Equal(true),
 		csvName+" install plan is not ready.")
 }

--- a/tests/lifecycle/helper/helper.go
+++ b/tests/lifecycle/helper/helper.go
@@ -1,4 +1,4 @@
-package lifehelper
+package helper
 
 import (
 	"context"
@@ -6,22 +6,24 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/gomega"
+
+	"github.com/golang/glog"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/cluster"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 
-	"github.com/golang/glog"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/replicaset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/gomega"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 // DefineDeployment defines a deployment.
@@ -34,9 +36,9 @@ func DefineDeployment(replica int32, containers int, name string) (*v1.Deploymen
 		deployment.RedefineWithReplicaNumber(
 			deployment.DefineDeployment(
 				name,
-				lifeparameters.LifecycleNamespace,
+				tsparams.LifecycleNamespace,
 				globalhelper.Configuration.General.TestImage,
-				lifeparameters.TestDeploymentLabels), replica),
+				tsparams.TestDeploymentLabels), replica),
 		containers-1,
 		globalhelper.Configuration.General.TestImage)
 
@@ -45,20 +47,20 @@ func DefineDeployment(replica int32, containers int, name string) (*v1.Deploymen
 
 func DefineReplicaSet(name string) *v1.ReplicaSet {
 	return replicaset.DefineReplicaSet(name,
-		lifeparameters.LifecycleNamespace,
+		tsparams.LifecycleNamespace,
 		globalhelper.Configuration.General.TestImage,
-		lifeparameters.TestDeploymentLabels)
+		tsparams.TestDeploymentLabels)
 }
 
 func DefineStatefulSet(name string) *v1.StatefulSet {
 	return statefulset.DefineStatefulSet(name,
-		lifeparameters.LifecycleNamespace,
+		tsparams.LifecycleNamespace,
 		globalhelper.Configuration.General.TestImage,
-		lifeparameters.TestDeploymentLabels)
+		tsparams.TestDeploymentLabels)
 }
 
 func DefinePod(name string) *corev1.Pod {
-	return pod.DefinePod(name, lifeparameters.LifecycleNamespace,
+	return pod.DefinePod(name, tsparams.LifecycleNamespace,
 		globalhelper.Configuration.General.TestImage)
 }
 
@@ -76,13 +78,13 @@ func CreateAndWaitUntilReplicaSetIsReady(replicaSet *v1.ReplicaSet, timeout time
 		status, err := isReplicaSetReady(runningReplica.Namespace, runningReplica.Name)
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"replicaSet %s is not ready, retry in %d seconds", runningReplica.Name, lifeparameters.RetryInterval))
+				"replicaSet %s is not ready, retry in %d seconds", runningReplica.Name, tsparams.RetryInterval))
 
 			return false
 		}
 
 		return status
-	}, timeout, lifeparameters.RetryInterval*time.Second).Should(Equal(true), "replicaSet is not ready")
+	}, timeout, tsparams.RetryInterval*time.Second).Should(Equal(true), "replicaSet is not ready")
 
 	return nil
 }
@@ -104,8 +106,8 @@ func EnableMasterScheduling(scheduleable bool) error {
 
 func DefineDaemonSetWithImagePullPolicy(name string, image string, pullPolicy corev1.PullPolicy) *v1.DaemonSet {
 	return daemonset.RedefineWithImagePullPolicy(
-		daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace, image,
-			lifeparameters.TestDeploymentLabels, name), pullPolicy)
+		daemonset.DefineDaemonSet(tsparams.LifecycleNamespace, image,
+			tsparams.TestDeploymentLabels, name), pullPolicy)
 }
 
 // WaitUntilClusterIsStable validates that all nodes are schedulable, and in ready state.
@@ -115,10 +117,10 @@ func WaitUntilClusterIsStable() error {
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
-	}, lifeparameters.WaitingTime, lifeparameters.RetryInterval*time.Second).Should(BeTrue())
+	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
 	err := nodes.WaitForNodesReady(globalhelper.APIClient,
-		lifeparameters.WaitingTime, lifeparameters.RetryInterval)
+		tsparams.WaitingTime, tsparams.RetryInterval)
 
 	return err
 }

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/tests"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 func TestLifecycle(t *testing.T) {
@@ -31,28 +31,28 @@ func TestLifecycle(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 
-	err := lifehelper.WaitUntilClusterIsStable()
+	err := tshelper.WaitUntilClusterIsStable()
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Create namespace")
-	err = namespaces.Create(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+	err = namespaces.Create(tsparams.LifecycleNamespace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
 	err = globalhelper.DefineTnfConfig(
-		[]string{lifeparameters.LifecycleNamespace},
-		[]string{lifeparameters.TestPodLabel},
+		[]string{tsparams.LifecycleNamespace},
+		[]string{tsparams.TestPodLabel},
 		[]string{})
 	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
 
-	By(fmt.Sprintf("Remove %s namespace", lifeparameters.LifecycleNamespace))
+	By(fmt.Sprintf("Remove %s namespace", tsparams.LifecycleNamespace))
 	err := namespaces.DeleteAndWait(
 		globalhelper.APIClient,
-		lifeparameters.LifecycleNamespace,
-		lifeparameters.WaitingTime,
+		tsparams.LifecycleNamespace,
+		tsparams.WaitingTime,
 	)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -61,7 +61,7 @@ var _ = AfterSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Remove masters scheduling")
-	err = lifehelper.EnableMasterScheduling(false)
+	err = tshelper.EnableMasterScheduling(false)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = os.Unsetenv("TNF_NON_INTRUSIVE_ONLY")

--- a/tests/lifecycle/parameters/parameters.go
+++ b/tests/lifecycle/parameters/parameters.go
@@ -1,4 +1,4 @@
-package lifeparameters
+package parameters
 
 import (
 	"fmt"

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -3,22 +3,24 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-container-shutdown", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -27,24 +29,24 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		By("Define deployment with preStop field configured")
 
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
-			deploymenta, lifeparameters.PreStopCommand)
+			deploymenta, tsparams.PreStopCommand)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -53,21 +55,21 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("One deployment, one pod without preStop field configured [negative]", func() {
 
 		By("Define deployment without prestop field configured")
-		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deployment, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -76,25 +78,25 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("One deployment, several pods, several containers that have preStop field configured", func() {
 
 		By("Define deployment with preStop field configured")
-		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(3, 2, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
-			deploymenta, lifeparameters.PreStopCommand)
+			deploymenta, tsparams.PreStopCommand)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymenta, lifeparameters.WaitingTime)
+			deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -103,36 +105,36 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("Two deployments, several pods, several containers that have preStop field configured", func() {
 
 		By("Define first deployment with preStop field configured")
-		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(3, 2, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineAllContainersWithPreStopSpec(
-			deploymenta, lifeparameters.PreStopCommand)
+			deploymenta, tsparams.PreStopCommand)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymenta, lifeparameters.WaitingTime)
+			deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with preStop field configured")
-		deploymentb, err := lifehelper.DefineDeployment(3, 2, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(3, 2, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineAllContainersWithPreStopSpec(
-			deploymentb, lifeparameters.PreStopCommand)
+			deploymentb, tsparams.PreStopCommand)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymentb, lifeparameters.WaitingTime)
+			deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -141,26 +143,26 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("One deployment, several pods, several containers one without preStop field configured [negative]", func() {
 
 		By("Define deployment with preStop field configured")
-		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(3, 2, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta, err = deployment.RedefineFirstContainerWithPreStopSpec(
-			deploymenta, lifeparameters.PreStopCommand)
+			deploymenta, tsparams.PreStopCommand)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymenta, lifeparameters.WaitingTime)
+			deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -169,30 +171,30 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 	It("Two deployments, several pods, several containers that do not have preStop field configured [negative]", func() {
 
 		By("Define & create first deployment")
-		deploymenta, err := lifehelper.DefineDeployment(3, 2, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(3, 2, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymenta, lifeparameters.WaitingTime)
+			deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb, err := lifehelper.DefineDeployment(3, 2, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(3, 2, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymentb, lifeparameters.WaitingTime)
+			deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfShutdownTcName,
+			tsparams.TnfShutdownTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -5,21 +5,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-deployment-scaling", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Enable intrusive tests")
@@ -31,22 +33,22 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 	It("One deployment, one pod, one container, scale in and out", func() {
 
 		By("Define Deployment")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(
-			deploymenta, lifeparameters.WaitingTime)
+			deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-deployment-scaling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfDeploymentScalingTcName,
+			tsparams.TnfDeploymentScalingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfDeploymentScalingTcName,
+			tsparams.TnfDeploymentScalingTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -3,10 +3,11 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
@@ -17,7 +18,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -25,23 +26,23 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One deployment with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -50,39 +51,39 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("Several deployments with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define deployments with ifNotPresent as ImagePullPolicy")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineWithImagePullPolicy(deploymentb, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentc, err := lifehelper.DefineDeployment(1, 1, "lifecycleputc")
+		deploymentc, err := tshelper.DefineDeployment(1, 1, "lifecycleputc")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentc = deployment.RedefineWithImagePullPolicy(deploymentc, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentc, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -91,21 +92,21 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One DaemonSet with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define DaemonSet with ifNotPresent as ImagePullPolicy")
-		daemonSet := lifehelper.DefineDaemonSetWithImagePullPolicy(
+		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(
 			"lifecycleds", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -114,33 +115,33 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("Several DaemonSets with ifNotPresent as ImagePullPolicy", func() {
 
 		By("Define DaemonSets with ifNotPresent as ImagePullPolicy")
-		daemonSeta := lifehelper.DefineDaemonSetWithImagePullPolicy(
+		daemonSeta := tshelper.DefineDaemonSetWithImagePullPolicy(
 			"lifecycledsa", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, lifeparameters.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		daemonSetb := lifehelper.DefineDaemonSetWithImagePullPolicy(
+		daemonSetb := tshelper.DefineDaemonSetWithImagePullPolicy(
 			"lifecycledsb", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		daemonSetc := lifehelper.DefineDaemonSetWithImagePullPolicy(
+		daemonSetc := tshelper.DefineDaemonSetWithImagePullPolicy(
 			"lifecycledsc", globalhelper.Configuration.General.TestImage, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -152,22 +153,22 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		// imagePullPolicy is automatically set to Always;
 		By("Define DaemonSet without ImagePullPolicy")
 		daemonSet := daemonset.DefineDaemonSet(
-			lifeparameters.LifecycleNamespace,
+			tsparams.LifecycleNamespace,
 			"registry.access.redhat.com/ubi8/ubi",
-			lifeparameters.TestDeploymentLabels, "lifecycleds")
+			tsparams.TestDeploymentLabels, "lifecycleds")
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -179,22 +180,22 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		// imagePullPolicy is automatically set to Always;
 		By("Define deployment without ImagePullPolicy")
 		deployment := deployment.DefineDeployment("lifecycleput",
-			lifeparameters.LifecycleNamespace,
+			tsparams.LifecycleNamespace,
 			"registry.access.redhat.com/ubi8/ubi:latest",
-			lifeparameters.TestDeploymentLabels)
+			tsparams.TestDeploymentLabels)
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -203,23 +204,23 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One deployment with Always as ImagePullPolicy [negative]", func() {
 
 		By("Define deployment with 'Always' as ImagePullPolicy")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullAlways)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -228,32 +229,32 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("Two deployments one with Never other with ifNotPresent as ImagePullPolicy [negative]", func() {
 
 		By("Define deployment with Never as ImagePullPolicy")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullNever)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineWithImagePullPolicy(deploymentb, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -262,30 +263,30 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 	It("One DaemonSet with Never one deployment with ifNotPresent as ImagePullPolicy [negative]", func() {
 
 		By("Define DaemonSet with Never as ImagePullPolicy")
-		daemonSet := lifehelper.DefineDaemonSetWithImagePullPolicy(
+		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(
 			"lifecycleds", globalhelper.Configuration.General.TestImage, v1.PullNever)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithImagePullPolicy(deploymenta, v1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfImagePullPolicyTcName,
+			tsparams.TnfImagePullPolicyTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -3,47 +3,49 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-liveness", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 50053
 	It("One deployment, one pod with a liveness probe", func() {
 		By("Define deployment with a liveness probe")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -51,30 +53,30 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50054
 	It("Two deployments, multiple pods each, all have a liveness probe", func() {
 		By("Define first deployment with a liveness probe")
-		deploymenta, err := lifehelper.DefineDeployment(3, 1, "lifecycledpa")
+		deploymenta, err := tshelper.DefineDeployment(3, 1, "lifecycledpa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with a liveness probe")
-		deploymentb, err := lifehelper.DefineDeployment(3, 1, "lifecycledpb")
+		deploymentb, err := tshelper.DefineDeployment(3, 1, "lifecycledpb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineWithLivenessProbe(deploymentb)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -83,19 +85,19 @@ var _ = Describe("lifecycle-liveness", func() {
 	It("One statefulSet, one pod with a liveness probe", func() {
 		By("Define statefulSet with a liveness probe")
 		statefulset := statefulset.RedefineWithLivenessProbe(
-			lifehelper.DefineStatefulSet("lifecycle-sf"))
-		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, lifeparameters.WaitingTime)
+			tshelper.DefineStatefulSet("lifecycle-sf"))
+		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -104,19 +106,19 @@ var _ = Describe("lifecycle-liveness", func() {
 	It("One pod with a liveness probe", func() {
 		By("Define pod with a liveness probe")
 		pod := pod.RedefineWithLivenessProbe(pod.RedefinePodWithLabel(
-			lifehelper.DefinePod("lifecycleput"), lifeparameters.TestDeploymentLabels))
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, lifeparameters.WaitingTime)
+			tshelper.DefinePod("lifecycleput"), tsparams.TestDeploymentLabels))
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -124,21 +126,21 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50057
 	It("One daemonSet without a liveness probe [negative]", func() {
 		By("Define daemonSet without a liveness probe")
-		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
 			globalhelper.Configuration.General.TestImage,
-			lifeparameters.TestDeploymentLabels, "lifecyclesds")
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+			tsparams.TestDeploymentLabels, "lifecyclesds")
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -146,29 +148,29 @@ var _ = Describe("lifecycle-liveness", func() {
 	// 50058
 	It("Two deployments, one pod each, one without a liveness probe [negative]", func() {
 		By("Define first deployment with a liveness probe")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledpa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithLivenessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment without a liveness probe")
-		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycledpb")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfLivenessTcName,
+			tsparams.TnfLivenessTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -3,30 +3,32 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	execute.BeforeAll(func() {
 		By("Make masters schedulable")
-		err := lifehelper.EnableMasterScheduling(true)
+		err := tshelper.EnableMasterScheduling(true)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -40,23 +42,23 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(2, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -71,32 +73,32 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create first deployment")
-		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(2, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -111,21 +113,21 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deployment, err := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		deployment, err := tshelper.DefineDeployment(2, 1, "lifecycleputone")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -140,28 +142,28 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create first deployment")
-		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputone")
+		deploymenta, err := tshelper.DefineDeployment(2, 1, "lifecycleputone")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputtwo")
+		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycleputtwo")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -176,23 +178,23 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		}
 
 		By("Define & create deployment")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycleputone")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycleputone")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodHighAvailabilityTcName,
+			tsparams.TnfPodHighAvailabilityTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -3,23 +3,25 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/replicaset"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-pod-owner-type", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -27,20 +29,20 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("One ReplicaSet, several pods", func() {
 
 		By("Define ReplicaSet with replica number")
-		replicaSet := replicaset.RedefineWithReplicaNumber(lifehelper.DefineReplicaSet("lifecyclers"), 3)
+		replicaSet := replicaset.RedefineWithReplicaNumber(tshelper.DefineReplicaSet("lifecyclers"), 3)
 
-		err := lifehelper.CreateAndWaitUntilReplicaSetIsReady(replicaSet, lifeparameters.WaitingTime)
+		err := tshelper.CreateAndWaitUntilReplicaSetIsReady(replicaSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -49,27 +51,27 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("Two deployments, several pods", func() {
 
 		By("Define deployments")
-		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(2, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -78,19 +80,19 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("StatefulSet pod", func() {
 
 		By("Define statefulSet")
-		statefulSet := lifehelper.DefineStatefulSet("lifecyclesf")
-		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulSet, lifeparameters.WaitingTime)
+		statefulSet := tshelper.DefineStatefulSet("lifecyclesf")
+		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -99,20 +101,20 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("One pod, not part of any workload resource [negative]", func() {
 
 		By("Define pod")
-		pod := pod.RedefinePodWithLabel(lifehelper.DefinePod("lifecyclepod"),
-			lifeparameters.TestDeploymentLabels)
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, lifeparameters.WaitingTime)
+		pod := pod.RedefinePodWithLabel(tshelper.DefinePod("lifecyclepod"),
+			tsparams.TestDeploymentLabels)
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -121,33 +123,33 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 	It("Two deployments, one pod not related to any resource [negative]", func() {
 
 		By("Define deployments")
-		deploymenta, err := lifehelper.DefineDeployment(2, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(2, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb, err := lifehelper.DefineDeployment(2, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define pod")
-		pod := pod.RedefinePodWithLabel(lifehelper.DefinePod("lifecyclepod"),
-			lifeparameters.TestDeploymentLabels)
-		err = globalhelper.CreateAndWaitUntilPodIsReady(pod, lifeparameters.WaitingTime)
+		pod := pod.RedefinePodWithLabel(tshelper.DefinePod("lifecyclepod"),
+			tsparams.TestDeploymentLabels)
+		err = globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodOwnerTypeTcName,
+			tsparams.TnfPodOwnerTypeTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -5,21 +5,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-pod-recreation", func() {
 
 	execute.BeforeAll(func() {
 		By("Make masters schedulable")
-		err := lifehelper.EnableMasterScheduling(true)
+		err := tshelper.EnableMasterScheduling(true)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Enable intrusive tests")
@@ -28,11 +30,11 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 	})
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -47,23 +49,23 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		// at least one "clean of any resource" worker is needed.
 		maxPodsPerDeployment := schedulableNodes - 1
 		By("Define & create deployment")
-		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -79,32 +81,32 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		// at least one "clean of any resource" worker is needed.
 		maxPodsPerDeployment := (schedulableNodes / 2) - 1
 		By("Define & create first deployment")
-		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb, err := lifehelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -119,23 +121,23 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		}
 
 		By("Define & create deployment")
-		deploymenta, err := lifehelper.DefineDeployment(schedulableNodes, 1, "lifecycleput")
+		deploymenta, err := tshelper.DefineDeployment(schedulableNodes, 1, "lifecycleput")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -153,32 +155,32 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		maxPodsPerDeploymentPerSecondDeployment := schedulableNodes - maxPodsPerDeploymentPerFirstDeployment
 
 		By("Define & create first deployment")
-		deploymenta, err := lifehelper.DefineDeployment(maxPodsPerDeploymentPerFirstDeployment, 1, "lifecycleputa")
+		deploymenta, err := tshelper.DefineDeployment(maxPodsPerDeploymentPerFirstDeployment, 1, "lifecycleputa")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, lifeparameters.TestDeploymentLabels)
+		deploymenta = deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define & create second deployment")
-		deploymentb, err := lifehelper.DefineDeployment(maxPodsPerDeploymentPerSecondDeployment, 1, "lifecycleputb")
+		deploymentb, err := tshelper.DefineDeployment(maxPodsPerDeploymentPerSecondDeployment, 1, "lifecycleputb")
 		Expect(err).ToNot(HaveOccurred())
 
-		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, lifeparameters.TestDeploymentLabels)
+		deploymentb = deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestDeploymentLabels)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodRecreationTcName,
+			tsparams.TnfPodRecreationTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -6,14 +6,16 @@ import (
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-pod-scheduling", func() {
@@ -24,11 +26,11 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	}
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -36,21 +38,21 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment, no nodeSelector nor nodeAffinity", func() {
 
 		By("Define Deployment")
-		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deployment, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -59,25 +61,25 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment with nodeSelector [negative]", func() {
 
 		By("Define Deployment with nodeSelector")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithNodeSelector(deploymenta,
 			map[string]string{configSuite.General.CnfNodeLabel: ""})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -86,23 +88,23 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment with nodeAffinity [negative]", func() {
 
 		By("Define Deployment with nodeAffinity")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithNodeAffinity(deploymenta, configSuite.General.CnfNodeLabel)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -111,31 +113,31 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("Two deployments, one pod each, one pod with nodeAffinity [negative]", func() {
 
 		By("Define Deployment without nodeAffinity")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledpa")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define Deployment with nodeAffinity")
-		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycledpb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineWithNodeAffinity(deploymentb,
 			configSuite.General.CnfNodeLabel)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -144,29 +146,29 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 	It("One deployment, one daemonSet [negative]", func() {
 
 		By("Define Deployment without nodeAffinity/ nodeSelector")
-		deployment, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deployment, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
 			globalhelper.Configuration.General.TestImage,
-			lifeparameters.TestDeploymentLabels, "lifecycleds")
+			tsparams.TestDeploymentLabels, "lifecycleds")
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfPodSchedulingTcName,
+			tsparams.TnfPodSchedulingTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -3,47 +3,49 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-readiness", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 50145
 	It("One deployment, one pod with a readiness probe", func() {
 		By("Define deployment with a readiness probe")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledp")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledp")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -51,30 +53,30 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50146
 	It("Two deployments, multiple pods each, all have a readiness probe", func() {
 		By("Define first deployment with a readiness probe")
-		deploymenta, err := lifehelper.DefineDeployment(3, 1, "lifecycledpa")
+		deploymenta, err := tshelper.DefineDeployment(3, 1, "lifecycledpa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment with a readiness probe")
-		deploymentb, err := lifehelper.DefineDeployment(3, 1, "lifecycledpb")
+		deploymentb, err := tshelper.DefineDeployment(3, 1, "lifecycledpb")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb = deployment.RedefineWithReadinessProbe(deploymentb)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -83,19 +85,19 @@ var _ = Describe("lifecycle-readiness", func() {
 	It("One statefulSet, one pod with a readiness probe", func() {
 		By("Define statefulSet with a readiness probe")
 		statefulset := statefulset.RedefineWithReadinessProbe(
-			lifehelper.DefineStatefulSet("lifecycle-sf"))
-		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, lifeparameters.WaitingTime)
+			tshelper.DefineStatefulSet("lifecycle-sf"))
+		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -104,19 +106,19 @@ var _ = Describe("lifecycle-readiness", func() {
 	It("One pod with a readiness probe", func() {
 		By("Define pod with a readiness probe")
 		pod := pod.RedefineWithReadinessProbe(pod.RedefinePodWithLabel(
-			lifehelper.DefinePod("lifecycleput"), lifeparameters.TestDeploymentLabels))
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, lifeparameters.WaitingTime)
+			tshelper.DefinePod("lifecycleput"), tsparams.TestDeploymentLabels))
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -124,21 +126,21 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50149
 	It("One daemonSet without a readiness probe [negative]", func() {
 		By("Define daemonSet without a readiness probe")
-		daemonSet := daemonset.DefineDaemonSet(lifeparameters.LifecycleNamespace,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
 			globalhelper.Configuration.General.TestImage,
-			lifeparameters.TestDeploymentLabels, "lifecycleds")
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, lifeparameters.WaitingTime)
+			tsparams.TestDeploymentLabels, "lifecycleds")
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -146,29 +148,29 @@ var _ = Describe("lifecycle-readiness", func() {
 	// 50150
 	It("Two deployments, one pod each, one without a readiness probe [negative]", func() {
 		By("Define first deployment with a readiness probe")
-		deploymenta, err := lifehelper.DefineDeployment(1, 1, "lifecycledpa")
+		deploymenta, err := tshelper.DefineDeployment(1, 1, "lifecycledpa")
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymenta = deployment.RedefineWithReadinessProbe(deploymenta)
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment without a readiness probe")
-		deploymentb, err := lifehelper.DefineDeployment(1, 1, "lifecycledpb")
+		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycledpb")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, lifeparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfReadinessTcName,
+			tsparams.TnfReadinessTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -5,21 +5,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifehelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/lifeparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
 var _ = Describe("lifecycle-statefulset-scaling", func() {
 
 	BeforeEach(func() {
-		err := lifehelper.WaitUntilClusterIsStable()
+		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(lifeparameters.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Enable intrusive tests")
@@ -30,19 +32,19 @@ var _ = Describe("lifecycle-statefulset-scaling", func() {
 	// 45439
 	It("One statefulSet, one pod", func() {
 		By("Define statefulSet")
-		statefulset := lifehelper.DefineStatefulSet("lifecyclesf")
-		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, lifeparameters.WaitingTime)
+		statefulset := tshelper.DefineStatefulSet("lifecyclesf")
+		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("start lifecycle-statefulset-scaling test")
 		err = globalhelper.LaunchTests(
-			lifeparameters.TnfStatefulSetScalingTcName,
+			tsparams.TnfStatefulSetScalingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			lifeparameters.TnfStatefulSetScalingTcName,
+			tsparams.TnfStatefulSetScalingTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -1,4 +1,4 @@
-package nethelper
+package helper
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/netparameters"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/rbac"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/service"
@@ -26,16 +26,16 @@ import (
 
 // DefineAndCreateDeploymentOnCluster defines deployment resource and creates it on cluster.
 func DefineAndCreateDeploymentOnCluster(replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(netparameters.TestDeploymentAName, replicaNumber, false, nil, nil)
+	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, replicaNumber, false, nil, nil)
 
-	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, netparameters.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
 // DefineAndCreateDeploymentWithMultusOnCluster defines deployment resource and creates it on cluster.
 func DefineAndCreateDeploymentWithMultusOnCluster(name string, nadNames []string, replicaNumber int32) error {
 	deploymentUnderTest := defineDeploymentBasedOnArgs(name, replicaNumber, true, nadNames, nil)
 
-	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, netparameters.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
 // DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster defines deployment resource and creates it on cluster.
@@ -45,32 +45,32 @@ func DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
 		name, replicaNumber,
 		false,
 		nadNames,
-		netparameters.NetworkingTestMultusSkipLabel)
+		tsparams.NetworkingTestMultusSkipLabel)
 
-	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, netparameters.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
 // DefineAndCreatePrivilegedDeploymentOnCluster defines deployment resource and creates it on cluster.
 func DefineAndCreatePrivilegedDeploymentOnCluster(replicaNumber int32) error {
 	deploymentUnderTest := defineDeploymentBasedOnArgs(
-		netparameters.TestDeploymentAName,
+		tsparams.TestDeploymentAName,
 		replicaNumber,
 		true,
 		nil,
 		nil)
 
-	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, netparameters.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
 // DefineAndCreateDeploymentWithSkippedLabelOnCluster defines deployment resource and creates it on cluster.
 func DefineAndCreateDeploymentWithSkippedLabelOnCluster(replicaNumber int32) error {
 	deploymentUnderTest := defineDeploymentBasedOnArgs(
-		netparameters.TestDeploymentAName,
+		tsparams.TestDeploymentAName,
 		replicaNumber,
 		true,
 		nil,
-		netparameters.NetworkingTestSkipLabel)
-	err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, netparameters.WaitingTime)
+		tsparams.NetworkingTestSkipLabel)
+	err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func DefineAndCreateDeamonsetWithMultusOnCluster(nadName string) error {
 }
 
 func DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(nadName string) error {
-	return defineDaemonSetBasedOnArgs(nadName, netparameters.NetworkingTestMultusSkipLabel)
+	return defineDaemonSetBasedOnArgs(nadName, tsparams.NetworkingTestMultusSkipLabel)
 }
 
 // AllowAuthenticatedUsersRunPrivilegedContainers adds all authenticated users to privileged group.
@@ -136,11 +136,11 @@ func ExecCmdOnAllPodInNamespace(command []string) error {
 func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, withNodePort bool) error {
 	testService := service.DefineService(
 		name,
-		netparameters.TestNetworkingNameSpace,
+		tsparams.TestNetworkingNameSpace,
 		port,
 		targetPort,
 		corev1.ProtocolTCP,
-		netparameters.TestDeploymentLabels)
+		tsparams.TestDeploymentLabels)
 
 	if withNodePort {
 		var err error
@@ -151,7 +151,7 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 		}
 	}
 
-	_, err := globalhelper.APIClient.Services(netparameters.TestNetworkingNameSpace).Create(
+	_, err := globalhelper.APIClient.Services(tsparams.TestNetworkingNameSpace).Create(
 		context.Background(),
 		testService, metav1.CreateOptions{})
 
@@ -159,7 +159,7 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 }
 
 func DefineAndCreateNadOnCluster(name string, intName string, network string) error {
-	nadOneInterface := nad.DefineNad(name, netparameters.TestNetworkingNameSpace, intName)
+	nadOneInterface := nad.DefineNad(name, tsparams.TestNetworkingNameSpace, intName)
 
 	if network != "" {
 		nadOneInterface = nad.RedefineNadWithWhereaboutsIpam(nadOneInterface, network)
@@ -174,7 +174,7 @@ func GetClusterMultusInterfaces() ([]string, error) {
 		return nil, err
 	}
 
-	podsList, err := globalhelper.GetListOfPodsInNamespace(netparameters.TestNetworkingNameSpace)
+	podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.TestNetworkingNameSpace)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func getInterfacesList(runningPod corev1.Pod) ([]string, error) {
 
 	var interfaceList []string
 
-	var linuxInterfaces []netparameters.IPOutputInterface
+	var linuxInterfaces []tsparams.IPOutputInterface
 	err = json.Unmarshal(links.Bytes(), &linuxInterfaces)
 
 	if err != nil {
@@ -256,9 +256,9 @@ func defineDeploymentBasedOnArgs(
 	deploymentStruct := deployment.RedefineWithReplicaNumber(
 		deployment.DefineDeployment(
 			name,
-			netparameters.TestNetworkingNameSpace,
+			tsparams.TestNetworkingNameSpace,
 			globalhelper.Configuration.General.TestImage,
-			netparameters.TestDeploymentLabels),
+			tsparams.TestDeploymentLabels),
 		replicaNumber)
 	if privileged {
 		deploymentStruct = deployment.RedefineWithContainersSecurityContextAll(deploymentStruct)
@@ -278,9 +278,9 @@ func defineDeploymentBasedOnArgs(
 func defineDaemonSetBasedOnArgs(nadName string, labels map[string]string) error {
 	testDaemonset := daemonset.RedefineDaemonSetWithNodeSelector(daemonset.RedefineWithMultus(
 		daemonset.DefineDaemonSet(
-			netparameters.TestNetworkingNameSpace,
+			tsparams.TestNetworkingNameSpace,
 			globalhelper.Configuration.General.TestImage,
-			netparameters.TestDeploymentLabels, "daemonsetnetworkingput"),
+			tsparams.TestDeploymentLabels, "daemonsetnetworkingput"),
 		nadName,
 	), map[string]string{globalhelper.Configuration.General.CnfNodeLabel: ""})
 
@@ -288,17 +288,17 @@ func defineDaemonSetBasedOnArgs(nadName string, labels map[string]string) error 
 		daemonset.RedefineDaemonSetWithLabel(testDaemonset, labels)
 	}
 
-	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(testDaemonset, netparameters.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(testDaemonset, tsparams.WaitingTime)
 }
 
 func defineAndCreatePrivilegedDaemonset() error {
 	daemonSet := daemonset.RedefineWithPrivilegeAndHostNetwork(daemonset.RedefineDaemonSetWithNodeSelector(
 		daemonset.DefineDaemonSet(
-			netparameters.TestNetworkingNameSpace,
+			tsparams.TestNetworkingNameSpace,
 			globalhelper.Configuration.General.TestImage,
-			netparameters.TestDeploymentLabels, "daemonsetnetworkingput",
+			tsparams.TestDeploymentLabels, "daemonsetnetworkingput",
 		), map[string]string{globalhelper.Configuration.General.WorkerNodeLabel: ""}))
-	err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, netparameters.WaitingTime)
+	err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 
 	if err != nil {
 		return err
@@ -308,7 +308,7 @@ func defineAndCreatePrivilegedDaemonset() error {
 }
 
 func execCmdOnPodsListInNamespace(command []string, execOn string) error {
-	runningTestPods, err := globalhelper.APIClient.Pods(netparameters.TestNetworkingNameSpace).List(
+	runningTestPods, err := globalhelper.APIClient.Pods(tsparams.TestNetworkingNameSpace).List(
 		context.Background(),
 		metav1.ListOptions{})
 	if err != nil {

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -2,24 +2,22 @@ package networking
 
 import (
 	"flag"
-	"runtime"
-	"time"
-
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/nethelper"
-
 	"fmt"
+	"runtime"
+	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/netparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
-
-	"testing"
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/networking/tests"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/cluster"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
 func TestNetworking(t *testing.T) {
@@ -41,35 +39,35 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
-	}, netparameters.WaitingTime, netparameters.RetryInterval*time.Second).Should(BeTrue())
+	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
 	By("Validate that all nodes are Ready")
-	err := nodes.WaitForNodesReady(globalhelper.APIClient, netparameters.WaitingTime, netparameters.RetryInterval)
+	err := nodes.WaitForNodesReady(globalhelper.APIClient, tsparams.WaitingTime, tsparams.RetryInterval)
 	Expect(err).ToNot(HaveOccurred())
 
-	By(fmt.Sprintf("Create %s namespace", netparameters.TestNetworkingNameSpace))
-	err = namespaces.Create(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+	By(fmt.Sprintf("Create %s namespace", tsparams.TestNetworkingNameSpace))
+	err = namespaces.Create(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
 	err = globalhelper.DefineTnfConfig(
-		[]string{netparameters.TestNetworkingNameSpace},
-		[]string{netparameters.TestPodLabel},
+		[]string{tsparams.TestNetworkingNameSpace},
+		[]string{tsparams.TestPodLabel},
 		[]string{})
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Set rbac policy which allows authenticated users to run privileged containers")
-	err = nethelper.AllowAuthenticatedUsersRunPrivilegedContainers()
+	err = tshelper.AllowAuthenticatedUsersRunPrivilegedContainers()
 	Expect(err).ToNot(HaveOccurred())
 
 })
 
 var _ = AfterSuite(func() {
-	By(fmt.Sprintf("Remove %s namespace", netparameters.TestNetworkingNameSpace))
+	By(fmt.Sprintf("Remove %s namespace", tsparams.TestNetworkingNameSpace))
 	err := namespaces.DeleteAndWait(
 		globalhelper.APIClient,
-		netparameters.TestNetworkingNameSpace,
-		netparameters.WaitingTime,
+		tsparams.TestNetworkingNameSpace,
+		tsparams.WaitingTime,
 	)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/networking/parameters/parameters.go
+++ b/tests/networking/parameters/parameters.go
@@ -1,4 +1,4 @@
-package netparameters
+package parameters
 
 import (
 	"fmt"

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -9,12 +9,13 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/nethelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/netparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
 var _ = Describe("Networking custom namespace, custom deployment,", func() {
@@ -27,16 +28,16 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err = namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, netparameters.TestNetworkingNameSpace)
+		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 
 		By("Clean namespace before each test")
-		err := namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -48,18 +49,18 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	// 45440
 	It("3 custom pods on Default network networking-icmpv4-connectivity", func() {
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -67,29 +68,29 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	// 45441
 	It("custom daemonset, 4 custom pods on Default network", func() {
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(2)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(2)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
 		daemonSet := daemonset.RedefineDaemonSetWithNodeSelector(daemonset.DefineDaemonSet(
-			netparameters.TestNetworkingNameSpace,
+			tsparams.TestNetworkingNameSpace,
 			configSuite.General.TestImage,
-			netparameters.TestDeploymentLabels, "daemonsetnetworkingput",
+			tsparams.TestDeploymentLabels, "daemonsetnetworkingput",
 		), map[string]string{configSuite.General.CnfNodeLabel: ""})
 
 		By("Create DaemonSet on cluster")
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, netparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -98,11 +99,11 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("3 custom pods on Default network networking-icmpv4-connectivity fail when "+
 		"one pod is disconnected [negative]", func() {
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreatePrivilegedDeploymentOnCluster(2)
+		err = tshelper.DefineAndCreatePrivilegedDeploymentOnCluster(2)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Close communication between deployment pods")
-		podsList, err := globalhelper.GetListOfPodsInNamespace(netparameters.TestNetworkingNameSpace)
+		podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 
 		for index := range podsList.Items {
@@ -115,13 +116,13 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -130,23 +131,23 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("2 custom pods on Default network networking-icmpv4-connectivity skip when label "+
 		"test-network-function.com/skip_connectivity_tests is set in deployment [skip]", func() {
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
+		err = tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove ping binary from test pod")
-		err = nethelper.ExecCmdOnOnePodInNamespace(
+		err = tshelper.ExecCmdOnOnePodInNamespace(
 			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -155,35 +156,35 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("custom daemonset, 4 custom pods on Default network networking-icmpv4-connectivity pass when label "+
 		"test-network-function.com/skip_connectivity_tests is set in deployment only", func() {
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
+		err = tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove ping binary from test pod")
-		err = nethelper.ExecCmdOnAllPodInNamespace(
+		err = tshelper.ExecCmdOnAllPodInNamespace(
 			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
 		daemonSet := daemonset.RedefineDaemonSetWithNodeSelector(
 			daemonset.DefineDaemonSet(
-				netparameters.TestNetworkingNameSpace,
+				tsparams.TestNetworkingNameSpace,
 				configSuite.General.TestImage,
-				netparameters.TestDeploymentLabels, "daemonsetnetworkingput",
+				tsparams.TestDeploymentLabels, "daemonsetnetworkingput",
 			), map[string]string{configSuite.General.CnfNodeLabel: ""})
 
 		By("Create DaemonSet on cluster")
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, netparameters.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfDefaultNetworkTcName,
+			tsparams.TnfDefaultNetworkTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -8,10 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/nethelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/netparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
 var _ = Describe("Networking custom namespace,", func() {
@@ -21,23 +22,23 @@ var _ = Describe("Networking custom namespace,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, netparameters.TestNetworkingNameSpace)
+		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Collect list of available interfaces from the cluster")
-		multusInterfaces, err = nethelper.GetClusterMultusInterfaces()
+		multusInterfaces, err = tshelper.GetClusterMultusInterfaces()
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, netparameters.TestNetworkingNameSpace)
+		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 
 		By("Clean namespace before each test")
-		err := namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -53,24 +54,24 @@ var _ = Describe("Networking custom namespace,", func() {
 	// 48328
 	It("custom deployment 3 pods, 1 NAD, connectivity via Multus secondary interface", func() {
 		By("Define and create Network-attachment-definition")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -78,29 +79,29 @@ var _ = Describe("Networking custom namespace,", func() {
 	// 48330
 	It("2 custom deployments 3 pods, 1 NAD, connectivity via Multus secondary interface", func() {
 		By("Define and create Network-attachment-definition")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define first deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentBName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 		time.Sleep(30 * time.Second)
@@ -109,33 +110,33 @@ var _ = Describe("Networking custom namespace,", func() {
 	// 48331
 	It("custom deployment and daemonset 3 pods, 2 NADs, connectivity via Multus secondary interfaces", func() {
 		By("Define and create Network-attachment-definition")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameB, multusInterfaces[0], netparameters.TestIPamIPNetworkB)
+		err = tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameB, multusInterfaces[0], tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define first deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentBName, []string{netparameters.TestNadNameB}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -143,23 +144,23 @@ var _ = Describe("Networking custom namespace,", func() {
 	// 48334
 	It("custom deployment 3 pods, 1 NAD missing IP, connectivity via Multus secondary interface[skip]", func() {
 		By("Define and create Network-attachment-definition")
-		err := nethelper.DefineAndCreateNadOnCluster(netparameters.TestNadNameA, multusInterfaces[0], "")
+		err := tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameA, multusInterfaces[0], "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -172,32 +173,32 @@ var _ = Describe("Networking custom namespace,", func() {
 		}
 
 		By("Define and create Network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(netparameters.TestNadNameB, multusInterfaces[1], "")
+		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, multusInterfaces[1], "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment-a and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 1)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment-b and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentBName, []string{netparameters.TestNadNameB}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -211,32 +212,32 @@ var _ = Describe("Networking custom namespace,", func() {
 		}
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(netparameters.TestNadNameB, multusInterfaces[1], "")
+		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, multusInterfaces[1], "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
 
-		err = nethelper.DefineAndCreateDeamonsetWithMultusOnCluster(netparameters.TestNadNameB)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusOnCluster(tsparams.TestNadNameB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -245,23 +246,23 @@ var _ = Describe("Networking custom namespace,", func() {
 	It("custom daemonset 3 pods with skip label [skip]", func() {
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = nethelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(netparameters.TestNadNameA)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -270,28 +271,28 @@ var _ = Describe("Networking custom namespace,", func() {
 	It("custom deployment and daemonset 3 pods with skip label[skip]", func() {
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = nethelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(netparameters.TestNadNameA)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -300,28 +301,28 @@ var _ = Describe("Networking custom namespace,", func() {
 	It("custom deployment and daemonSet 3 pods, daemonSet has skip label", func() {
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = nethelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(netparameters.TestNadNameA)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -330,28 +331,28 @@ var _ = Describe("Networking custom namespace,", func() {
 	It("custom deployment 3 pods, 2 NADs, multiple Multus interfaces on deployment", func() {
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameB, multusInterfaces[0], netparameters.TestIPamIPNetworkB)
+		err = tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameB, multusInterfaces[0], tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA, netparameters.TestNadNameB}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA, tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -361,28 +362,28 @@ var _ = Describe("Networking custom namespace,", func() {
 	It("custom deployment 3 pods,1 NAD,no connectivity via Multus secondary interface[negative]", func() {
 
 		By("Define and create Network-attachment-definition")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Put one deployment's pod  interface down")
-		err = nethelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -395,36 +396,36 @@ var _ = Describe("Networking custom namespace,", func() {
 			Skip("There is not enough secondary network interfaces to run the test case")
 		}
 
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameB, multusInterfaces[1], netparameters.TestIPamIPNetworkB)
+		err = tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameB, multusInterfaces[1], tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Put one deployment's pod interface down")
-		err = nethelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = nethelper.DefineAndCreateDeamonsetWithMultusOnCluster(netparameters.TestNadNameB)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusOnCluster(tsparams.TestNadNameB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -438,36 +439,36 @@ var _ = Describe("Networking custom namespace,", func() {
 		}
 
 		By("Define and create network-attachment-definitions")
-		err := nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameA, multusInterfaces[0], netparameters.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateNadOnCluster(
-			netparameters.TestNadNameB, multusInterfaces[1], netparameters.TestIPamIPNetworkB)
+		err = tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameB, multusInterfaces[1], tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			netparameters.TestDeploymentAName, []string{netparameters.TestNadNameB, netparameters.TestNadNameA}, 3)
+		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
+			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameB, tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Put one deployment's pod interface down")
-		err = nethelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = nethelper.DefineAndCreateDeamonsetWithMultusOnCluster(netparameters.TestNadNameB)
+		err = tshelper.DefineAndCreateDeamonsetWithMultusOnCluster(tsparams.TestNadNameB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfMultusIpv4TcName,
+			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/networking/tests/networking_nodeport_service.go
+++ b/tests/networking/tests/networking_nodeport_service.go
@@ -7,10 +7,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/nethelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/networking/netparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
 var _ = Describe("Networking custom namespace, custom deployment,", func() {
@@ -18,9 +19,9 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, netparameters.TestNetworkingNameSpace)
+		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -28,7 +29,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	BeforeEach(func() {
 
 		By("Clean namespace before each test")
-		err := namespaces.Clean(netparameters.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -41,18 +42,18 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("2 custom pods, no service installed, service Should not have type of nodePort", func() {
 
 		By("Define deployment and create it on cluster")
-		err := nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -62,22 +63,22 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("2 custom pods, service installed without NodePort, service Should not have type of nodePort", func() {
 
 		By("Define Service")
-		err := nethelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false)
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -87,25 +88,25 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("2 custom pods, multiple services installed without NodePort, service Should not have type of nodePort", func() {
 
 		By("Define multiple Services")
-		err := nethelper.DefineAndCreateServiceOnCluster("testservicefirst", 3022, 3022, false)
+		err := tshelper.DefineAndCreateServiceOnCluster("testservicefirst", 3022, 3022, false)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = nethelper.DefineAndCreateServiceOnCluster("testservicesecond", 3023, 3023, false)
+		err = tshelper.DefineAndCreateServiceOnCluster("testservicesecond", 3023, 3023, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -114,22 +115,22 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	It("2 custom pods, service installed with NodePort, service Should not have type of nodePort [negative]", func() {
 
 		By("Define Services with NodePort")
-		err := nethelper.DefineAndCreateServiceOnCluster("testservice", 30022, 3022, true)
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 30022, 3022, true)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,24 +141,24 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		"nodePort [negative]", func() {
 
 		By("Define Services")
-		err := nethelper.DefineAndCreateServiceOnCluster("testservicefirst", 30022, 3022, true)
+		err := tshelper.DefineAndCreateServiceOnCluster("testservicefirst", 30022, 3022, true)
 		Expect(err).ToNot(HaveOccurred())
-		err = nethelper.DefineAndCreateServiceOnCluster("testservicesecond", 3022, 3022, false)
+		err = tshelper.DefineAndCreateServiceOnCluster("testservicesecond", 3022, 3022, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
-		err = nethelper.DefineAndCreateDeploymentOnCluster(3)
+		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			netparameters.TnfNodePortTcName,
+			tsparams.TnfNodePortTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/observability/helper/helper.go
+++ b/tests/observability/helper/helper.go
@@ -1,22 +1,23 @@
-package observabilityhelper
+package helper
 
 import (
 	"fmt"
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/observability/observabilityparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/observability/parameters"
 )
 
 // For some reason, there's a function that expects labels' key/values separated
 // by colon instead of the equal char.
 func GetTnfTargetPodLabelsSlice() []string {
-	return []string{observabilityparameters.TestPodLabelKey + ":" + observabilityparameters.TestPodLabelValue}
+	return []string{tsparams.TestPodLabelKey + ":" + tsparams.TestPodLabelValue}
 }
 
 // DefineDeploymentWithStdoutBuffers defines a deployment with a given name and replicas number, creating
@@ -46,9 +47,9 @@ func DefineDaemonSetWithStdoutBuffers(name string, stdoutBuffers []string) *apps
 }
 
 func DefinePodWithStdoutBuffer(name string, stdoutBuffer string) *corev1.Pod {
-	newPod := pod.DefinePod(name, observabilityparameters.TestNamespace, globalhelper.Configuration.General.TestImage)
+	newPod := pod.DefinePod(name, tsparams.TestNamespace, globalhelper.Configuration.General.TestImage)
 	// Add labels.
-	newPod = pod.RedefinePodWithLabel(newPod, observabilityparameters.TnfTargetPodLabels)
+	newPod = pod.RedefinePodWithLabel(newPod, tsparams.TnfTargetPodLabels)
 	// Change command to use the stdout buffer.
 	newPod.Spec.Containers[0].Command = getContainerCommandWithStdout(stdoutBuffer)
 
@@ -56,7 +57,7 @@ func DefinePodWithStdoutBuffer(name string, stdoutBuffer string) *corev1.Pod {
 }
 
 func DefineDeploymentWithoutTargetLabels(name string) *appsv1.Deployment {
-	return deployment.DefineDeployment(name, observabilityparameters.TestNamespace,
+	return deployment.DefineDeployment(name, tsparams.TestNamespace,
 		globalhelper.Configuration.General.TestImage,
 		map[string]string{"fakeLabelKey": "fakeLabelValue"})
 }
@@ -80,7 +81,7 @@ func createContainerSpecsFromStdoutBuffers(stdoutBuffers []string) []corev1.Cont
 
 		containerSpecs = append(containerSpecs,
 			corev1.Container{
-				Name:    fmt.Sprintf("%s-%d", observabilityparameters.TestContainerBaseName, index),
+				Name:    fmt.Sprintf("%s-%d", tsparams.TestContainerBaseName, index),
 				Image:   globalhelper.Configuration.General.TestImage,
 				Command: getContainerCommandWithStdout(stdoutLines),
 			},
@@ -93,8 +94,8 @@ func createContainerSpecsFromStdoutBuffers(stdoutBuffers []string) []corev1.Cont
 func defineDeploymentWithContainerSpecs(name string, replicas int,
 	containerSpecs []corev1.Container) *appsv1.Deployment {
 	// Define base deployment
-	dep := deployment.DefineDeployment(name, observabilityparameters.TestNamespace,
-		globalhelper.Configuration.General.TestImage, observabilityparameters.TnfTargetPodLabels)
+	dep := deployment.DefineDeployment(name, tsparams.TestNamespace,
+		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
 
 	// Customize its replicas and container specs.
 	dep = deployment.RedefineWithReplicaNumber(dep, int32(replicas))
@@ -106,8 +107,8 @@ func defineDeploymentWithContainerSpecs(name string, replicas int,
 func defineStatefulSetWithContainerSpecs(name string, replicas int,
 	containerSpecs []corev1.Container) *appsv1.StatefulSet {
 	// Define base statefulSet
-	sts := statefulset.DefineStatefulSet(name, observabilityparameters.TestNamespace,
-		globalhelper.Configuration.General.TestImage, observabilityparameters.TnfTargetPodLabels)
+	sts := statefulset.DefineStatefulSet(name, tsparams.TestNamespace,
+		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
 
 	// Customize its replicas and container specs.
 	sts = statefulset.RedefineWithReplicaNumber(sts, int32(replicas))
@@ -119,8 +120,8 @@ func defineStatefulSetWithContainerSpecs(name string, replicas int,
 func defineDaemonSetWithContainerSpecs(name string,
 	containerSpecs []corev1.Container) *appsv1.DaemonSet {
 	// Define base daemonSet
-	daemonSet := daemonset.DefineDaemonSet(observabilityparameters.TestNamespace,
-		globalhelper.Configuration.General.TestImage, observabilityparameters.TnfTargetPodLabels, name)
+	daemonSet := daemonset.DefineDaemonSet(tsparams.TestNamespace,
+		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels, name)
 
 	// Customize its container specs.
 	return daemonset.RedefineWithContainerSpecs(daemonSet, containerSpecs)

--- a/tests/observability/observability_suite_test.go
+++ b/tests/observability/observability_suite_test.go
@@ -8,11 +8,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/observability/observabilityhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/observability/observabilityparameters"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/observability/tests"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/observability/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/observability/parameters"
 )
 
 func TestObservability(t *testing.T) {
@@ -28,25 +30,25 @@ func TestObservability(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 
-	By(fmt.Sprintf("Create %s namespace", observabilityparameters.TestNamespace))
-	err := namespaces.Create(observabilityparameters.TestNamespace, globalhelper.APIClient)
+	By(fmt.Sprintf("Create %s namespace", tsparams.TestNamespace))
+	err := namespaces.Create(tsparams.TestNamespace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
 	err = globalhelper.DefineTnfConfig(
-		[]string{observabilityparameters.TestNamespace},
-		observabilityhelper.GetTnfTargetPodLabelsSlice(),
+		[]string{tsparams.TestNamespace},
+		tshelper.GetTnfTargetPodLabelsSlice(),
 		[]string{})
 	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
 
-	By(fmt.Sprintf("Remove %s namespace", observabilityparameters.TestNamespace))
+	By(fmt.Sprintf("Remove %s namespace", tsparams.TestNamespace))
 	err := namespaces.DeleteAndWait(
 		globalhelper.APIClient,
-		observabilityparameters.TestNamespace,
-		observabilityparameters.NsResourcesDeleteTimeoutMins,
+		tsparams.TestNamespace,
+		tsparams.NsResourcesDeleteTimeoutMins,
 	)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/observability/parameters/parameters.go
+++ b/tests/observability/parameters/parameters.go
@@ -1,4 +1,4 @@
-package observabilityparameters
+package parameters
 
 import "time"
 

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -3,20 +3,22 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/observability/observabilityhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/observability/observabilityparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/observability/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/observability/parameters"
 )
 
-var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
-	const tnfTestCaseName = observabilityparameters.TnfContainerLoggingTcName
+var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
+	const tnfTestCaseName = tsparams.TnfContainerLoggingTcName
 	qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
 
 	BeforeEach(func() {
-		By("Clean namespace " + observabilityparameters.TestNamespace + " before each test")
-		err := namespaces.Clean(observabilityparameters.TestNamespace, globalhelper.APIClient)
+		By("Clean namespace " + tsparams.TestNamespace + " before each test")
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -24,12 +26,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod one container that prints two log lines", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.TwoLogLines})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.TwoLogLines})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -45,12 +47,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod one container that prints one log line", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLine})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -66,12 +68,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod with two containers, both containers print two log lines to stdout", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.TwoLogLines, observabilityparameters.TwoLogLines})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.TwoLogLines, tsparams.TwoLogLines})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -87,12 +89,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One daemonset with two containers, first prints two lines, the second one line", func() {
 
 		By("Deploy daemonset in the cluster")
-		daemonSet := observabilityhelper.DefineDaemonSetWithStdoutBuffers(
-			observabilityparameters.TestDaemonSetBaseName,
-			[]string{observabilityparameters.TwoLogLines, observabilityparameters.OneLogLine})
+		daemonSet := tshelper.DefineDaemonSetWithStdoutBuffers(
+			tsparams.TestDaemonSetBaseName,
+			[]string{tsparams.TwoLogLines, tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet,
-			observabilityparameters.DaemonSetDeployTimeoutMins)
+			tsparams.DaemonSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -108,21 +110,21 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("Two deployments, two pods with two containers each, all printing 1 log line", func() {
 
 		By("Create deployment1 in the cluster")
-		deployment1 := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName+"1", 2,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.OneLogLine})
+		deployment1 := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName+"1", 2,
+			[]string{tsparams.OneLogLine, tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment1,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create deployment2 in the cluster")
-		deployment2 := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName+"2", 2,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.OneLogLine})
+		deployment2 := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName+"2", 2,
+			[]string{tsparams.OneLogLine, tsparams.OneLogLine})
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment2,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -139,21 +141,21 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 		"line each", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLine})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create statefulset in the cluster")
-		statefulset := observabilityhelper.DefineStatefulSetWithStdoutBuffers(
-			observabilityparameters.TestStatefulSetBaseName, 1,
-			[]string{observabilityparameters.OneLogLine})
+		statefulset := tshelper.DefineStatefulSetWithStdoutBuffers(
+			tsparams.TestStatefulSetBaseName, 1,
+			[]string{tsparams.OneLogLine})
 
 		err = globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset,
-			observabilityparameters.StatefulSetDeployTimeoutMins)
+			tsparams.StatefulSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -169,10 +171,10 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One pod with one container that prints one log line to stdout", func() {
 
 		By("Create pod in the cluster")
-		pod := observabilityhelper.DefinePodWithStdoutBuffer(
-			observabilityparameters.TestPodBaseName, observabilityparameters.OneLogLine)
+		pod := tshelper.DefinePodWithStdoutBuffer(
+			tsparams.TestPodBaseName, tsparams.OneLogLine)
 
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, observabilityparameters.PodDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.PodDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -188,10 +190,10 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One pod with one container that prints to stdout one log line starting with a tab char", func() {
 
 		By("Create pod in the cluster")
-		pod := observabilityhelper.DefinePodWithStdoutBuffer(observabilityparameters.TestPodBaseName,
-			"\t"+observabilityparameters.OneLogLine)
+		pod := tshelper.DefinePodWithStdoutBuffer(tsparams.TestPodBaseName,
+			"\t"+tsparams.OneLogLine)
 
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, observabilityparameters.PodDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.PodDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -207,12 +209,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod one container without any log line to stdout [negative]", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.NoLogLines})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.NoLogLines})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -228,12 +230,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod two containers but only one printing one log line [negative]", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.NoLogLines})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLine, tsparams.NoLogLines})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -249,21 +251,21 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("Two deployments one pod two containers each, first deployment passing but second fails [negative]", func() {
 
 		By("Create deployment1 in the cluster whose containers print one line to stdout each")
-		deployment1 := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName+"1", 1,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.OneLogLine})
+		deployment1 := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName+"1", 1,
+			[]string{tsparams.OneLogLine, tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment1,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create deployment2 in the cluster but only the first of its containers prints a line to stdout")
-		deployment2 := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName+"2", 1,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.NoLogLines})
+		deployment2 := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName+"2", 1,
+			[]string{tsparams.OneLogLine, tsparams.NoLogLines})
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment2,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -279,10 +281,10 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One pod one container without any log line to stdout [negative]", func() {
 
 		By("Create pod in the cluster")
-		pod := observabilityhelper.DefinePodWithStdoutBuffer(observabilityparameters.TestPodBaseName,
-			observabilityparameters.NoLogLines)
+		pod := tshelper.DefinePodWithStdoutBuffer(tsparams.TestPodBaseName,
+			tsparams.NoLogLines)
 
-		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, observabilityparameters.PodDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilPodIsReady(pod, tsparams.PodDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -299,21 +301,21 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 		"one log line [negative]", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLine})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy statefulset in the cluster")
-		statefulset := observabilityhelper.DefineStatefulSetWithStdoutBuffers(
-			observabilityparameters.TestStatefulSetBaseName, 1,
-			[]string{observabilityparameters.NoLogLines})
+		statefulset := tshelper.DefineStatefulSetWithStdoutBuffers(
+			tsparams.TestStatefulSetBaseName, 1,
+			[]string{tsparams.NoLogLines})
 
 		err = globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulset,
-			observabilityparameters.StatefulSetDeployTimeoutMins)
+			tsparams.StatefulSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -329,12 +331,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment one pod one container printing one log line without newline char [negative]", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLineWithoutNewLine})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLineWithoutNewLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -351,12 +353,12 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 		"one line without newline [negative]", func() {
 
 		By("Create deployment in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithStdoutBuffers(
-			observabilityparameters.TestDeploymentBaseName, 1,
-			[]string{observabilityparameters.OneLogLine, observabilityparameters.OneLogLineWithoutNewLine})
+		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
+			tsparams.TestDeploymentBaseName, 1,
+			[]string{tsparams.OneLogLine, tsparams.OneLogLineWithoutNewLine})
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")
@@ -372,11 +374,11 @@ var _ = Describe(observabilityparameters.TnfContainerLoggingTcName, func() {
 	It("One deployment with one pod and one container without TNF target labels [skip]", func() {
 
 		By("Create deployment without TNF target labels in the cluster")
-		deployment := observabilityhelper.DefineDeploymentWithoutTargetLabels(
-			observabilityparameters.TestDeploymentBaseName)
+		deployment := tshelper.DefineDeploymentWithoutTargetLabels(
+			tsparams.TestDeploymentBaseName)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
-			observabilityparameters.DeploymentDeployTimeoutMins)
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tnfTestCaseName + " test case")


### PR DESCRIPTION
All test suites use a globalhelper and local/ts ad hoc helper functions.
As it's a common pattern for this project, there's no need for using the
test suite name as prefix for folders, files or package names.

In order to differentiate them from the global ones, the prefix "ts" ("test
suite") can be reused across all the test suites.

In short:
- This commit avoids the redundant repetition of the ts name.
- Makes helper/params import names shorter, helping the code to not
  trespass on the 120 chars line width.