### PR TITLE
Add dependabot YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# dependabot config
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    vendor: true
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Similar changes/files: 
- https://github.com/test-network-function/cnf-certification-test/blob/main/.github/dependabot.yml
- https://github.com/test-network-function/autodiscover/pull/2
- https://github.com/test-network-function/l2discovery/pull/9
- https://github.com/test-network-function/oct/pull/4

Still maintains the `vendor` directory.