### PR TITLE
Added platform-alteration-hugepages-2m-only verification scenarious

### DIFF
--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -20,6 +20,7 @@ var (
 	TestPodName            = "platform-alteration-pod"
 	TnfTargetPodLabels     = map[string]string{
 		testPodLabelPrefixName: testPodLabelValue,
+		"app":                  "test",
 	}
 
 	NotRedHatRelease = "quay.io/baselibrary/ubuntu:latest"
@@ -37,15 +38,15 @@ const (
 	TnfHugePagesConfigName    = "platform-alteration-hugepages-config"
 	TnfBootParamsName         = "platform-alteration-boot-params"
 	TnfSysctlConfigName       = "platform-alteration-sysctl-config"
+	TnfHugePages2mOnlyName    = "platform-alteration-hugepages-2m-only"
 
 	Getenforce    = `chroot /host getenforce`
 	Enforcing     = "Enforcing"
 	SetPermissive = `chroot /host setenforce 0`
 	SetEnforce    = `chroot /host setenforce 1`
 
-	RebootWaitingTime  = 10 * time.Minute
-	Reboot             = `chroot /host systemctl reboot`
-	FindHugePagesFiles = "find /host/sys/devices/system/node/ -name nr_hugepages"
-
+	RebootWaitingTime     = 10 * time.Minute
+	Reboot                = `chroot /host systemctl reboot`
+	FindHugePagesFiles    = "find /host/sys/devices/system/node/ -name nr_hugepages"
 	PerformanceProfileCrd = "performanceprofiles.performance.openshift.io"
 )

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/platformalteration/parameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("platform-alteration-hugepages-2m-only", func() {
+
+	BeforeEach(func() {
+		By("Clean namespace before each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55865
+	It("One deployment, one pod with 2Mi hugepages", func() {
+
+		By("Define deployment")
+		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
+			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+		deployment.RedefineWithCPUResources(dep, "500m", "250m")
+		deployment.RedefineWith2MiHugepages(dep, 4)
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start platform-alteration-hugepages-2m-only test")
+		err = globalhelper.LaunchTests(tsparams.TnfHugePages2mOnlyName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55866
+	It("One pod with 2Mi hugepages", func() {
+
+		By("Define pod with 2Mi hugepages")
+		puta := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage)
+		pod.RedefineWithCPUResources(puta, "500m", "250m")
+		pod.RedefineWith2MiHugepages(puta, 4)
+		pod.RedefinePodWithLabel(puta, tsparams.TnfTargetPodLabels)
+
+		err := globalhelper.CreateAndWaitUntilPodIsReady(puta, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start platform-alteration-hugepages-2m-only test")
+		err = globalhelper.LaunchTests(tsparams.TnfHugePages2mOnlyName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// 55867
+	It("One deployment, one pod, two containers, only one with 2Mi hugepages", func() {
+
+		By("Define deployment")
+		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
+			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+		deployment.RedefineWithCPUResources(dep, "500m", "250m")
+		deployment.RedefineWith2MiHugepages(dep, 4)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start platform-alteration-hugepages-2m-only test")
+		err = globalhelper.LaunchTests(tsparams.TnfHugePages2mOnlyName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	// 55868
+	It("One pod, two containers, one with 2Mi hugepages, other with 1Gi [negative]", func() {
+
+		By("Define pod")
+		put := pod.DefinePod(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
+			globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToPod(put, 1, globalhelper.Configuration.General.TestImage)
+		pod.RedefinePodWithLabel(put, tsparams.TnfTargetPodLabels)
+		pod.RedefineWithCPUResources(put, "500m", "250m")
+
+		err := pod.RedefineFirstContainerWith2MiHugepages(put, 4)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = pod.RedefineSecondContainerWith1GHugepages(put, 2)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Start platform-alteration-hugepages-2m-only test")
+		err = globalhelper.LaunchTests(tsparams.TnfHugePages2mOnlyName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).To(HaveOccurred())
+
+		By("Verify test case status in Junit and Claim reports")
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+})

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -281,3 +281,12 @@ func RedefineWithSysPtrace(deployment *v1.Deployment) {
 		}
 	}
 }
+
+func RedefineWith2MiHugepages(deployment *v1.Deployment, hugepages int) {
+	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Mi"))
+
+	for i := range deployment.Spec.Template.Spec.Containers {
+		deployment.Spec.Template.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+		deployment.Spec.Template.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+	}
+}

--- a/tests/utils/pod/pod.go
+++ b/tests/utils/pod/pod.go
@@ -1,6 +1,8 @@
 package pod
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -144,4 +146,39 @@ func RedefineWithPodantiAffinity(put *corev1.Pod, label map[string]string) {
 				},
 			},
 		}}
+}
+
+func RedefineWith2MiHugepages(pod *corev1.Pod, hugepages int) {
+	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Mi"))
+
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+	}
+}
+
+func RedefineFirstContainerWith2MiHugepages(pod *corev1.Pod, hugepages int) error {
+	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Mi"))
+
+	if len(pod.Spec.Containers) > 0 {
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+		pod.Spec.Containers[0].Resources.Limits[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+
+		return nil
+	}
+
+	return fmt.Errorf("pod %s does not have enough containers", pod.Name)
+}
+
+func RedefineSecondContainerWith1GHugepages(pod *corev1.Pod, hugepages int) error {
+	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Gi"))
+
+	if len(pod.Spec.Containers) > 1 {
+		pod.Spec.Containers[1].Resources.Requests[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
+		pod.Spec.Containers[1].Resources.Limits[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
+
+		return nil
+	}
+
+	return fmt.Errorf("pod %s does not have enough containers", pod.Name)
 }


### PR DESCRIPTION
* There is an ongoing [PR](https://gitlab.cee.redhat.com/cnf/cnf-pipeline/-/merge_requests/420) in cnf-pipeline repo to configure hugepages-2m in the performance profile 
being applied in the CI. 

Automated 55865-55868.