### PR TITLE
Update Go to 1.18.6

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.5
+          go-version: 1.18.6
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/x49AQzIVX-s

Similar changes:
- https://github.com/test-network-function/cnf-certification-test/pull/492
- https://github.com/test-network-function/test-network-function-claim/pull/62
- https://github.com/test-network-function/l2discovery/pull/15
- https://github.com/test-network-function/privileged-daemonset/pull/7
- https://github.com/test-network-function/oct/pull/1