### PR TITLE
Add ginkgo seed usage to improve debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Below is an e2e flow example:
 1. export `DEBUG_TNF`=true.
 2. run `make test-all` / `make test-features`.
 3. under reports folder, a `Debug` folder will be generated, containing suites folders with TNF logs for each of the tests. 
+4. on each run, ginkgo is generating a seed number to distinguish the run from other runs, in order to repeat the exact same run,
+   export `GINKGO_SEED_NUMBER=seed`, and then repeat stage 2 above.
 
 
 # cnfcert-tests-verification - How to contribute

--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ Below is an e2e flow example:
 1. export `DEBUG_TNF`=true.
 2. run `make test-all` / `make test-features`.
 3. under reports folder, a `Debug` folder will be generated, containing suites folders with TNF logs for each of the tests. 
-4. on each run, ginkgo is generating a seed number to distinguish the run from other runs, in order to repeat the exact same run,
+4. on each run, ginkgo is generating a seed number, the seed is used to randomize the execution order of the tests, in order to repeat the exact same run,
    export `GINKGO_SEED_NUMBER=seed`, and then repeat stage 2 above.
+   when launching stage 2 after exporting the seed, this is an output example - the seed will be different -
+   "Running Suite: CNFCert lifecycle tests - /root/tnf-qe/cnfcert-tests-verification/tests/lifecycle
+   ================================================================================================
+   Random Seed: 1668617625"
+   
 
 
 # cnfcert-tests-verification - How to contribute

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,7 +3,12 @@
 GOPATH="${GOPATH:-~/go}"
 export PATH=$PATH:$GOPATH/bin
 EXCLUDED_FOLDERS=""
+GINKGO_SEED_FLAG=""
 ALL_TESTS_FOLDERS=$(ls -d ./tests/*/)
+
+if [[ "${GINKGO_SEED_NUMBER}" != "" ]]; then 
+    GINKGO_SEED_FLAG="--seed=${GINKGO_SEED_NUMBER}"
+fi
 
 function run_tests {
     case $1 in
@@ -22,7 +27,7 @@ function run_tests {
                   all_default_suites+=" $folder"
                 fi
             done
-            ginkgo -timeout=24h -v --keep-going --require-suite -r $all_default_suites
+            ginkgo -timeout=24h -v --keep-going ${GINKGO_SEED_FLAG} --require-suite -r $all_default_suites
             ;;
         features)
             if [ -z "$FEATURES" ]; then {
@@ -38,7 +43,7 @@ function run_tests {
                     } fi
                     done
                 done
-            ginkgo -timeout=24h -v --keep-going --require-suite $command
+            ginkgo -timeout=24h -v --keep-going ${GINKGO_SEED_FLAG} --require-suite $command
             ;;
         *)
         echo "Unknown case"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,6 +7,7 @@ GINKGO_SEED_FLAG=""
 ALL_TESTS_FOLDERS=$(ls -d ./tests/*/)
 
 if [[ "${GINKGO_SEED_NUMBER}" != "" ]]; then 
+    echo "Using ginkgo seed number: ${GINKGO_SEED_NUMBER}"
     GINKGO_SEED_FLAG="--seed=${GINKGO_SEED_NUMBER}"
 fi
 


### PR DESCRIPTION
ginkgo seed is used to rerun the same exact job with a seed that was generated by ginkgo, which will improve debugging.