### PR TITLE
Add ocp-node-os tc

### DIFF
--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -39,6 +39,7 @@ const (
 	TnfBootParamsName         = "platform-alteration-boot-params"
 	TnfSysctlConfigName       = "platform-alteration-sysctl-config"
 	TnfHugePages2mOnlyName    = "platform-alteration-hugepages-2m-only"
+	TnfOcpNodeOsName          = "platform-alteration-ocp-node-os-lifecycle"
 
 	Getenforce    = `chroot /host getenforce`
 	Enforcing     = "Enforcing"

--- a/tests/platformalteration/tests/platform_alteration_ocp_node_os.go
+++ b/tests/platformalteration/tests/platform_alteration_ocp_node_os.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/platformalteration/parameters"
+
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+)
+
+var _ = Describe("platform-alteration-ocp-node-os", func() {
+
+	It("Nodes OS should be compatible with OCP version", func() {
+		By("Start platform-alteration-ocp-node-os test")
+		err := globalhelper.LaunchTests(tsparams.TnfOcpNodeOsName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfOcpNodeOsName, globalparameters.TestCasePassed)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
Same as ocp-lifecycle tc, there is no way to change the environment, just expect it to pass.