### PR TITLE
Fixed security context in daemonSet.go

### DIFF
--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -137,11 +137,13 @@ func GetClusterMultusInterfaces() ([]string, error) {
 	var nodesInterfacesList [][]string
 
 	for _, runningPod := range podsList.Items {
-		nodeInterfaces, err := getInterfacesList(runningPod)
-		if err != nil {
-			return nil, err
+		if !strings.Contains(runningPod.Spec.NodeName, "master") {
+			nodeInterfaces, err := getInterfacesList(runningPod)
+			if err != nil {
+				return nil, err
+			}
+			nodesInterfacesList = append(nodesInterfacesList, nodeInterfaces)
 		}
-		nodesInterfacesList = append(nodesInterfacesList, nodeInterfaces)
 	}
 
 	var lastMatch []string

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -78,8 +79,18 @@ var _ = Describe("Networking custom namespace,", func() {
 
 	// 48330
 	It("2 custom deployments 3 pods, 1 NAD, connectivity via Multus secondary interface", func() {
+		// The NetworkAttachmentDefintion (mcvlan) created for this TC uses an interface that exists only in worker nodes,
+		// so we need to make sure the test pods are not deployed in master nodes.
+		err := globalhelper.EnableMasterScheduling(false)
+		Expect(err).ToNot(HaveOccurred())
+
+		defer func() {
+			err := globalhelper.EnableMasterScheduling(true)
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to enable master scheduling: %v", err))
+		}()
+
 		By("Define and create Network-attachment-definition")
-		err := tshelper.DefineAndCreateNadOnCluster(
+		err = tshelper.DefineAndCreateNadOnCluster(
 			tsparams.TestNadNameA, multusInterfaces[0], tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -81,7 +81,12 @@ func RedefineWithPrivilegeAndHostNetwork(daemonSet *v1.DaemonSet) {
 		daemonSet.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
 	}
 
-	daemonSet.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = pointer.BoolPtr(true)
+	daemonSet.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		Privileged: pointer.Bool(true),
+		RunAsUser:  pointer.Int64(0),
+		Capabilities: &corev1.Capabilities{
+			Add: []corev1.Capability{"ALL"}},
+	}
 }
 
 func RedefineWithMultus(daemonSet *v1.DaemonSet, nadName string) {


### PR DESCRIPTION
1. Fixed security context in daemonSet.go
2. Fixed a tc that tried to deploy a NAD that uses an interface that exists only in worker nodes by disabling 
master scheduling, in that way, only worker nodes will be scheduled.