### PR TITLE
Access control automount token service account tests

### DIFF
--- a/tests/accesscontrol/helper/helper.go
+++ b/tests/accesscontrol/helper/helper.go
@@ -1,11 +1,16 @@
 package helper
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+	v1 "k8s.io/api/apps/v1"
 )
 
 func DeleteNamespaces(nsToDelete []string, clientSet *client.ClientSet, timeout time.Duration) error {
@@ -27,4 +32,22 @@ func DeleteNamespaces(nsToDelete []string, clientSet *client.ClientSet, timeout 
 	}
 
 	return nil
+}
+
+func DefineDeployment(replica int32, containers int, name string) (*v1.Deployment, error) {
+	if containers < 1 {
+		return nil, errors.New("invalid containers number")
+	}
+
+	deploymentStruct := globalhelper.AppendContainersToDeployment(
+		deployment.RedefineWithReplicaNumber(
+			deployment.DefineDeployment(
+				name,
+				parameters.TestAccessControlNameSpace,
+				globalhelper.Configuration.General.TestImage,
+				parameters.TestDeploymentLabels), replica),
+		containers-1,
+		globalhelper.Configuration.General.TestImage)
+
+	return deploymentStruct, nil
 }

--- a/tests/accesscontrol/helper/helper.go
+++ b/tests/accesscontrol/helper/helper.go
@@ -56,25 +56,32 @@ func DefineDeployment(replica int32, containers int, name string) (*v1.Deploymen
 
 func SetServiceAccountAutomountServiceAccountToken(namespace, saname, value string) error {
 	var boolVal bool
+
 	serviceacct, err := globalhelper.APIClient.ServiceAccounts(namespace).
 		Get(context.TODO(), saname, metav1.GetOptions{})
+
 	if err != nil {
-		return fmt.Errorf("Error getting service account: %w", err)
+		return fmt.Errorf("error getting service account: %w", err)
 	}
 
-	if value == "true" {
+	switch value {
+	case "true":
 		boolVal = true
 		serviceacct.AutomountServiceAccountToken = &boolVal
-	} else if value == "false" {
+
+	case "false":
 		boolVal = false
 		serviceacct.AutomountServiceAccountToken = &boolVal
-	} else if value == "nil" {
+
+	case "nil":
 		serviceacct.AutomountServiceAccountToken = nil
-	} else {
-		return fmt.Errorf("Invalid value for token value")
+
+	default:
+		return fmt.Errorf("invalid value for token value")
 	}
 
 	_, err = globalhelper.APIClient.ServiceAccounts(parameters.TestAccessControlNameSpace).
 		Update(context.TODO(), serviceacct, metav1.UpdateOptions{})
+
 	return err
 }

--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -24,4 +24,6 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
+
+	ServiceAccountName = "default"
 )

--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -17,5 +17,11 @@ var (
 	InvalidNamespace           = "openshift-test"
 	AdditionalValidNamespace   = "ac-test"
 
-	TestCaseNameAccessControlNamespace = "access-control-namespace"
+	TestCaseNameAccessControlNamespace         = "access-control-namespace"
+	TestCaseNameAccessControlPodAutomountToken = "access-control-pod-automount-service-account-token"
+
+	TestDeploymentLabels = map[string]string{
+		testPodLabelPrefixName: testPodLabelValue,
+		"app":                  "test",
+	}
 )

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -10,11 +10,27 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
 var _ = Describe("Access-control pod-automount-service-account-token , ", func() {
 
 	execute.BeforeAll(func() {
+		By("Define tnf config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{parameters.TestAccessControlNameSpace},
+			[]string{parameters.TestPodLabel},
+			[]string{},
+			[]string{})
+		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
+
+	})
+
+	BeforeEach(func() {
+
+		By("Clean namespace before each test")
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 
 	})
 
@@ -37,14 +53,14 @@ var _ = Describe("Access-control pod-automount-service-account-token , ", func()
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlNamespace,
+			parameters.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53034
 	It("one deployment, one pod, token true [negative]", func() {
-		By("Define deployment with automountServiceAccountToken set to false")
+		By("Define deployment with automountServiceAccountToken set to true")
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -57,42 +73,97 @@ var _ = Describe("Access-control pod-automount-service-account-token , ", func()
 		err = globalhelper.LaunchTests(
 			parameters.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlNamespace,
-			globalparameters.TestCasePassed)
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53035
 	It("one deployment, one pod, token not set, service account's token false", func() {
-
+		Skip("Under development")
 	})
 
 	// 53036
 	It("one deployment, one pod, token not set, service account's token true [negative]", func() {
-
+		Skip("Under development")
 	})
 
 	// 53040
 	It("one deployment, one pod, token not set, service account's token not set [negative]", func() {
-
+		Skip("Under development")
 	})
 
 	// 53054
 	It("one deployment, one pod, token false, service account's token true", func() {
-
+		Skip("Under development")
 	})
 
 	// 53036
 	It("two deployments, one pod each, tokens false", func() {
+		By("Define deployments with automountServiceAccountTokens set to false")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		Expect(err).ToNot(HaveOccurred())
 
+		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep2 = deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53057
 	It("two deployments, one pod each, one token true [negative]", func() {
+		By("Define deployments with automountServiceAccountTokens set to different values")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, true)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep2 = deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
 
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -83,22 +83,112 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 	// 53035
 	It("one deployment, one pod, token not set, service account's token false", func() {
-		Skip("Under development")
+		By("Define deployment with automountServiceAccountToken not set")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Set namespace's default serviceaccount's automountServiceAccountToken to false")
+		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
+			parameters.ServiceAccountName, "false")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53036
 	It("one deployment, one pod, token not set, service account's token true [negative]", func() {
-		Skip("Under development")
+		By("Define deployment with automountServiceAccountToken not set")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Set namespace's defualt serviceaccount's automountServiceAccountToken to true")
+		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
+			parameters.ServiceAccountName, "true")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53040
 	It("one deployment, one pod, token not set, service account's token not set [negative]", func() {
-		Skip("Under development")
+		By("Define deployment with automountServiceAccountToken not set")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Set namespace's default serviceaccount's automountServiceAccountToken to nil")
+		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
+			parameters.ServiceAccountName, "nil")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53054
 	It("one deployment, one pod, token false, service account's token true", func() {
-		Skip("Under development")
+		By("Define deployment with automountServiceAccountToken not set")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Set namespace's default serviceaccount's automountServiceAccountToken to true")
+		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
+			parameters.ServiceAccountName, "true")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53036

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -1,0 +1,99 @@
+package accesscontrol
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
+)
+
+var _ = Describe("Access-control pod-automount-service-account-token , ", func() {
+
+	execute.BeforeAll(func() {
+
+	})
+
+	// 53033
+	It("one deployment, one pod, token false", func() {
+		By("Define deployment with automountServiceAccountToken set to false")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlNamespace,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 53034
+	It("one deployment, one pod, token true [negative]", func() {
+		By("Define deployment with automountServiceAccountToken set to false")
+		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		Expect(err).ToNot(HaveOccurred())
+
+		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, true)
+
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			parameters.TestCaseNameAccessControlPodAutomountToken,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(
+			parameters.TestCaseNameAccessControlNamespace,
+			globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 53035
+	It("one deployment, one pod, token not set, service account's token false", func() {
+
+	})
+
+	// 53036
+	It("one deployment, one pod, token not set, service account's token true [negative]", func() {
+
+	})
+
+	// 53040
+	It("one deployment, one pod, token not set, service account's token not set [negative]", func() {
+
+	})
+
+	// 53054
+	It("one deployment, one pod, token false, service account's token true", func() {
+
+	})
+
+	// 53036
+	It("two deployments, one pod each, tokens false", func() {
+
+	})
+
+	// 53057
+	It("two deployments, one pod each, one token true [negative]", func() {
+
+	})
+
+})

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-automount-service-account-token , ", func() {
+var _ = Describe("Access-control pod-automount-service-account-token, ", func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")
@@ -27,7 +27,6 @@ var _ = Describe("Access-control pod-automount-service-account-token , ", func()
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
@@ -18,8 +18,8 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{parameters.TestAccessControlNameSpace},
-			[]string{parameters.TestPodLabel},
+			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
@@ -28,7 +28,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -36,23 +36,23 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53033
 	It("one deployment, one pod, token false", func() {
 		By("Define deployment with automountServiceAccountToken set to false")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -60,23 +60,23 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53034
 	It("one deployment, one pod, token true [negative]", func() {
 		By("Define deployment with automountServiceAccountToken set to true")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, true)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -84,26 +84,26 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53035
 	It("one deployment, one pod, token not set, service account's token false", func() {
 		By("Define deployment with automountServiceAccountToken not set")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Set namespace's default serviceaccount's automountServiceAccountToken to false")
-		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
-			parameters.ServiceAccountName, "false")
+		err = tshelper.SetServiceAccountAutomountServiceAccountToken(tsparams.TestAccessControlNameSpace,
+			tsparams.ServiceAccountName, "false")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -111,26 +111,26 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53036
 	It("one deployment, one pod, token not set, service account's token true [negative]", func() {
 		By("Define deployment with automountServiceAccountToken not set")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Set namespace's default serviceaccount's automountServiceAccountToken to true")
-		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
-			parameters.ServiceAccountName, "true")
+		err = tshelper.SetServiceAccountAutomountServiceAccountToken(tsparams.TestAccessControlNameSpace,
+			tsparams.ServiceAccountName, "true")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -138,26 +138,26 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53040
 	It("one deployment, one pod, token not set, service account's token not set [negative]", func() {
 		By("Define deployment with automountServiceAccountToken not set")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Set namespace's default serviceaccount's automountServiceAccountToken to nil")
-		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
-			parameters.ServiceAccountName, "nil")
+		err = tshelper.SetServiceAccountAutomountServiceAccountToken(tsparams.TestAccessControlNameSpace,
+			tsparams.ServiceAccountName, "nil")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -165,28 +165,28 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53054
 	It("one deployment, one pod, token false, service account's token true", func() {
 		By("Define deployment with automountServiceAccountToken set to false")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Set namespace's default serviceaccount's automountServiceAccountToken to true")
-		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
-			parameters.ServiceAccountName, "true")
+		err = tshelper.SetServiceAccountAutomountServiceAccountToken(tsparams.TestAccessControlNameSpace,
+			tsparams.ServiceAccountName, "true")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -194,31 +194,31 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53036
 	It("two deployments, one pod each, tokens false", func() {
 		By("Define deployments with automountServiceAccountTokens set to false")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2 = deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -226,31 +226,31 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 	// 53057
 	It("two deployments, one pod each, one token true [negative]", func() {
 		By("Define deployments with automountServiceAccountTokens set to different values")
-		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep = deployment.RedefineWithAutomountServiceAccountToken(dep, true)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2 = deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodAutomountToken,
+			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -117,7 +117,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Set namespace's defualt serviceaccount's automountServiceAccountToken to true")
+		By("Set namespace's default serviceaccount's automountServiceAccountToken to true")
 		err = helper.SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace,
 			parameters.ServiceAccountName, "true")
 		Expect(err).ToNot(HaveOccurred())
@@ -164,7 +164,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 	// 53054
 	It("one deployment, one pod, token false, service account's token true", func() {
-		By("Define deployment with automountServiceAccountToken not set")
+		By("Define deployment with automountServiceAccountToken set to false")
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -234,3 +234,10 @@ func RedefineWithPriviledgedContainer(deployment *v1.Deployment) *v1.Deployment 
 
 	return deployment
 }
+
+// RedefineWithAutomountServiceAccountToken redefines deployment with provided automountServiceAccountToken value
+func RedefineWithAutomountServiceAccountToken(deployment *v1.Deployment, token bool) *v1.Deployment {
+	deployment.Spec.Template.Spec.AutomountServiceAccountToken = &token
+
+	return deployment
+}

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -235,7 +235,6 @@ func RedefineWithPriviledgedContainer(deployment *v1.Deployment) *v1.Deployment 
 	return deployment
 }
 
-// RedefineWithAutomountServiceAccountToken redefines deployment with provided automountServiceAccountToken value
 func RedefineWithAutomountServiceAccountToken(deployment *v1.Deployment, token bool) *v1.Deployment {
 	deployment.Spec.Template.Spec.AutomountServiceAccountToken = &token
 


### PR DESCRIPTION
Remaining four access-control pod-automount-service-account-token test cases