### PR TITLE
Decrease 1Gi-sized hugepages required by pod.

### DIFF
--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -102,7 +102,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 		err := pod.RedefineFirstContainerWith2MiHugepages(put, 4)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = pod.RedefineSecondContainerWith1GHugepages(put, 2)
+		err = pod.RedefineSecondContainerWith1GHugepages(put, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)


### PR DESCRIPTION
There's no need for this test case to require more than one hugepages of size 1Gi. This will fix the failing test case in QE for OCP 4.9.