### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    vendor: true
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
The error we are currently seeing:
```
The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed
```

According to the `vendor` [section](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#vendor) of the dependabot documentation: "Don't use this option if you're using gomod as Dependabot automatically detects vendoring for this tool"