### PR TITLE
Clean namespaces after each test

### DIFF
--- a/tests/accesscontrol/tests/access_control_container_host_port.go
+++ b/tests/accesscontrol/tests/access_control_container_host_port.go
@@ -31,7 +31,12 @@ var _ = Describe("Access-control container-host-port,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63884

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control non-root user,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 56427

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63736

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -39,7 +39,18 @@ var _ = Describe("Access-control namespace, ", func() {
 
 		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespaces after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(tsparams.AdditionalValidNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51860

--- a/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
+++ b/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
@@ -37,6 +37,15 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespaces after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 56469
 	It("one deployment, one pod in a namespace with resource quota", func() {
 		By("Define deployment")

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63466

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63647

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 56427

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -18,17 +18,14 @@ import (
 var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 	execute.BeforeAll(func() {
-
 		By("Clean namespace before all tests")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestAccessControlNameSpace)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -36,7 +33,16 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 45447

--- a/tests/accesscontrol/tests/access_control_one_process_per_container.go
+++ b/tests/accesscontrol/tests/access_control_one_process_per_container.go
@@ -32,7 +32,12 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("one deployment, one pod, one container, only one process", func() {

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -33,7 +33,12 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53033

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -29,7 +29,12 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 56427

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -29,7 +29,12 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53140

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -23,14 +23,18 @@ var _ = Describe("Access-control pod-host-network ", func() {
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
 	})
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 53293

--- a/tests/accesscontrol/tests/access_control_pod_service_account.go
+++ b/tests/accesscontrol/tests/access_control_pod_service_account.go
@@ -18,6 +18,12 @@ var _ = Describe("Access-control pod-service-account,", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("one pod with valid service account", func() {
 
 		By("Create service account")

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -23,14 +23,18 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
 	})
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 55021

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -23,14 +23,18 @@ var _ = Describe("Access-control security-context,", func() {
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
 	})
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63736

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63992

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 63835

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -30,7 +30,12 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 54657

--- a/tests/affiliatedcertification/tests/affiliated_common.go
+++ b/tests/affiliatedcertification/tests/affiliated_common.go
@@ -23,7 +23,6 @@ func preConfigureAffiliatedCertificationEnvironment() {
 	err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.APIClient)
 	Expect(err).ToNot(HaveOccurred(),
 		"Error cleaning namespace "+tsparams.TestCertificationNameSpace)
-
 	By("Ensure default catalog source is enabled")
 
 	catalogEnabled, err := tshelper.IsCatalogSourceEnabled(

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -33,6 +33,12 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 55327
 	It("One pod, label is set, Affinity rules are set", func() {
 		By("Define & create pod")

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -24,6 +24,12 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 47311
 	It("One deployment, one pod with preStop field configured", func() {
 

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -25,6 +25,12 @@ var _ = Describe("lifecycle-container-startup", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 55910
 	It("One deployment, one pod with postStart spec", func() {
 		By("Define deployment with postStart spec")

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -29,6 +29,16 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Disable intrusive tests")
+		err = os.Setenv("TNF_NON_INTRUSIVE_ONLY", "true")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 47398
 	It("One deployment, one pod, one container, scale in and out", func() {
 

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -22,6 +22,12 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 48473
 	It("One deployment with ifNotPresent as ImagePullPolicy", func() {
 

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -27,6 +27,12 @@ var _ = Describe("lifecycle-liveness", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 50053
 	It("One deployment, one pod with a liveness probe", func() {
 		By("Define deployment with a liveness probe")

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -32,6 +32,12 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 48492
 	It("One deployment, replicas are more than 1, podAntiAffinity is set", func() {
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -24,6 +24,12 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 47409
 	It("One ReplicaSet, several pods", func() {
 

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -38,6 +38,12 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 47405
 	It("One deployment with PodAntiAffinity, replicas are less than schedulable nodes", func() {
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -34,6 +34,12 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 48120
 	It("One deployment, no nodeSelector nor nodeAffinity", func() {
 

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -18,7 +18,12 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 54984

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -27,6 +27,12 @@ var _ = Describe("lifecycle-readiness", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 50145
 	It("One deployment, one pod with a readiness probe", func() {
 		By("Define deployment with a readiness probe")

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -27,6 +27,12 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 54808
 	It("One deployment, one pod with a startup probe", func() {
 		By("Define deployment with a startup probe")

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -29,6 +29,16 @@ var _ = Describe("lifecycle-statefulset-scaling", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Disable intrusive tests")
+		err = os.Setenv("TNF_NON_INTRUSIVE_ONLY", "true")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 45439
 	It("One statefulSet, one pod", func() {
 		By("Define statefulSet")

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -18,6 +18,12 @@ var _ = Describe("manageability-container-port-name", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("One pod with valid port name", func() {
 
 		By("Define pod")

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -18,6 +18,12 @@ var _ = Describe("manageability-containers-image-tag", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("One pod with valid image tag", func() {
 
 		By("Define pod")

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -26,7 +26,6 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	}
 
 	execute.BeforeAll(func() {
-
 		By("Clean namespace before all tests")
 		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -35,7 +34,6 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -43,7 +41,12 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 45440

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -18,17 +18,14 @@ import (
 var _ = Describe("Networking dual-stack-service,", func() {
 
 	execute.BeforeAll(func() {
-
 		By("Clean namespace before all tests")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespaces before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -39,7 +36,19 @@ var _ = Describe("Networking dual-stack-service,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespaces after each test")
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 62506

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -25,7 +25,6 @@ var _ = Describe("Networking custom namespace,", func() {
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -33,7 +32,16 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 48328

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -32,7 +32,6 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespaces before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -43,7 +42,19 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespaces after each test")
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 59740

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -24,11 +24,9 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -36,7 +34,16 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 59536

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -28,7 +28,6 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 	})
 
 	BeforeEach(func() {
-
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
@@ -36,7 +35,16 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Remove reports from report directory")
+		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 61487

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -21,6 +21,12 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace " + tsparams.TestNamespace + " after each test")
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 51747
 	It("One deployment one pod one container that prints two log lines", func() {
 		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -22,6 +22,12 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	const tnfTestCaseName = tsparams.TnfPodDisruptionBudgetTcName
 
 	// 56635

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -22,6 +22,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace " + tsparams.TestNamespace + " after each test")
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// Positive #1.
 	It("One deployment one pod one container with terminationMessagePolicy set to FallbackToLogsOnError", func() {
 

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -19,8 +19,13 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("One pod with only exclusive containers", func() {
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
 
+	It("One pod with only exclusive containers", func() {
 		By("Define pod")
 		testPod := tshelper.DefineExclusivePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
 			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)

--- a/tests/performance/tests/rt_app_no_exec_probes.go
+++ b/tests/performance/tests/rt_app_no_exec_probes.go
@@ -19,6 +19,12 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("Rt app pod with no exec probes", func() {
 
 		By("Define pod")

--- a/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
+++ b/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
@@ -20,8 +20,13 @@ var _ = Describe("performance-exclusive-cpu-pool-rt-scheduling-policy",
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("One pod running in exclusive cpu pool and shared cpu scheduling policy", func() {
+		AfterEach(func() {
+			By("Clean namespace after each test")
+			err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
+		It("One pod running in exclusive cpu pool and shared cpu scheduling policy", func() {
 			By("Define RT pod")
 			testPod := tshelper.DefineRtPod(tsparams.TestPodName, tsparams.PerformanceNamespace,
 				tsparams.RtImageName, tsparams.TnfTargetPodLabels)

--- a/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
+++ b/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
@@ -18,6 +18,12 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", func() 
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("One pod with container running in shared cpu pool", func() {
 
 		By("Define pod")

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -22,6 +22,12 @@ var _ = Describe("platform-alteration-base-image", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 51297
 	It("One deployment, one pod, running test image", func() {
 

--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -21,12 +21,16 @@ var _ = Describe("platform-alteration-boot-params", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51302
 	It("unchanged boot params", func() {
-
 		By("Create daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -18,7 +18,12 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("One deployment, one pod with 1Gi hugepages", func() {

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -18,7 +18,12 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 55865

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -21,7 +21,12 @@ var _ = Describe("platform-alteration-hugepages-config", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51308

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -20,6 +20,12 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 51319
 	It("One deployment, one pod, several containers, all running Red Hat release", func() {
 

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -27,6 +27,12 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 51310
 	It("SELinux is enforcing on all nodes", func() {
 		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -43,6 +43,12 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	// 56594
 	It("istio is installed", func() {
 		By("Define a test pod with istio container")
@@ -110,6 +116,12 @@ var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Clean namespace after each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -23,7 +23,12 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51302

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -17,7 +17,12 @@ var _ = Describe("platform-alteration-tainted-node-kernel", func() {
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		By("Clean namespace after each test")
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51389


### PR DESCRIPTION
`AfterEach` test we should also cleanup the namespace or else we might get leftovers.