### PR TITLE
Changing networking-service-type test name to access-control-service-type

### DIFF
--- a/tests/networking/parameters/parameters.go
+++ b/tests/networking/parameters/parameters.go
@@ -27,7 +27,7 @@ var (
 	TestDeploymentBName            = "networkingputb"
 	TnfDefaultNetworkTcName        = "networking-icmpv4-connectivity"
 	TnfMultusIpv4TcName            = "networking-icmpv4-connectivity-multus"
-	TnfNodePortTcName              = "networking-service-type"
+	TnfNodePortTcName              = "access-control-service-type"
 	TnfNetworkPolicyDenyAllTcName  = "networking-network-policy-deny-all"
 	TnfOcpReservedPortsUsageTcName = "networking-ocp-reserved-ports-usage"
 	TnfReservedPartnerPortsTcName  = "networking-reserved-partner-ports"


### PR DESCRIPTION
See (https://github.com/test-network-function/cnf-certification-test/pull/1120)