### PR TITLE
Update GolangCI-lint to v1.53.3

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -14,7 +14,7 @@ else
   else
     DEPLOY_PATH=${GOPATH}/bin
   fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.53.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.53.3
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1236

https://github.com/golangci/golangci-lint/releases/tag/v1.53.3