### PR TITLE
Cleanup 'my-role-binding' in accesscontrol suite tests

### DIFF
--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -43,7 +43,7 @@ const (
 	TestCaseNameAccessControlContainerHostPort      = "access-control-container-host-port"
 	TestCaseNameAccessControlSysAdminCapability     = "access-control-sys-admin-capability-check"
 	TestCaseNameAccessControlNonRootUser            = "access-control-security-context-non-root-user-check"
-	TestCaseNameAccessControlCluterRoleBindings     = "access-control-cluster-role-bindings"
+	TestCaseNameAccessControlClusterRoleBindings    = "access-control-cluster-role-bindings"
 	TnfNodePortTcName                               = "access-control-service-type"
 	TestCaseNameAccessControlPrivilegeEscalation    = "access-control-security-context-privilege-escalation"
 	TestCaseNameAccessControlPodHostPath            = "access-control-pod-host-path"

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -31,9 +31,10 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 	})
+
 	// 56427
 	It("one deployment, one pod, does not have cluster role binding", func() {
-		By("Define deployment  that dont have rolebinfing")
+		By("Define deployment that do not have rolebinding")
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -42,13 +43,13 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			tsparams.TestCaseNameAccessControlCluterRoleBindings,
+			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			tsparams.TestCaseNameAccessControlCluterRoleBindings,
+			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -63,15 +64,22 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			tsparams.TestCaseNameAccessControlCluterRoleBindings,
+			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			tsparams.TestCaseNameAccessControlCluterRoleBindings,
+			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-	})
 
+		By("Delete service account")
+		err = globalhelper.DeleteClusterRoleBinding(tsparams.TestAccessControlNameSpace, "my-cluster-role-binding")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Delete cluster role binding")
+		err = globalhelper.DeleteServiceAccount(tsparams.TestAccessControlNameSpace, "my-service-account")
+		Expect(err).ToNot(HaveOccurred())
+	})
 })

--- a/tests/utils/rbac/rbac.go
+++ b/tests/utils/rbac/rbac.go
@@ -43,7 +43,7 @@ func DefineRbacAuthorizationClusterServiceAccountSubjects(namespace, name string
 	// Define the RoleBinding
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-role-binding",
+			Name:      "my-cluster-role-binding",
 			Namespace: namespace,
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
* Changed "my-role-binding" to "my-cluster-role-binding"
* Added safeguard `Get` calls before running Create or Delete commands.
* Corrected some typos.