### PR TITLE
add latest go version installation

### DIFF
--- a/scripts/install-latest-go.sh
+++ b/scripts/install-latest-go.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+LATEST=$(curl https://go.dev/VERSION?m=text)
+wget https://go.dev/dl/${LATEST}.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf ${LATEST}.linux-amd64.tar.gz
+rm ${LATEST}.linux-amd64.tar.gz
+


### PR DESCRIPTION
The current go version being installed by CI executer bm-setup playbook is go1.18. our project requires go1.19

I Implemented the latest go version installation In order to avoid errors like in the following job: 
https://auto-jenkins-csb-kniqe.apps.ocp-c1.prod.psi.redhat.com/view/TNF/job/CNF/job/test-ocp-general-tnf/435/console

`go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18`

