### PR TITLE
Replaced infinibox operator with prometurbo

### DIFF
--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -50,8 +50,8 @@ var (
 	OperatorSourceNamespace            = "openshift-marketplace"
 	OperatorLabel                      = map[string]string{"test-network-function.com/operator": "target"}
 	UncertifiedOperatorPrefixFalcon    = "falcon-operator"
-	CertifiedOperatorPrefixInfinibox   = "infinibox-operator"
-	CertifiedOperatorFullInfinibox     = "infinibox-operator.v2.4.0"
+	CertifiedOperatorPrefixPrometurbo  = "prometurbo-operator"
+	CertifiedOperatorFullPrometurbo    = "prometurbo-operator.v8.8.2"
 	CertifiedOperatorPrefixInstana     = "instana-agent-operator"
 	CertifiedOperatorFullInstana       = "instana-agent-operator.v2.0.4"
 	UncertifiedOperatorPrefixSriov     = "sriov-fec"

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -48,31 +48,31 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 			Label:          tsparams.OperatorLabel,
 		})
 
-		By("Deploy infinibox-operator for testing")
-		// infinibox-operator: in certified-operators group and version is certified
+		By("Deploy prometurbo operator for testing")
+		// prometurbo operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
-			"infinibox-operator-certified",
+			"prometurbo-certified",
 			"stable",
 			tsparams.TestCertificationNameSpace,
 			tsparams.CertifiedOperatorGroup,
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorFullInfinibox,
+			tsparams.CertifiedOperatorFullPrometurbo,
 			v1alpha1.ApprovalManual,
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
-			tsparams.CertifiedOperatorPrefixInfinibox)
+			tsparams.CertifiedOperatorPrefixPrometurbo)
 
-		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullInfinibox,
+		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullPrometurbo,
 			tsparams.TestCertificationNameSpace)
 
-		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixInfinibox,
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixPrometurbo,
 			tsparams.TestCertificationNameSpace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixInfinibox+
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixPrometurbo+
 			" is not ready")
 
-		// add infinibox operator info to array for cleanup in AfterEach
+		// add prometurbo operator info to array for cleanup in AfterEach
 		installedLabeledOperators = append(installedLabeledOperators, tsparams.OperatorLabelInfo{
-			OperatorPrefix: tsparams.CertifiedOperatorPrefixInfinibox,
+			OperatorPrefix: tsparams.CertifiedOperatorPrefixPrometurbo,
 			Namespace:      tsparams.TestCertificationNameSpace,
 			Label:          tsparams.OperatorLabel,
 		})
@@ -151,11 +151,11 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixInfinibox,
+				tsparams.CertifiedOperatorPrefixPrometurbo,
 				tsparams.TestCertificationNameSpace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInfinibox)
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixPrometurbo)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -220,11 +220,11 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixInfinibox,
+				tsparams.CertifiedOperatorPrefixPrometurbo,
 				tsparams.TestCertificationNameSpace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInfinibox)
+			"Error labeling operator "+tsparams.CertifiedOperatorPrefixPrometurbo)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(


### PR DESCRIPTION
replaced infinibox operator with prometurbo, which should pass on all ocp versions