### PR TITLE
Automated affinity required pods tc verification

### DIFF
--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -126,3 +126,10 @@ func AppendContainersToPod(pod *corev1.Pod, containersNum int, image string) {
 			})
 	}
 }
+
+// AppendLabelsToPod appends labels to given pod manifest.
+func AppendLabelsToPod(pod *corev1.Pod, labels map[string]string) {
+	for name, value := range labels {
+		pod.Labels[name] = value
+	}
+}

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -30,14 +30,7 @@ func LaunchTests(testCaseName string, tcNameForReport string) error {
 		"-t", Configuration.General.TnfConfigDir,
 		"-o", Configuration.General.TnfReportDir,
 		"-i", fmt.Sprintf("%s:%s", Configuration.General.TnfImage, Configuration.General.TnfImageTag),
-	}
-
-	if len(testCaseName) > 0 {
-		testArgs = append(testArgs, "-f")
-		testArgs = append(testArgs, testCaseName)
-		glog.V(5).Info(fmt.Sprintf("add test suite %s", testCaseName))
-	} else {
-		panic("No test suite name provided.")
+		"-l", testCaseName,
 	}
 
 	cmd := exec.Command(fmt.Sprintf("./%s", Configuration.General.TnfEntryPointScript))

--- a/tests/lifecycle/parameters/parameters.go
+++ b/tests/lifecycle/parameters/parameters.go
@@ -49,7 +49,7 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
-	AffinityRequired = map[string]string{
+	AffinityRequiredPodLabels = map[string]string{
 		"AffinityRequired": "true",
 	}
 )

