### PR TITLE
Fixed negative test cases for platform-lateration-is-redhat-release.

### DIFF
--- a/tests/platformalteration/helper/helper.go
+++ b/tests/platformalteration/helper/helper.go
@@ -11,7 +11,11 @@ import (
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
+
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -113,4 +117,38 @@ func AppendIstioContainerToPod(pod *corev1.Pod, image string) {
 			Image:   image,
 			Command: []string{"/bin/bash", "-c", "sleep INF"},
 		})
+}
+
+// Creates deployment with one pod with one non-UBI based container.
+func DefineDeploymentWithNonUBIContainer() *v1.Deployment {
+	dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
+		tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
+
+	// Workaround as this non-ubi test image needs /bin/sh (busybox) instead of /bin/bash.
+	deployment.RedefineWithContainerSpecs(dep, []corev1.Container{
+		{
+			Name:    "test",
+			Image:   tsparams.NotRedHatRelease,
+			Command: []string{"/bin/sh", "-c", "sleep INF"},
+		},
+	})
+
+	return dep
+}
+
+// Creates statefulset with one pod with one non-UBI based container.
+func DefineStatefulSetWithNonUBIContainer() *v1.StatefulSet {
+	sts := statefulset.DefineStatefulSet(tsparams.TestStatefulSetName, tsparams.PlatformAlterationNamespace,
+		tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
+
+	// Workaround as this non-ubi test image needs /bin/sh (busybox) instead of /bin/bash.
+	statefulset.RedefineWithContainerSpecs(sts, []corev1.Container{
+		{
+			Name:    "test",
+			Image:   tsparams.NotRedHatRelease,
+			Command: []string{"/bin/sh", "-c", "sleep INF"},
+		},
+	})
+
+	return sts
 }

--- a/tests/platformalteration/helper/helper.go
+++ b/tests/platformalteration/helper/helper.go
@@ -15,7 +15,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
 
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -120,7 +120,7 @@ func AppendIstioContainerToPod(pod *corev1.Pod, image string) {
 }
 
 // Creates deployment with one pod with one non-UBI based container.
-func DefineDeploymentWithNonUBIContainer() *v1.Deployment {
+func DefineDeploymentWithNonUBIContainer() *appsv1.Deployment {
 	dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
 		tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
 
@@ -137,7 +137,7 @@ func DefineDeploymentWithNonUBIContainer() *v1.Deployment {
 }
 
 // Creates statefulset with one pod with one non-UBI based container.
-func DefineStatefulSetWithNonUBIContainer() *v1.StatefulSet {
+func DefineStatefulSetWithNonUBIContainer() *appsv1.StatefulSet {
 	sts := statefulset.DefineStatefulSet(tsparams.TestStatefulSetName, tsparams.PlatformAlterationNamespace,
 		tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
 

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -5,11 +5,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/platformalteration/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/platformalteration/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
 )
 
 var _ = Describe("platform-alteration-is-redhat-release", func() {
@@ -73,12 +73,12 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 	It("One deployment, one pod, 2 containers, one running Red Hat release, other is not [negative]", func() {
 
 		By("Define deployment")
-		deployment := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
+		dep := tshelper.DefineDeploymentWithNonUBIContainer()
 
-		globalhelper.AppendContainersToDeployment(deployment, 1, globalhelper.Configuration.General.TestImage)
+		// Append UBI-based container.
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-is-redhat-release test")
@@ -98,8 +98,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 	It("One statefulSet, one pod that is not running Red Hat release [negative]", func() {
 
 		By("Define statefulSet")
-		statefulSet := statefulset.DefineStatefulSet(tsparams.TestStatefulSetName, tsparams.PlatformAlterationNamespace,
-			tsparams.NotRedHatRelease, tsparams.TnfTargetPodLabels)
+		statefulSet := tshelper.DefineStatefulSetWithNonUBIContainer()
 
 		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The negative TCs for this TNF test case failed because both deployment and statefulset couldn't be created and the QE tc timed-out.

It happened because the selected non-UBI image for this TC doesn't have a /bin/bash binary. The shell is linked to busybox in /bin/sh instead.