### PR TITLE
Upgrade Golangci-lint to v1.50.0

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -13,7 +13,7 @@ else
   else
     DEPLOY_PATH=${GOPATH}/bin
   fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.49.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.50.0
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604