--- a/tests/lifecycle/parameters/parameters.go
+++ b/tests/lifecycle/parameters/parameters.go
@@ -36,6 +36,7 @@ var (
 	TnfPersistentVolumeReclaimPolicyTcName = "lifecycle-persistent-volume-reclaim-policy"
 	TnfCPUIsolationTcName                  = "lifecycle-cpu-isolation"
 	TnfStartUpProbeTcName                  = "lifecycle-startup-probe"
+	TnfAffinityRequiredPodsTcName          = "lifecycle-affinity-required-pods"
 )
 
 var (
@@ -47,5 +48,8 @@ var (
 	TestTargetLabels       = map[string]string{
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
+	}
+	AffinityRequired = map[string]string{
+		"AffinityRequired": "true",
 	}
 )

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -37,8 +37,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 	It("One pod, label is set, Affinity rules are set", func() {
 		By("Define & create pod")
 		put := tshelper.DefinePod(tsparams.TestPodName)
-		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(put, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(put, tsparams.AffinityRequiredPodLabels)
 		pod.RedefineWithNodeAffinity(put, configSuite.General.CnfNodeLabel)
 		pod.RedefineWithPodAffinity(put, tsparams.TestTargetLabels)
 
@@ -60,8 +60,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 	It("Two pods, labels are set for both, Affinity rules are set", func() {
 		By("Define & create pods")
 		putA := tshelper.DefinePod(tsparams.TestPodName)
-		pod.RedefinePodWithLabel(putA, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(putA, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(putA, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(putA, tsparams.AffinityRequiredPodLabels)
 		pod.RedefineWithNodeAffinity(putA, configSuite.General.CnfNodeLabel)
 		pod.RedefineWithPodAffinity(putA, tsparams.TestTargetLabels)
 
@@ -69,8 +69,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		putB := tshelper.DefinePod("lifecycle-podb")
-		pod.RedefinePodWithLabel(putB, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(putB, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(putB, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(putB, tsparams.AffinityRequiredPodLabels)
 		pod.RedefineWithNodeAffinity(putB, configSuite.General.CnfNodeLabel)
 		pod.RedefineWithPodAffinity(putB, tsparams.TestTargetLabels)
 
@@ -92,8 +92,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 	It("One pod, label is set, affinity rules are not set [negative]", func() {
 		By("Define & create pod")
 		put := tshelper.DefinePod(tsparams.TestPodName)
-		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(put, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(put, tsparams.AffinityRequiredPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,8 +112,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 	// 55330
 	It("One pod, label is set, podantiaffinity is set [negative]", func() {
 		put := tshelper.DefinePod(tsparams.TestPodName)
-		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(put, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(put, tsparams.AffinityRequiredPodLabels)
 		pod.RedefineWithPodantiAffinity(put, tsparams.TestTargetLabels)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
@@ -134,8 +134,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 	It("Two pods, labels are set for both, affinity rules are not set for one of the pods [negative]", func() {
 		By("Define & create pods")
 		putA := tshelper.DefinePod(tsparams.TestPodName)
-		pod.RedefinePodWithLabel(putA, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(putA, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(putA, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(putA, tsparams.AffinityRequiredPodLabels)
 		pod.RedefineWithNodeAffinity(putA, configSuite.General.CnfNodeLabel)
 		pod.RedefineWithPodAffinity(putA, tsparams.TestTargetLabels)
 
@@ -143,8 +143,8 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		putB := tshelper.DefinePod("lifecycle-podb")
-		pod.RedefinePodWithLabel(putB, tsparams.TestTargetLabels)
-		pod.RedefinePodWithLabel(putB, tsparams.AffinityRequired)
+		globalhelper.AppendLabelsToPod(putB, tsparams.TestTargetLabels)
+		globalhelper.AppendLabelsToPod(putB, tsparams.AffinityRequiredPodLabels)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(putB, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
+
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
+)
+
+var _ = Describe("lifecycle-affinity-required-pods", func() {
+
+	configSuite, err := config.NewConfig()
+	if err != nil {
+		glog.Fatal(fmt.Errorf("can not load config file"))
+	}
+
+	BeforeEach(func() {
+		err := tshelper.WaitUntilClusterIsStable()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Clean namespace before each test")
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 55327
+	It("One pod, label is set, Affinity rules are set", func() {
+		By("Define & create pod")
+		put := tshelper.DefinePod(tsparams.TestPodName)
+		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+		pod.RedefineWithNodeAffinity(put, configSuite.General.CnfNodeLabel)
+		pod.RedefineWithPodAffinity(put, tsparams.TestTargetLabels)
+
+		err := globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle-affinity-required-pods test")
+		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55328
+	It("Two pods, labels are set for both, Affinity rules are set", func() {
+		By("Define & create pods")
+		putA := tshelper.DefinePod(tsparams.TestPodName)
+		pod.RedefinePodWithLabel(putA, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(putA, tsparams.AffinityRequired)
+		pod.RedefineWithNodeAffinity(putA, configSuite.General.CnfNodeLabel)
+		pod.RedefineWithPodAffinity(putA, tsparams.TestTargetLabels)
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(putA, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		putB := tshelper.DefinePod("lifecycle-podb")
+		pod.RedefinePodWithLabel(putB, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(putB, tsparams.AffinityRequired)
+		pod.RedefineWithNodeAffinity(putB, configSuite.General.CnfNodeLabel)
+		pod.RedefineWithPodAffinity(putB, tsparams.TestTargetLabels)
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(putB, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle-affinity-required-pods test")
+		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55329
+	It("One pod, label is set, affinity rules are not set [negative]", func() {
+		By("Define & create pod")
+		put := tshelper.DefinePod(tsparams.TestPodName)
+		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+
+		err := globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle-affinity-required-pods test")
+		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55330
+	It("One pod, label is set, podantiaffinity is set [negative]", func() {
+		put := tshelper.DefinePod(tsparams.TestPodName)
+		pod.RedefinePodWithLabel(put, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(put, tsparams.AffinityRequired)
+		pod.RedefineWithPodantiAffinity(put, tsparams.TestTargetLabels)
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle-affinity-required-pods test")
+		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55333
+	It("Two pods, labels are set for both, affinity rules are not set for one of the pods [negative]", func() {
+		By("Define & create pods")
+		putA := tshelper.DefinePod(tsparams.TestPodName)
+		pod.RedefinePodWithLabel(putA, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(putA, tsparams.AffinityRequired)
+		pod.RedefineWithNodeAffinity(putA, configSuite.General.CnfNodeLabel)
+		pod.RedefineWithPodAffinity(putA, tsparams.TestTargetLabels)
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(putA, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		putB := tshelper.DefinePod("lifecycle-podb")
+		pod.RedefinePodWithLabel(putB, tsparams.TestTargetLabels)
+		pod.RedefinePodWithLabel(putB, tsparams.AffinityRequired)
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(putB, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start lifecycle-affinity-required-pods test")
+		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+})

--- a/tests/utils/pod/pod.go
+++ b/tests/utils/pod/pod.go
@@ -25,16 +25,7 @@ func DefinePod(podName string, namespace string, image string) *corev1.Pod {
 
 // RedefinePodWithLabel adds label to given pod manifest.
 func RedefinePodWithLabel(pod *corev1.Pod, label map[string]string) {
-	newMap := make(map[string]string)
-	for k, v := range pod.Labels {
-		newMap[k] = v
-	}
-
-	for k, v := range label {
-		newMap[k] = v
-	}
-
-	pod.Labels = newMap
+	pod.ObjectMeta.Labels = label
 }
 
 // RedefineWithReadinessProbe adds readiness probe to given pod manifest.

--- a/tests/utils/pod/pod.go
+++ b/tests/utils/pod/pod.go
@@ -25,7 +25,16 @@ func DefinePod(podName string, namespace string, image string) *corev1.Pod {
 
 // RedefinePodWithLabel adds label to given pod manifest.
 func RedefinePodWithLabel(pod *corev1.Pod, label map[string]string) {
-	pod.ObjectMeta.Labels = label
+	newMap := make(map[string]string)
+	for k, v := range pod.Labels {
+		newMap[k] = v
+	}
+
+	for k, v := range label {
+		newMap[k] = v
+	}
+
+	pod.Labels = newMap
 }
 
 // RedefineWithReadinessProbe adds readiness probe to given pod manifest.
@@ -95,4 +104,53 @@ func RedefineWithCPUResources(pod *corev1.Pod, limit string, req string) {
 
 func RedefineWithRunTimeClass(pod *corev1.Pod, rtcName string) {
 	pod.Spec.RuntimeClassName = pointer.String(rtcName)
+}
+
+// RedefineWithNodeAffinity redefines pod with nodeAffinity spec.
+func RedefineWithNodeAffinity(pod *corev1.Pod, key string) {
+	pod.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      key,
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+		}}
+}
+
+// RedefineWithPodAffinity redefines pod with podAffinity spec.
+func RedefineWithPodAffinity(put *corev1.Pod, label map[string]string) {
+	put.Spec.Affinity = &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: label,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}}
+}
+
+// RedefineWithPodantiAffinity redefines pod with podAntiAffinity spec.
+func RedefineWithPodantiAffinity(put *corev1.Pod, label map[string]string) {
+	put.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: label,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}}
 }


### PR DESCRIPTION
Considering this [PR](https://github.com/test-network-function/cnf-certification-test/pull/608/files)
affinity-required-deployments/statefulSets will not be automated.

I had to edit the runhelper.go in order to be able to provide 1 out of 3 labels each tc must have: 
1. test case name
2. common/ extended tags
3. test suite name

thus, I added the -l argument in the cmd line, which will target the specific tc, instead of specifying if it's common/extended.

Eventually, using -l made the -f redundant, and hence I deleted it. 