### PR TITLE
Update NotRedHatRelease image ref

### DIFF
--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -23,7 +23,7 @@ var (
 		"app":                  "test",
 	}
 
-	NotRedHatRelease = "quay.io/baselibrary/ubuntu:latest"
+	NotRedHatRelease = "quay.io/jitesoft/nginx:1.23.3"
 )
 
 const (


### PR DESCRIPTION
https://quay.io/repository/jitesoft/nginx/manifest/sha256:8876307eb58f5c35b4c78c6979ae5ed36bc3bae33c82a1d5e7572fe62fa3cbc7

This is the link to the `1.23.3` release of this nginx image.

The reason for this change is from the logs of the QE runs:
```
[37mDEBUG  [0m[Mar 10 22:20:38.628][suite.go: 79] Running preflight container tests for: test  
[36mINFO   [0m[Mar 10 22:20:38.628][containers.go: 78] Running preflight container test against image: quay.io/baselibrary/ubuntu:latest with name: test 
[31mERROR  [0m[Mar 10 22:20:40.471][containers.go: 115] failed to pull remote container: unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377 
[31mFATAL  [0m[Mar 10 22:20:40.471][suite.go: 82] failed running preflight on image: quay.io/baselibrary/ubuntu:latest error: failed to pull remote container: unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377 
+ RESULT=1
+ set +o pipefail
```

The `preflight` tests run prior to the ginkgo It blocks being created and it has a problem with the ubuntu:latest image used prior to this PR.