### PR TITLE
Roll back to prior implementation of AppendLabelsToPod function

### DIFF
--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -128,8 +128,17 @@ func AppendContainersToPod(pod *corev1.Pod, containersNum int, image string) {
 }
 
 // AppendLabelsToPod appends labels to given pod manifest.
+// from go documentation : "if you pass a map to a function that changes the contents of the map,
+// the changes will be visible in the caller" - thats the reason for copying the map.
 func AppendLabelsToPod(pod *corev1.Pod, labels map[string]string) {
-	for name, value := range labels {
-		pod.Labels[name] = value
+	newMap := make(map[string]string)
+	for k, v := range pod.Labels {
+		newMap[k] = v
 	}
+
+	for k, v := range labels {
+		newMap[k] = v
+	}
+
+	pod.Labels = newMap
 }


### PR DESCRIPTION
This is required because the current implementation is changing the original labels.