### PR TITLE
Changed deployment spec-changing funcs that don't use pointers for values to return deployment pointer

### DIFF
--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -39,7 +39,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep, false)
+		dep = deployment.RedefineWithHostIpc(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep, true)
+		dep = deployment.RedefineWithHostIpc(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep, false)
+		dep = deployment.RedefineWithHostIpc(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep2, false)
+		dep2 = deployment.RedefineWithHostIpc(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep, true)
+		dep = deployment.RedefineWithHostIpc(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -127,7 +127,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostIpc(dep2, false)
+		dep2 = deployment.RedefineWithHostIpc(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -39,7 +39,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep, false)
+		dep = deployment.RedefineWithHostNetwork(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep, true)
+		dep = deployment.RedefineWithHostNetwork(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep, false)
+		dep = deployment.RedefineWithHostNetwork(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep2, false)
+		dep2 = deployment.RedefineWithHostNetwork(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep, err := helper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep, true)
+		dep = deployment.RedefineWithHostNetwork(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -127,7 +127,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		dep2, err := helper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostNetwork(dep2, false)
+		dep2 = deployment.RedefineWithHostNetwork(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -39,7 +39,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep, false)
+		dep = deployment.RedefineWithHostPid(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep, true)
+		dep = deployment.RedefineWithHostPid(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep, false)
+		dep = deployment.RedefineWithHostPid(dep, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep2, false)
+		dep2 = deployment.RedefineWithHostPid(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep, true)
+		dep = deployment.RedefineWithHostPid(dep, true)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -127,7 +127,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithHostPid(dep2, false)
+		dep2 = deployment.RedefineWithHostPid(dep2, false)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -235,18 +235,24 @@ func RedefineWithPriviledgedContainer(deployment *v1.Deployment) *v1.Deployment 
 	return deployment
 }
 
-func RedefineWithHostPid(deployment *v1.Deployment, hostPid bool) {
+func RedefineWithHostPid(deployment *v1.Deployment, hostPid bool) *v1.Deployment {
 	deployment.Spec.Template.Spec.HostPID = hostPid
+
+	return deployment
 }
 
-func RedefineWithHostIpc(deployment *v1.Deployment, hostIpc bool) {
+func RedefineWithHostIpc(deployment *v1.Deployment, hostIpc bool) *v1.Deployment {
 	deployment.Spec.Template.Spec.HostIPC = hostIpc
+
+	return deployment
 }
 
 func RedefineWithAutomountServiceAccountToken(deployment *v1.Deployment, token bool) {
 	deployment.Spec.Template.Spec.AutomountServiceAccountToken = &token
 }
 
-func RedefineWithHostNetwork(deployment *v1.Deployment, hostNetwork bool) {
+func RedefineWithHostNetwork(deployment *v1.Deployment, hostNetwork bool) *v1.Deployment {
 	deployment.Spec.Template.Spec.HostNetwork = hostNetwork
+
+	return deployment
 }


### PR DESCRIPTION
Based on mostly process of elimination, I think this *might* fix the access-control tests that fail due to deployment creation timeout. If we merge it in and it doesn't fix those tests during the Jenkins build, I'll revert it. 