### PR TITLE
Fixed CNCF annotation for multus networking test cases.

### DIFF
--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -91,7 +91,7 @@ func RedefineWithPrivilegeAndHostNetwork(daemonSet *appsv1.DaemonSet) {
 
 func RedefineWithMultus(daemonSet *appsv1.DaemonSet, nadName string) {
 	daemonSet.Spec.Template.Annotations = map[string]string{
-		"k8s.appsv1.cni.cncf.io/networks": fmt.Sprintf(`[ { "name": "%s" } ]`, nadName),
+		"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[ { "name": "%s" } ]`, nadName),
 	}
 }
 

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -88,7 +88,7 @@ func RedefineWithMultus(deployment *appsv1.Deployment, nadNames []string) *appsv
 	bString, _ := json.Marshal(nadAnnotations)
 
 	deployment.Spec.Template.Annotations = map[string]string{
-		"k8s.appsv1.cni.cncf.io/networks": string(bString),
+		"k8s.v1.cni.cncf.io/networks": string(bString),
 	}
 
 	return deployment


### PR DESCRIPTION
PR#229 mistakenly modified the CNCF annotations that are used to set the extra multus networks for pods under test.