### PR TITLE
Update setup-go action to v4

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.20
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.2
 


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/927