### PR TITLE
Update Go to v1.19.5

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/wrmRT7JlevE

Related to: https://github.com/test-network-function/cnf-certification-test/pull/779