### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,10 +13,10 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.6
+          go-version: 1.20.1
 
       - uses: actions/checkout@v3
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,13 +24,13 @@ linters-settings:
     statements: 85
   unused:
     check-exported: true
-    go: "1.19"
+    go: "1.20"
   stylecheck:
     dot-import-whitelist:
       - github.com/onsi/gomega
       - github.com/onsi/ginkgo/v2
     # Select the Go version to target. The default is '1.13'.
-    go: "1.19"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks: [ "all", "-ST1001"]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cnfcert-tests-verification
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/glog v1.0.0


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873