### PR TITLE
Remove init func

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -32,13 +32,29 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: .github/workflows/*.yml config/*.yaml
-          strict: true
+          config_data: |
+            extends: default
+            rules:
+              line-length:
+                level: warning
+              trailing-spaces:
+                level: warning
+              brackets:
+                level: warning
+              empty-lines:
+                level: warning
 
       - name: Run lint
         run: make lint
 
+      - name: Checkout the cnf-certification-test repo
+        uses: actions/checkout@v3
+        with:
+          repository: test-network-function/cnf-certification-test
+          path: cnf-certification-test
+
       - name: Run Unit Tests
-        run: make unit-tests
+        run: TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test make unit-tests
 
       - name: Install ginkgo
         run: make install-ginkgo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,7 +97,3 @@ issues:
   new: false
   include:
     - EXC0002 # disable excluding of issues about comments from golint
-  exclude-rules:
-    - path: tests/globalhelper/init.go
-      linters:
-        - gochecknoinits

--- a/tests/accesscontrol/access_control_suite_test.go
+++ b/tests/accesscontrol/access_control_suite_test.go
@@ -21,9 +21,9 @@ import (
 func TestAccessControl(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert access-control tests", reporterConfig)
@@ -31,7 +31,7 @@ func TestAccessControl(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("Create namespace")
-	err := namespaces.Create(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+	err := namespaces.Create(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
 
 	err = globalhelper.AllowAuthenticatedUsersRunPrivilegedContainers()
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 			parameters.InvalidNamespace,
 			parameters.TestAnotherNamespace,
 		},
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		parameters.Timeout,
 	)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/helper/helper.go
+++ b/tests/accesscontrol/helper/helper.go
@@ -48,9 +48,9 @@ func DefineDeployment(replica int32, containers int, name string) (*appsv1.Deplo
 	}
 
 	deploymentStruct := deployment.DefineDeployment(name, parameters.TestAccessControlNameSpace,
-		globalhelper.Configuration.General.TestImage, parameters.TestDeploymentLabels)
+		globalhelper.GetConfiguration().General.TestImage, parameters.TestDeploymentLabels)
 
-	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.Configuration.General.TestImage)
+	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.GetConfiguration().General.TestImage)
 	deployment.RedefineWithReplicaNumber(deploymentStruct, replica)
 
 	return deploymentStruct, nil
@@ -63,9 +63,9 @@ func DefineDeploymentWithClusterRoleBindingWithServiceAccount(replica int32, con
 	}
 
 	deploymentStruct := deployment.DefineDeployment(name, parameters.TestAccessControlNameSpace,
-		globalhelper.Configuration.General.TestImage, parameters.TestDeploymentLabels)
+		globalhelper.GetConfiguration().General.TestImage, parameters.TestDeploymentLabels)
 
-	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.Configuration.General.TestImage)
+	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.GetConfiguration().General.TestImage)
 	deployment.RedefineWithReplicaNumber(deploymentStruct, replica)
 	deployment.AppendServiceAccount(deploymentStruct, "my-service-account")
 
@@ -78,9 +78,9 @@ func DefineDeploymentWithNamespace(replica int32, containers int, name string, n
 	}
 
 	deploymentStruct := deployment.DefineDeployment(name, namespace,
-		globalhelper.Configuration.General.TestImage, parameters.TestDeploymentLabels)
+		globalhelper.GetConfiguration().General.TestImage, parameters.TestDeploymentLabels)
 
-	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.Configuration.General.TestImage)
+	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.GetConfiguration().General.TestImage)
 	deployment.RedefineWithReplicaNumber(deploymentStruct, replica)
 
 	return deploymentStruct, nil
@@ -92,13 +92,13 @@ func DefineDeploymentWithContainerPorts(name string, replicaNumber int32, ports 
 	}
 
 	deploymentStruct := deployment.DefineDeployment(name, parameters.TestAccessControlNameSpace,
-		globalhelper.Configuration.General.TestImage, parameters.TestDeploymentLabels)
+		globalhelper.GetConfiguration().General.TestImage, parameters.TestDeploymentLabels)
 
-	globalhelper.AppendContainersToDeployment(deploymentStruct, len(ports)-1, globalhelper.Configuration.General.TestImage)
+	globalhelper.AppendContainersToDeployment(deploymentStruct, len(ports)-1, globalhelper.GetConfiguration().General.TestImage)
 	deployment.RedefineWithReplicaNumber(deploymentStruct, replicaNumber)
 
 	portSpecs := container.CreateContainerSpecsFromContainerPorts(ports,
-		globalhelper.Configuration.General.TestImage, "test")
+		globalhelper.GetConfiguration().General.TestImage, "test")
 
 	deployment.RedefineWithContainerSpecs(deploymentStruct, portSpecs)
 
@@ -108,7 +108,7 @@ func DefineDeploymentWithContainerPorts(name string, replicaNumber int32, ports 
 func SetServiceAccountAutomountServiceAccountToken(namespace, saname, value string) error {
 	var boolVal bool
 
-	serviceacct, err := globalhelper.APIClient.ServiceAccounts(namespace).
+	serviceacct, err := globalhelper.GetAPIClient().ServiceAccounts(namespace).
 		Get(context.TODO(), saname, metav1.GetOptions{})
 
 	if err != nil {
@@ -131,7 +131,7 @@ func SetServiceAccountAutomountServiceAccountToken(namespace, saname, value stri
 		return fmt.Errorf("invalid value for token value")
 	}
 
-	_, err = globalhelper.APIClient.ServiceAccounts(parameters.TestAccessControlNameSpace).
+	_, err = globalhelper.GetAPIClient().ServiceAccounts(parameters.TestAccessControlNameSpace).
 		Update(context.TODO(), serviceacct, metav1.UpdateOptions{})
 
 	return err
@@ -147,13 +147,13 @@ func DefineAndCreateResourceQuota(namespace string, clientSet *client.ClientSet)
 func DefineAndCreateInstallPlan(name, namespace string, clientSet *client.ClientSet) error {
 	plan := installplan.DefineInstallPlan(name, namespace)
 
-	return globalhelper.APIClient.Create(context.TODO(), plan)
+	return globalhelper.GetAPIClient().Create(context.TODO(), plan)
 }
 
 func DefineAndCreateSubscription(name, namespace string, clientSet *client.ClientSet) error {
 	subscription := subscription.DefineSubscription(name, namespace)
 
-	return globalhelper.APIClient.Create(context.TODO(), subscription)
+	return globalhelper.GetAPIClient().Create(context.TODO(), subscription)
 }
 
 // DefineAndCreateServiceOnCluster defines service resource and creates it on cluster.
@@ -194,7 +194,7 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 		}
 	}
 
-	_, err := globalhelper.APIClient.Services(parameters.TestAccessControlNameSpace).Create(
+	_, err := globalhelper.GetAPIClient().Services(parameters.TestAccessControlNameSpace).Create(
 		context.Background(),
 		testService, metav1.CreateOptions{})
 	if err != nil {

--- a/tests/accesscontrol/tests/access_control_container_host_port.go
+++ b/tests/accesscontrol/tests/access_control_container_host_port.go
@@ -29,13 +29,13 @@ var _ = Describe("Access-control container-host-port,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control non-root user,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -16,40 +16,40 @@ var _ = Describe("Access-control namespace, ", func() {
 
 	execute.BeforeAll(func() {
 		By("Clean test suite namespace before tests")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create additional namespaces for testing")
 		// these namespaces will only be used for the access-control-namespace tests
-		err = namespaces.Create(tsparams.AdditionalValidNamespace, globalhelper.APIClient)
+		err = namespaces.Create(tsparams.AdditionalValidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Create(tsparams.InvalidNamespace, globalhelper.APIClient)
+		err = namespaces.Create(tsparams.InvalidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 	})
 
 	BeforeEach(func() {
 		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalValidNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalValidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalValidNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalValidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.InvalidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -163,7 +163,7 @@ var _ = Describe("Access-control namespace, ", func() {
 
 		By("Create custom resource")
 		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -191,7 +191,7 @@ var _ = Describe("Access-control namespace, ", func() {
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
 		By("Create custom resource")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.InvalidNamespace, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.InvalidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -220,11 +220,11 @@ var _ = Describe("Access-control namespace, ", func() {
 
 		By("Create custom resources")
 		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		err = tshelper.DefineAndCreateInstallPlan("test-plan-2", tsparams.AdditionalValidNamespace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -252,10 +252,10 @@ var _ = Describe("Access-control namespace, ", func() {
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
 		By("Create custom resources")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
-		err = tshelper.DefineAndCreateInstallPlan("test-plan-2", tsparams.InvalidNamespace, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateInstallPlan("test-plan-2", tsparams.InvalidNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -284,11 +284,11 @@ var _ = Describe("Access-control namespace, ", func() {
 
 		By("Create custom resources")
 		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		err = tshelper.DefineAndCreateSubscription("test-sub", tsparams.TestAccessControlNameSpace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating subscription")
 
 		By("Start test")
@@ -317,11 +317,11 @@ var _ = Describe("Access-control namespace, ", func() {
 
 		By("Create custom resources")
 		err = tshelper.DefineAndCreateInstallPlan("test-plan", tsparams.TestAccessControlNameSpace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		err = tshelper.DefineAndCreateSubscription("test-sub", tsparams.AdditionalValidNamespace,
-			globalhelper.APIClient)
+			globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred(), "Error creating subscription")
 
 		By("Start test")

--- a/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
+++ b/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
@@ -24,25 +24,25 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
 		By("Create additional namespace for testing")
-		err = namespaces.Create(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		err = namespaces.Create(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -56,7 +56,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Apply resource quota to namespace")
-		err = tshelper.DefineAndCreateResourceQuota(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateResourceQuota(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
@@ -104,7 +104,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Apply resource quota to namespace")
-		err = tshelper.DefineAndCreateResourceQuota(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateResourceQuota(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2, err := tshelper.DefineDeploymentWithNamespace(1, 1, "accesscontroldeployment2",
@@ -115,7 +115,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Apply resource quota to namespace")
-		err = tshelper.DefineAndCreateResourceQuota(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateResourceQuota(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
@@ -148,7 +148,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Apply resource quota to namespace")
-		err = tshelper.DefineAndCreateResourceQuota(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.APIClient)
+		err = tshelper.DefineAndCreateResourceQuota(tsparams.AdditionalNamespaceForResourceQuotas, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -19,7 +19,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 	execute.BeforeAll(func() {
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestAccessControlNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -27,7 +27,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -37,7 +37,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/accesscontrol/tests/access_control_one_process_per_container.go
+++ b/tests/accesscontrol/tests/access_control_one_process_per_container.go
@@ -30,13 +30,13 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -89,7 +89,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,7 +112,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
 		Expect(err).ToNot(HaveOccurred())
 
-		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err = deployment.RedefineContainerCommand(dep, 1, commandToLaunchTwoProcesses)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -31,13 +31,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -27,7 +27,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 	})

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -28,7 +28,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 	})

--- a/tests/accesscontrol/tests/access_control_pod_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_role_bindings.go
@@ -31,16 +31,16 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 
 		By("Create additional namespace for testing")
 		// these namespaces will only be used for the access-control-namespace tests
-		err := namespaces.Create(tsparams.TestAnotherNamespace, globalhelper.APIClient)
+		err := namespaces.Create(tsparams.TestAnotherNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.TestAnotherNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.TestAnotherNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		setupInitialRbacConfiguration()
@@ -50,7 +50,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		By("Define pod")
 
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
 
@@ -74,7 +74,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		By("Define pod")
 
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		By("Define pod")
 
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
@@ -125,7 +125,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 	It("one pod with role binding in different namespace", func() {
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_pod_service_account.go
+++ b/tests/accesscontrol/tests/access_control_pod_service_account.go
@@ -14,13 +14,13 @@ var _ = Describe("Access-control pod-service-account,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -32,7 +32,7 @@ var _ = Describe("Access-control pod-service-account,", func() {
 
 		By("Define pod with service account")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
 
@@ -57,7 +57,7 @@ var _ = Describe("Access-control pod-service-account,", func() {
 		By("Define pod with empty service account")
 
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, "")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
@@ -81,7 +81,7 @@ var _ = Describe("Access-control pod-service-account,", func() {
 		By("Define pod with empty service account")
 
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestDeploymentLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, "default")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_projected_volume_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_projected_volume_service_account_token.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control projected-volume-service-account-token,", func(
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -27,13 +27,13 @@ var _ = Describe("Access-control security-context,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -28,13 +28,13 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -25,9 +25,9 @@ import (
 func TestAffiliatedCertification(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert affiliated-certification tests", reporterConfig)
@@ -37,7 +37,7 @@ var isCloudCasaAlreadyLabeled bool
 
 var _ = BeforeSuite(func() {
 	By("Create namespace")
-	err := namespaces.Create(tsparams.TestCertificationNameSpace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.TestCertificationNameSpace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
 
 	isCloudCasaAlreadyLabeled, err = tshelper.DoesOperatorHaveLabels(tsparams.UnrelatedOperatorPrefixCloudcasa,
@@ -62,7 +62,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.TestCertificationNameSpace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.TestCertificationNameSpace,
 		tsparams.Timeout,
 	)

--- a/tests/affiliatedcertification/helper/helper.go
+++ b/tests/affiliatedcertification/helper/helper.go
@@ -122,7 +122,7 @@ func DoesOperatorHaveLabels(prefixCsvName string, namespace string, labels map[s
 
 // GetCsvByPrefix returns csv object based on given prefix.
 func GetCsvByPrefix(prefixCsvName string, namespace string) (*v1alpha1.ClusterServiceVersion, error) {
-	csvs, err := globalhelper.APIClient.ClusterServiceVersions(namespace).List(
+	csvs, err := globalhelper.GetAPIClient().ClusterServiceVersions(namespace).List(
 		context.TODO(), metav1.ListOptions{},
 	)
 	if err != nil {
@@ -166,7 +166,7 @@ func DeployOperatorSubscription(operatorPackage, channel, namespace, group,
 }
 
 func updateCsv(namespace string, csv *v1alpha1.ClusterServiceVersion) error {
-	_, err := globalhelper.APIClient.ClusterServiceVersions(namespace).Update(
+	_, err := globalhelper.GetAPIClient().ClusterServiceVersions(namespace).Update(
 		context.TODO(), csv, metav1.UpdateOptions{},
 	)
 

--- a/tests/affiliatedcertification/helper/operator.go
+++ b/tests/affiliatedcertification/helper/operator.go
@@ -22,12 +22,12 @@ import (
 )
 
 func DeployOperatorGroup(namespace string, operatorGroup *olmv1.OperatorGroup) error {
-	err := namespaces.Create(namespace, globalhelper.APIClient)
+	err := namespaces.Create(namespace, globalhelper.GetAPIClient())
 	if err != nil {
 		return err
 	}
 
-	err = globalhelper.APIClient.Create(context.TODO(),
+	err = globalhelper.GetAPIClient().Create(context.TODO(),
 		&olmv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      operatorGroup.Name,
@@ -46,7 +46,7 @@ func DeployOperatorGroup(namespace string, operatorGroup *olmv1.OperatorGroup) e
 
 func IsOperatorGroupInstalled(operatorGroupName, namespace string) error {
 	var operatorGroup olmv1.OperatorGroup
-	err := globalhelper.APIClient.Get(context.TODO(),
+	err := globalhelper.GetAPIClient().Get(context.TODO(),
 		goclient.ObjectKey{Name: operatorGroupName, Namespace: namespace},
 		&operatorGroup)
 
@@ -58,7 +58,7 @@ func IsOperatorGroupInstalled(operatorGroupName, namespace string) error {
 }
 
 func DeployOperator(subscription *v1alpha1.Subscription) error {
-	err := globalhelper.APIClient.Create(context.TODO(),
+	err := globalhelper.GetAPIClient().Create(context.TODO(),
 		&v1alpha1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subscription.Name,
@@ -83,7 +83,7 @@ func DeployOperator(subscription *v1alpha1.Subscription) error {
 }
 
 func GetInstallPlanByCSV(namespace string, csvName string) (*v1alpha1.InstallPlan, error) {
-	installPlans, err := globalhelper.APIClient.InstallPlans(namespace).List(context.TODO(), metav1.ListOptions{})
+	installPlans, err := globalhelper.GetAPIClient().InstallPlans(namespace).List(context.TODO(), metav1.ListOptions{})
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to get InstallPlans: %w", err)
@@ -115,7 +115,7 @@ func ApproveInstallPlan(namespace string, plan *v1alpha1.InstallPlan) error {
 }
 
 func DeployRHCertifiedOperatorSource(ocpVersion string) error {
-	err := globalhelper.APIClient.Create(context.TODO(),
+	err := globalhelper.GetAPIClient().Create(context.TODO(),
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tsparams.CertifiedOperatorGroup,
@@ -151,7 +151,7 @@ func EnableCatalogSource(name string) error {
 }
 
 func IsCatalogSourceEnabled(name, namespace, displayName string) (bool, error) {
-	source, err := globalhelper.APIClient.CatalogSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	source, err := globalhelper.GetAPIClient().CatalogSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}
@@ -160,7 +160,7 @@ func IsCatalogSourceEnabled(name, namespace, displayName string) (bool, error) {
 }
 
 func DeleteCatalogSource(name, namespace, displayName string) error {
-	source, err := globalhelper.APIClient.CatalogSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	source, err := globalhelper.GetAPIClient().CatalogSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -170,14 +170,14 @@ func DeleteCatalogSource(name, namespace, displayName string) error {
 	}
 
 	if source.Spec.DisplayName == displayName {
-		return globalhelper.APIClient.Delete(context.TODO(), source)
+		return globalhelper.GetAPIClient().Delete(context.TODO(), source)
 	}
 
 	return nil
 }
 
 func setCatalogSource(disable bool, name string) error {
-	_, err := globalhelper.APIClient.OcpClientInterface.OperatorHubs().Patch(context.TODO(),
+	_, err := globalhelper.GetAPIClient().OcpClientInterface.OperatorHubs().Patch(context.TODO(),
 		"cluster",
 		types.MergePatchType,
 		[]byte("{\"spec\":{\"sources\":[{\"disabled\": "+strconv.FormatBool(disable)+",\"name\": \""+name+"\"}]}}"),
@@ -192,7 +192,7 @@ func setCatalogSource(disable bool, name string) error {
 }
 
 func updateInstallPlan(namespace string, plan *v1alpha1.InstallPlan) error {
-	_, err := globalhelper.APIClient.InstallPlans(namespace).Update(
+	_, err := globalhelper.GetAPIClient().InstallPlans(namespace).Update(
 		context.TODO(), plan, metav1.UpdateOptions{},
 	)
 

--- a/tests/affiliatedcertification/tests/affiliated_common.go
+++ b/tests/affiliatedcertification/tests/affiliated_common.go
@@ -20,7 +20,7 @@ import (
 func preConfigureAffiliatedCertificationEnvironment() {
 	By("Clean test namespace")
 
-	err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.APIClient)
+	err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred(),
 		"Error cleaning namespace "+tsparams.TestCertificationNameSpace)
 	By("Ensure default catalog source is enabled")

--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -14,7 +14,7 @@ import (
 
 // CreateAndWaitUntilDaemonSetIsReady creates daemonSet and waits until all pods are up and running.
 func CreateAndWaitUntilDaemonSetIsReady(daemonSet *appsv1.DaemonSet, timeout time.Duration) error {
-	runningDaemonSet, err := APIClient.DaemonSets(daemonSet.Namespace).Create(
+	runningDaemonSet, err := GetAPIClient().DaemonSets(daemonSet.Namespace).Create(
 		context.Background(), daemonSet, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create daemonset %q (ns %s): %w", daemonSet.Name, daemonSet.Namespace, err)
@@ -36,7 +36,7 @@ func CreateAndWaitUntilDaemonSetIsReady(daemonSet *appsv1.DaemonSet, timeout tim
 }
 
 func isDaemonSetReady(namespace string, name string) (bool, error) {
-	daemonSet, err := APIClient.DaemonSets(namespace).Get(
+	daemonSet, err := GetAPIClient().DaemonSets(namespace).Get(
 		context.Background(),
 		name,
 		metav1.GetOptions{},

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -14,7 +14,7 @@ import (
 
 // IsDeploymentReady checks if a deployment is ready.
 func IsDeploymentReady(operatorNamespace string, deploymentName string) (bool, error) {
-	testDeployment, err := APIClient.Deployments(operatorNamespace).Get(
+	testDeployment, err := GetAPIClient().Deployments(operatorNamespace).Get(
 		context.Background(),
 		deploymentName,
 		metav1.GetOptions{},
@@ -34,7 +34,7 @@ func IsDeploymentReady(operatorNamespace string, deploymentName string) (bool, e
 
 // CreateAndWaitUntilDeploymentIsReady creates deployment and wait until all deployment replicas are up and running.
 func CreateAndWaitUntilDeploymentIsReady(deployment *appsv1.Deployment, timeout time.Duration) error {
-	runningDeployment, err := APIClient.Deployments(deployment.Namespace).Create(
+	runningDeployment, err := GetAPIClient().Deployments(deployment.Namespace).Create(
 		context.Background(),
 		deployment,
 		metav1.CreateOptions{})
@@ -59,7 +59,7 @@ func CreateAndWaitUntilDeploymentIsReady(deployment *appsv1.Deployment, timeout 
 }
 
 func getDeploymentStatus(name, namespaces string) string {
-	dep, err := APIClient.Deployments(namespaces).Get(context.Background(), name, metav1.GetOptions{})
+	dep, err := GetAPIClient().Deployments(namespaces).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return time.Now().String() + " " + err.Error()
 	}

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -77,7 +77,7 @@ func ValidateIfReportsAreValid(tcName string, tcExpectedStatus string) error {
 // DefineTnfConfig creates tnf_config.yml file under tnf config directory.
 func DefineTnfConfig(namespaces []string, targetPodLabels []string,
 	certifiedContainerInfo []string, crdFilters []string) error {
-	tnfConfigFilePath := path.Join(Configuration.General.TnfConfigDir, globalparameters.DefaultTnfConfigFileName)
+	tnfConfigFilePath := path.Join(GetConfiguration().General.TnfConfigDir, globalparameters.DefaultTnfConfigFileName)
 
 	configFile, err := os.OpenFile(tnfConfigFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
@@ -112,7 +112,7 @@ func DefineTnfConfig(namespaces []string, targetPodLabels []string,
 	}
 
 	glog.V(5).Info(fmt.Sprintf("%s deployed under %s directory",
-		globalparameters.DefaultTnfConfigFileName, Configuration.General.TnfConfigDir))
+		globalparameters.DefaultTnfConfigFileName, GetConfiguration().General.TnfConfigDir))
 
 	return nil
 }
@@ -249,7 +249,7 @@ func validateIfParamInAllowedListOfParams(parameter string, listOfParameters []s
 
 // AllowAuthenticatedUsersRunPrivilegedContainers adds all authenticated users to privileged group.
 func AllowAuthenticatedUsersRunPrivilegedContainers() error {
-	_, err := APIClient.ClusterRoleBindings().Get(
+	_, err := GetAPIClient().ClusterRoleBindings().Get(
 		context.Background(),
 		"system:openshift:scc:privileged",
 		metav1.GetOptions{},
@@ -262,7 +262,7 @@ func AllowAuthenticatedUsersRunPrivilegedContainers() error {
 			*rbac.DefineRbacAuthorizationClusterGroupSubjects([]string{"system:authenticated"}),
 		)
 
-		_, err = APIClient.ClusterRoleBindings().Create(context.Background(), roleBind, metav1.CreateOptions{})
+		_, err = GetAPIClient().ClusterRoleBindings().Create(context.Background(), roleBind, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create cluster role binding: %w", err)
 		}
@@ -289,19 +289,19 @@ func CreateClusterRoleBinding(nameSpace, name string) error {
 	}
 
 	// Exit early if the cluster role binding already exists
-	_, err := APIClient.ClusterRoleBindings().Get(context.Background(), name, metav1.GetOptions{})
+	_, err := GetAPIClient().ClusterRoleBindings().Get(context.Background(), name, metav1.GetOptions{})
 	if err == nil {
 		return nil
 	}
 
 	// Create the service account
-	_, err = APIClient.ServiceAccounts(nameSpace).Create(context.Background(), serviceAccount, metav1.CreateOptions{})
+	_, err = GetAPIClient().ServiceAccounts(nameSpace).Create(context.Background(), serviceAccount, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create cServiceAccount: %w", err)
 	}
 
 	roleBind := rbac.DefineRbacAuthorizationClusterServiceAccountSubjects(nameSpace, name)
-	if _, err := APIClient.ClusterRoleBindings().Create(context.Background(), roleBind, metav1.CreateOptions{}); err != nil {
+	if _, err := GetAPIClient().ClusterRoleBindings().Create(context.Background(), roleBind, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create cluster role binding: %w", err)
 	}
 
@@ -310,12 +310,12 @@ func CreateClusterRoleBinding(nameSpace, name string) error {
 
 func DeleteClusterRoleBinding(nameSpace, name string) error {
 	// Exit if the cluster role binding does not exist
-	_, err := APIClient.ClusterRoleBindings().Get(context.Background(), name, metav1.GetOptions{})
+	_, err := GetAPIClient().ClusterRoleBindings().Get(context.Background(), name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 
-	if err := APIClient.ClusterRoleBindings().Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+	if err := GetAPIClient().ClusterRoleBindings().Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("failed to delete cluster role binding: %w", err)
 	}
 

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -18,14 +18,14 @@ func GetAPIClient() *testclient.ClientSet {
 		return apiclient
 	}
 
-	tempClient, err := config.DefineClients()
+	var err error
+	apiclient, err = config.DefineClients()
+
 	if err != nil {
 		glog.Fatal(fmt.Sprintf("can not load api client. Please check KUBECONFIG env var - %s", err))
 	}
 
-	apiclient = tempClient
-
-	return tempClient
+	return apiclient
 }
 
 func GetConfiguration() *config.Config {
@@ -33,12 +33,12 @@ func GetConfiguration() *config.Config {
 		return conf
 	}
 
-	Configuration, err := config.NewConfig()
+	var err error
+	conf, err = config.NewConfig()
+
 	if err != nil {
 		glog.Fatal(fmt.Sprintf("can not load configuration - %s", err))
 	}
 
-	conf = Configuration
-
-	return Configuration
+	return conf
 }

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -2,7 +2,6 @@ package globalhelper
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/golang/glog"
 	testclient "github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
@@ -10,27 +9,36 @@ import (
 )
 
 var (
-	APIClient     *testclient.ClientSet
-	Configuration *config.Config
+	apiclient *testclient.ClientSet
+	conf      *config.Config
 )
 
-func init() {
-	if os.Getenv("UNIT_TEST") != "" {
-		Configuration = &config.Config{}
-
-		return
+func GetAPIClient() *testclient.ClientSet {
+	if apiclient != nil {
+		return apiclient
 	}
 
-	var err error
-	APIClient, err = config.DefineClients()
-
+	tempClient, err := config.DefineClients()
 	if err != nil {
 		glog.Fatal(fmt.Sprintf("can not load api client. Please check KUBECONFIG env var - %s", err))
 	}
 
-	Configuration, err = config.NewConfig()
+	apiclient = tempClient
 
+	return tempClient
+}
+
+func GetConfiguration() *config.Config {
+	if conf != nil {
+		return conf
+	}
+
+	Configuration, err := config.NewConfig()
 	if err != nil {
 		glog.Fatal(fmt.Sprintf("can not load configuration - %s", err))
 	}
+
+	conf = Configuration
+
+	return Configuration
 }

--- a/tests/globalhelper/networkpolicy.go
+++ b/tests/globalhelper/networkpolicy.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CreateAndWaitUntilNetworkPolicyIsReady(networkPolicy *networkingv1.NetworkPolicy, timeout time.Duration) error {
-	policy, err := APIClient.NetworkPolicies(networkPolicy.Namespace).Create(
+	policy, err := GetAPIClient().NetworkPolicies(networkPolicy.Namespace).Create(
 		context.Background(), networkPolicy, metav1.CreateOptions{})
 
 	if err != nil {
@@ -36,7 +36,7 @@ func CreateAndWaitUntilNetworkPolicyIsReady(networkPolicy *networkingv1.NetworkP
 }
 
 func doesNetworkPolicyExist(namespace, name string) (bool, error) {
-	if _, err := APIClient.NetworkPolicies(namespace).Get(
+	if _, err := GetAPIClient().NetworkPolicies(namespace).Get(
 		context.Background(),
 		name,
 		metav1.GetOptions{},

--- a/tests/globalhelper/nodes.go
+++ b/tests/globalhelper/nodes.go
@@ -9,14 +9,14 @@ import (
 
 // EnableMasterScheduling enables/disables master nodes scheduling.
 func EnableMasterScheduling(scheduleable bool) error {
-	scheduler, err := APIClient.OcpClientInterface.Schedulers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	scheduler, err := GetAPIClient().OcpClientInterface.Schedulers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get schedulers: %w", err)
 	}
 
 	scheduler.Spec.MastersSchedulable = scheduleable
 
-	_, err = APIClient.OcpClientInterface.Schedulers().Update(context.TODO(), scheduler, metav1.UpdateOptions{})
+	_, err = GetAPIClient().OcpClientInterface.Schedulers().Update(context.TODO(), scheduler, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update schedulers: %w", err)
 	}

--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -20,7 +20,7 @@ import (
 func ExecCommand(pod corev1.Pod, command []string) (bytes.Buffer, error) {
 	var buf bytes.Buffer
 
-	req := APIClient.CoreV1Interface.RESTClient().
+	req := GetAPIClient().CoreV1Interface.RESTClient().
 		Post().
 		Namespace(pod.Namespace).
 		Resource("pods").
@@ -35,7 +35,7 @@ func ExecCommand(pod corev1.Pod, command []string) (bytes.Buffer, error) {
 			TTY:       true,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(APIClient.Config, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(GetAPIClient().Config, "POST", req.URL())
 	if err != nil {
 		return buf, err
 	}
@@ -55,7 +55,7 @@ func ExecCommand(pod corev1.Pod, command []string) (bytes.Buffer, error) {
 
 // GetListOfPodsInNamespace returns list of pods for given namespace.
 func GetListOfPodsInNamespace(namespace string) (*corev1.PodList, error) {
-	runningPods, err := APIClient.Pods(namespace).List(context.Background(), metav1.ListOptions{})
+	runningPods, err := GetAPIClient().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func GetListOfPodsInNamespace(namespace string) (*corev1.PodList, error) {
 
 // CreateAndWaitUntilPodIsReady creates a pod and waits until all it's containers are ready.
 func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error {
-	createdPod, err := APIClient.Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	createdPod, err := GetAPIClient().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create pod %q (ns %s): %w", pod.Name, pod.Namespace, err)
 	}
@@ -88,7 +88,7 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 
 // isPodReady checks if a pod is ready.
 func isPodReady(namespace string, podName string) (bool, error) {
-	podObject, err := APIClient.Pods(namespace).Get(
+	podObject, err := GetAPIClient().Pods(namespace).Get(
 		context.Background(),
 		podName,
 		metav1.GetOptions{},

--- a/tests/globalhelper/poddisruptionbudget.go
+++ b/tests/globalhelper/poddisruptionbudget.go
@@ -14,7 +14,7 @@ import (
 
 // IsPodDisruptionBudgetCreated checks if a pod disruption budget is created.
 func IsPodDisruptionBudgetCreated(pdbName string, namespace string) (bool, error) {
-	pdb, err := APIClient.PolicyV1Interface.PodDisruptionBudgets(namespace).Get(context.Background(), pdbName, metav1.GetOptions{})
+	pdb, err := GetAPIClient().PolicyV1Interface.PodDisruptionBudgets(namespace).Get(context.Background(), pdbName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -24,7 +24,7 @@ func IsPodDisruptionBudgetCreated(pdbName string, namespace string) (bool, error
 
 // CreatPodDisruptionBudget creates Pod Disruption Budget and wait until pdb is created.
 func CreatePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, timeout time.Duration) error {
-	poddisruptionbudget, err := APIClient.PolicyV1Interface.PodDisruptionBudgets(pdb.Namespace).Create(
+	poddisruptionbudget, err := GetAPIClient().PolicyV1Interface.PodDisruptionBudgets(pdb.Namespace).Create(
 		context.Background(),
 		pdb,
 		metav1.CreateOptions{})

--- a/tests/globalhelper/rbac.go
+++ b/tests/globalhelper/rbac.go
@@ -18,7 +18,7 @@ func CreateServiceAccount(serviceAccountName, namespace string) error {
 			Namespace: namespace}}
 
 	_, err :=
-		APIClient.CoreV1Interface.ServiceAccounts(namespace).Create(context.Background(), &serviceAccount, metav1.CreateOptions{})
+		GetAPIClient().CoreV1Interface.ServiceAccounts(namespace).Create(context.Background(), &serviceAccount, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
 		glog.V(5).Info(fmt.Sprintf("serviceaccount %s already installed", serviceAccountName))
@@ -30,7 +30,7 @@ func CreateServiceAccount(serviceAccountName, namespace string) error {
 }
 
 func DeleteServiceAccount(serviceAccountName, namespace string) error {
-	serviceAccount, err := APIClient.ServiceAccounts(namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
+	serviceAccount, err := GetAPIClient().ServiceAccounts(namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
 
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -40,7 +40,7 @@ func DeleteServiceAccount(serviceAccountName, namespace string) error {
 		return err
 	}
 
-	err = APIClient.ServiceAccounts(namespace).Delete(context.Background(), serviceAccountName,
+	err = GetAPIClient().ServiceAccounts(namespace).Delete(context.Background(), serviceAccountName,
 		metav1.DeleteOptions{})
 
 	if err != nil {
@@ -69,7 +69,7 @@ func CreateRole(roleName, namespace string) error {
 	}
 
 	_, err :=
-		APIClient.RbacV1Interface.Roles(namespace).Create(context.Background(), &aRole, metav1.CreateOptions{})
+		GetAPIClient().RbacV1Interface.Roles(namespace).Create(context.Background(), &aRole, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
 		glog.V(5).Info(fmt.Sprintf("role %s already installed", roleName))
@@ -82,7 +82,7 @@ func CreateRole(roleName, namespace string) error {
 
 func DeleteRoleBinding(bindingName, namespace string) error {
 	err :=
-		APIClient.RbacV1Interface.RoleBindings(namespace).Delete(context.Background(), bindingName, metav1.DeleteOptions{})
+		GetAPIClient().RbacV1Interface.RoleBindings(namespace).Delete(context.Background(), bindingName, metav1.DeleteOptions{})
 
 	if k8serrors.IsNotFound(err) {
 		glog.V(5).Info(fmt.Sprintf("rolebinding %s does not exist", bindingName))
@@ -117,7 +117,7 @@ func CreateRoleBindingWithServiceAccountSubject(bindingName, roleName, serviceAc
 	}
 
 	_, err :=
-		APIClient.RbacV1Interface.RoleBindings(namespace).Create(context.Background(), &aRoleBinding, metav1.CreateOptions{})
+		GetAPIClient().RbacV1Interface.RoleBindings(namespace).Create(context.Background(), &aRoleBinding, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
 		glog.V(5).Info(fmt.Sprintf("rolebinding %s already exists", bindingName))

--- a/tests/globalhelper/replicaset.go
+++ b/tests/globalhelper/replicaset.go
@@ -13,7 +13,7 @@ import (
 
 // CreateAndWaitUntilReplicaSetIsReady creates replicaSet and waits until all it's replicas are ready.
 func CreateAndWaitUntilReplicaSetIsReady(replicaSet *appsv1.ReplicaSet, timeout time.Duration) error {
-	runningReplica, err := APIClient.ReplicaSets(replicaSet.Namespace).Create(context.Background(),
+	runningReplica, err := GetAPIClient().ReplicaSets(replicaSet.Namespace).Create(context.Background(),
 		replicaSet, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create replicaSet %q (ns %s): %w", replicaSet.Name, replicaSet.Namespace, err)
@@ -36,7 +36,7 @@ func CreateAndWaitUntilReplicaSetIsReady(replicaSet *appsv1.ReplicaSet, timeout 
 
 // isReplicaSetReady checks if a replicaset is ready.
 func isReplicaSetReady(namespace, replicaSetName string) (bool, error) {
-	testReplicaSet, err := APIClient.ReplicaSets(namespace).Get(
+	testReplicaSet, err := GetAPIClient().ReplicaSets(namespace).Get(
 		context.Background(),
 		replicaSetName,
 		metav1.GetOptions{},

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -18,7 +18,7 @@ import (
 
 // OpenClaimReport opens claim.json file and returns struct.
 func OpenClaimReport() (*claim.Root, error) {
-	dataClaim, err := os.Open(path.Join(Configuration.General.TnfReportDir, globalparameters.DefaultClaimFileName))
+	dataClaim, err := os.Open(path.Join(GetConfiguration().General.TnfReportDir, globalparameters.DefaultClaimFileName))
 	if err != nil {
 		return nil, fmt.Errorf("error opening %s report file: %w", globalparameters.DefaultClaimFileName, err)
 	}
@@ -57,7 +57,7 @@ func IsTestCaseSkippedInClaimReport(testCaseName string, claimReport claim.Root)
 // OpenJunitTestReport returns junit struct.
 func OpenJunitTestReport() (*globalparameters.JUnitTestSuites, error) {
 	junitReportFile, err := os.Open(
-		path.Join(Configuration.General.TnfReportDir, globalparameters.DefaultJunitReportName),
+		path.Join(GetConfiguration().General.TnfReportDir, globalparameters.DefaultJunitReportName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error opening %s report file: %w", globalparameters.DefaultJunitReportName, err)
@@ -96,7 +96,7 @@ func IsTestCaseSkippedInJunitReport(report *globalparameters.JUnitTestSuites, te
 
 // RemoveContentsFromReportDir removes all files from report dir.
 func RemoveContentsFromReportDir() error {
-	tnfReportDir, err := os.Open(Configuration.General.TnfReportDir)
+	tnfReportDir, err := os.Open(GetConfiguration().General.TnfReportDir)
 	if err != nil {
 		return fmt.Errorf("failed to open report directory: %w", err)
 	}
@@ -109,14 +109,14 @@ func RemoveContentsFromReportDir() error {
 	}
 
 	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(Configuration.General.TnfReportDir, name))
+		err = os.RemoveAll(filepath.Join(GetConfiguration().General.TnfReportDir, name))
 		if err != nil {
 			return fmt.Errorf("failed to remove content from report directory: %w", err)
 		}
 
 		glog.V(5).Info(fmt.Sprintf("file %s removed from %s directory",
 			name,
-			Configuration.General.TnfReportDir))
+			GetConfiguration().General.TnfReportDir))
 	}
 
 	return nil
@@ -234,8 +234,8 @@ func containsString(list []string, item string) bool {
 }
 
 func CopyClaimFileToTcFolder(tcName, formattedTcName string) {
-	srcClaim := path.Join(Configuration.General.TnfReportDir, globalparameters.DefaultClaimFileName)
-	dstClaim := path.Join(Configuration.General.ReportDirAbsPath, "Debug", getTestSuiteName(tcName), formattedTcName,
+	srcClaim := path.Join(GetConfiguration().General.TnfReportDir, globalparameters.DefaultClaimFileName)
+	dstClaim := path.Join(GetConfiguration().General.ReportDirAbsPath, "Debug", getTestSuiteName(tcName), formattedTcName,
 		globalparameters.DefaultClaimFileName)
 
 	_, err := os.Stat(srcClaim)

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -27,24 +27,24 @@ func LaunchTests(testCaseName string, tcNameForReport string) error {
 	glog.V(5).Info(fmt.Sprintf("container engine set to %s", containerEngine))
 	testArgs := []string{
 		"-k", os.Getenv("KUBECONFIG"),
-		"-c", Configuration.General.DockerConfigDir + "/config",
-		"-t", Configuration.General.TnfConfigDir,
-		"-o", Configuration.General.TnfReportDir,
-		"-i", fmt.Sprintf("%s:%s", Configuration.General.TnfImage, Configuration.General.TnfImageTag),
+		"-c", GetConfiguration().General.DockerConfigDir + "/config",
+		"-t", GetConfiguration().General.TnfConfigDir,
+		"-o", GetConfiguration().General.TnfReportDir,
+		"-i", fmt.Sprintf("%s:%s", GetConfiguration().General.TnfImage, GetConfiguration().General.TnfImageTag),
 		"-l", testCaseName,
 	}
 
-	cmd := exec.Command(fmt.Sprintf("./%s", Configuration.General.TnfEntryPointScript))
+	cmd := exec.Command(fmt.Sprintf("./%s", GetConfiguration().General.TnfEntryPointScript))
 	cmd.Args = append(cmd.Args, testArgs...)
-	cmd.Dir = Configuration.General.TnfRepoPath
+	cmd.Dir = GetConfiguration().General.TnfRepoPath
 
-	debugTnf, err := Configuration.DebugTnf()
+	debugTnf, err := GetConfiguration().DebugTnf()
 	if err != nil {
 		return fmt.Errorf("failed to set env var TNF_LOG_LEVEL: %w", err)
 	}
 
 	if debugTnf {
-		outfile := Configuration.CreateLogFile(getTestSuiteName(testCaseName), tcNameForReport)
+		outfile := GetConfiguration().CreateLogFile(getTestSuiteName(testCaseName), tcNameForReport)
 
 		defer outfile.Close()
 

--- a/tests/globalhelper/runtimeclass.go
+++ b/tests/globalhelper/runtimeclass.go
@@ -12,7 +12,7 @@ import (
 )
 
 func CreateRunTimeClass(rtc *nodev1.RuntimeClass) error {
-	rtc, err := APIClient.RuntimeClasses().Create(context.Background(), rtc, metav1.CreateOptions{})
+	rtc, err := GetAPIClient().RuntimeClasses().Create(context.Background(), rtc, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create runtimeclass %q (ns %s): %w", rtc.Name, rtc.Namespace, err)
 	}
@@ -32,7 +32,7 @@ func CreateRunTimeClass(rtc *nodev1.RuntimeClass) error {
 }
 
 func isRtcCreated(rtc *nodev1.RuntimeClass) (bool, error) {
-	rtc, err := APIClient.RuntimeClasses().Get(context.Background(), rtc.Name, metav1.GetOptions{})
+	rtc, err := GetAPIClient().RuntimeClasses().Get(context.Background(), rtc.Name, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/tests/globalhelper/statefulset.go
+++ b/tests/globalhelper/statefulset.go
@@ -14,7 +14,7 @@ import (
 
 // CreateAndWaitUntilStatefulSetIsReady creates statefulset and waits until all it's replicas are ready.
 func CreateAndWaitUntilStatefulSetIsReady(statefulSet *appsv1.StatefulSet, timeout time.Duration) error {
-	runningStatefulSet, err := APIClient.StatefulSets(statefulSet.Namespace).Create(context.Background(),
+	runningStatefulSet, err := GetAPIClient().StatefulSets(statefulSet.Namespace).Create(context.Background(),
 		statefulSet, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create statefulSet %q (ns %s): %w", statefulSet.Name, statefulSet.Namespace, err)
@@ -37,7 +37,7 @@ func CreateAndWaitUntilStatefulSetIsReady(statefulSet *appsv1.StatefulSet, timeo
 
 // isStatefulSetReady checks if a statefulset is ready.
 func isStatefulSetReady(namespace string, statefulSetName string) (bool, error) {
-	testStatefulSet, err := APIClient.StatefulSets(namespace).Get(
+	testStatefulSet, err := GetAPIClient().StatefulSets(namespace).Get(
 		context.Background(),
 		statefulSetName,
 		metav1.GetOptions{},

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -23,9 +23,9 @@ import (
 func TestLifecycle(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert lifecycle tests", reporterConfig)
@@ -37,7 +37,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Create namespace")
-	err = namespaces.Create(tsparams.LifecycleNamespace, globalhelper.APIClient)
+	err = namespaces.Create(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.LifecycleNamespace))
-	err := namespaces.DeleteAndWait(globalhelper.APIClient, tsparams.LifecycleNamespace, tsparams.WaitingTime)
+	err := namespaces.DeleteAndWait(globalhelper.GetAPIClient(), tsparams.LifecycleNamespace, tsparams.WaitingTime)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Remove reports from reports directory")

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -29,13 +29,13 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -20,13 +20,13 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -21,13 +21,13 @@ var _ = Describe("lifecycle-container-startup", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -124,7 +124,7 @@ var _ = Describe("lifecycle-container-startup", func() {
 	It("One daemonSet without postStart spec [negative]", func() {
 		By("Define daemonSet without postStart spec")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -26,14 +26,14 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test in order to enable RunTimeClass deletion.")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Delete all RTC's that were created by the previous test case.")
@@ -54,7 +54,7 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		annotationsMap := make(map[string]string)
 
 		By("Define pod with resources and runTimeClass")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 
 		By("Add annotations to the pod")
@@ -91,9 +91,9 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		annotationsMap := make(map[string]string)
 
 		By("Define pod with resources and runTimeClass")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
-		globalhelper.AppendContainersToPod(put, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToPod(put, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		By("Add annotations to the pod")
 		annotationsMap["cpu-load-balancing.crio.io"] = disableVar
@@ -130,7 +130,7 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 
 		By("Define deployment with resources and runTimeClass")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
 		By("Add annotations to the pod")
 		annotationsMap["cpu-load-balancing.crio.io"] = disableVar
@@ -167,7 +167,7 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		annotationsMap := make(map[string]string)
 
 		By("Define daemonSet with resources and runTimeClass")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		By("Add annotations to the pod")
@@ -202,7 +202,7 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 	// 54734
 	It("One daemonSet no annotations [negative]", func() {
 		By("Define daemonSet with resources and runTimeClass")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		By("Define runTimeClass")
@@ -235,7 +235,7 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 
 		By("Define deployment with resources and runTimeClass")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
 		By("Add annotations to the pod")
 		annotationsMap["cpu-load-balancing.crio.io"] = disableVar
@@ -263,9 +263,9 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		annotationsMap := make(map[string]string)
 
 		By("Define pod with resources and runTimeClass")
-		puta := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		puta := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
-		putb := pod.DefinePod("lifecycle-podb", tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		putb := pod.DefinePod("lifecycle-podb", tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 
 		By("Add annotations to the pod")

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -21,7 +21,7 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Enable intrusive tests")
@@ -31,7 +31,7 @@ var _ = Describe("lifecycle-deployment-scaling", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Disable intrusive tests")

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -18,13 +18,13 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -93,7 +93,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSet with ifNotPresent as ImagePullPolicy")
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
-			globalhelper.Configuration.General.TestImage, corev1.PullIfNotPresent)
+			globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -113,19 +113,19 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSets with ifNotPresent as ImagePullPolicy")
 		daemonSeta := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
-			globalhelper.Configuration.General.TestImage, corev1.PullIfNotPresent)
+			globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetb := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsb",
-			globalhelper.Configuration.General.TestImage, corev1.PullIfNotPresent)
+			globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetc := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsc",
-			globalhelper.Configuration.General.TestImage, corev1.PullIfNotPresent)
+			globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -242,7 +242,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		By("Define DaemonSet with Never as ImagePullPolicy")
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
-			globalhelper.Configuration.General.TestImage, corev1.PullNever)
+			globalhelper.GetConfiguration().General.TestImage, corev1.PullNever)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -23,13 +23,13 @@ var _ = Describe("lifecycle-liveness", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -126,7 +126,7 @@ var _ = Describe("lifecycle-liveness", func() {
 	It("One daemonSet without a liveness probe [negative]", func() {
 		By("Define daemonSet without a liveness probe")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -29,13 +29,13 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test in order to enable PVs deletion.")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Delete all PVs that were created by the previous test case.")
@@ -67,7 +67,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
 		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, tsparams.TestPVCName)
 
@@ -102,7 +102,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define pod")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 		pod.RedefineWithPVC(put, tsparams.TestVolumeName, tsparams.TestPVCName)
 
@@ -138,7 +138,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 
 		By("Define replicaSet")
 		rs := replicaset.DefineReplicaSet(tsparams.TestReplicaSetName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 		replicaset.RedefineWithPVC(rs, tsparams.TestVolumeName, tsparams.TestPVCName)
 
 		err = globalhelper.CreateAndWaitUntilReplicaSetIsReady(rs, tsparams.WaitingTime)
@@ -173,7 +173,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
 		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, tsparams.TestPVCName)
 
@@ -208,7 +208,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define pod")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 		pod.RedefineWithPVC(put, tsparams.TestVolumeName, tsparams.TestPVCName)
 
@@ -261,11 +261,11 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
 
 		By("Define deployments")
 		depa := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
 		deployment.RedefineWithPVC(depa, tsparams.TestVolumeName, tsparams.TestPVCName)
 
-		depb := deployment.DefineDeployment("lifecycle-dpb", tsparams.LifecycleNamespace, globalhelper.Configuration.General.TestImage,
+		depb := deployment.DefineDeployment("lifecycle-dpb", tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 
 		deployment.RedefineWithPVC(depb, tsparams.TestVolumeName, "lifecycle-pvcb")

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -28,19 +28,19 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 48492
 	It("One deployment, replicas are more than 1, podAntiAffinity is set", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 2 {
@@ -68,7 +68,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48495
 	It("Two deployments, replicas are more than 1, podAntiAffinity is set", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -105,7 +105,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48499
 	It("One deployment, replicas are more than 1, podAntiAffinity is not set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 2 {
@@ -131,7 +131,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48500
 	It("Two deployments, replicas are more than 1, podAntiAffinity is not set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -164,7 +164,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48869
 	It("One deployment, replicas equal to 1, podAntiAffinity is set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -20,13 +20,13 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -34,19 +34,19 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 47405
 	It("One deployment with PodAntiAffinity, replicas are less than schedulable nodes", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {
@@ -76,7 +76,7 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 	// 47406
 	It("Two deployments with PodAntiAffinity, replicas are less than schedulable nodes", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -115,7 +115,7 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 	// 47407
 	It("One deployment with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {
@@ -143,7 +143,7 @@ var _ = Describe("lifecycle-pod-recreation", func() {
 
 	// 47408
 	It("Two deployments with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.APIClient)
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		// all nodes will be scheduled with a pod.

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -30,13 +30,13 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -146,7 +146,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		By("Define daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -16,13 +16,13 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -23,13 +23,13 @@ var _ = Describe("lifecycle-readiness", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -125,7 +125,7 @@ var _ = Describe("lifecycle-readiness", func() {
 	It("One daemonSet without a readiness probe [negative]", func() {
 		By("Define daemonSet without a readiness probe")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -23,13 +23,13 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -128,7 +128,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName)
 		Expect(err).ToNot(HaveOccurred())
 
-		globalhelper.AppendContainersToDeployment(deploymenta, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(deploymenta, 1, globalhelper.GetConfiguration().General.TestImage)
 		deployment.RedefineWithStartUpProbe(deploymenta)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
@@ -148,7 +148,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 	It("One daemonSet without a startup probe [negative]", func() {
 		By("Define daemonSet without a startup probe")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.LifecycleNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
@@ -199,7 +199,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithStartUpProbe(deploymenta)
-		globalhelper.AppendContainersToDeployment(deploymenta, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(deploymenta, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -21,7 +21,7 @@ var _ = Describe("lifecycle-statefulset-scaling", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Clean namespace before each test")
-		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Enable intrusive tests")
@@ -31,7 +31,7 @@ var _ = Describe("lifecycle-statefulset-scaling", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Disable intrusive tests")

--- a/tests/manageability/manageability_suite_test.go
+++ b/tests/manageability/manageability_suite_test.go
@@ -21,9 +21,9 @@ import (
 func TestPerformance(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert performance tests", reporterConfig)
@@ -32,7 +32,7 @@ func TestPerformance(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	By("Create namespace")
-	err := namespaces.Create(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.ManageabilityNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.ManageabilityNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -14,13 +14,13 @@ var _ = Describe("manageability-container-port-name", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -14,13 +14,13 @@ var _ = Describe("manageability-containers-image-tag", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("manageability-containers-image-tag", func() {
 
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.ManageabilityNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -24,9 +24,9 @@ import (
 func TestNetworking(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert networking tests", reporterConfig)
@@ -36,18 +36,18 @@ var _ = BeforeSuite(func() {
 
 	By("Validate that cluster is Schedulable")
 	Eventually(func() bool {
-		isClusterReady, err := cluster.IsClusterStable(globalhelper.APIClient)
+		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
 	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
 	By("Validate that all nodes are Ready")
-	err := nodes.WaitForNodesReady(globalhelper.APIClient, tsparams.WaitingTime, tsparams.RetryInterval)
+	err := nodes.WaitForNodesReady(globalhelper.GetAPIClient(), tsparams.WaitingTime, tsparams.RetryInterval)
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprintf("Create %s namespace", tsparams.TestNetworkingNameSpace))
-	err = namespaces.Create(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+	err = namespaces.Create(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
@@ -67,14 +67,14 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("Remove networking test namespaces")
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.TestNetworkingNameSpace,
 		tsparams.WaitingTime,
 	)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.AdditionalNetworkingNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -27,7 +27,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 
 	execute.BeforeAll(func() {
 		By("Clean namespace before all tests")
-		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -35,7 +35,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -19,7 +19,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 
 	execute.BeforeAll(func() {
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -27,10 +27,10 @@ var _ = Describe("Networking dual-stack-service,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -40,10 +40,10 @@ var _ = Describe("Networking dual-stack-service,", func() {
 
 	AfterEach(func() {
 		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -20,13 +20,13 @@ var _ = Describe("Networking custom namespace,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -36,7 +36,7 @@ var _ = Describe("Networking custom namespace,", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -19,24 +19,24 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create additional namespaces for testing")
 		// this namespace will only be used for the networking-network-policy-deny-all tests
-		err = namespaces.Create(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		err = namespaces.Create(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 	})
 
 	BeforeEach(func() {
 		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -46,10 +46,10 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 
 	AfterEach(func() {
 		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.APIClient)
+		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -20,7 +20,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -28,7 +28,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -38,7 +38,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -20,7 +20,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -29,7 +29,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")
@@ -39,7 +39,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -21,7 +21,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	execute.BeforeAll(func() {
 
 		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
 		Expect(err).ToNot(HaveOccurred())
@@ -31,7 +31,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	BeforeEach(func() {
 
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove reports from report directory")

--- a/tests/observability/helper/helper.go
+++ b/tests/observability/helper/helper.go
@@ -56,7 +56,7 @@ func DefineDaemonSetWithStdoutBuffers(name string, stdoutBuffers []string) *apps
 }
 
 func DefinePodWithStdoutBuffer(name string, stdoutBuffer string) *corev1.Pod {
-	newPod := pod.DefinePod(name, tsparams.TestNamespace, globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+	newPod := pod.DefinePod(name, tsparams.TestNamespace, globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 	// Change command to use the stdout buffer.
 	newPod.Spec.Containers[0].Command = getContainerCommandWithStdout(stdoutBuffer)
@@ -66,7 +66,7 @@ func DefinePodWithStdoutBuffer(name string, stdoutBuffer string) *corev1.Pod {
 
 func DefineDeploymentWithoutTargetLabels(name string) *appsv1.Deployment {
 	return deployment.DefineDeployment(name, tsparams.TestNamespace,
-		globalhelper.Configuration.General.TestImage,
+		globalhelper.GetConfiguration().General.TestImage,
 		map[string]string{"fakeLabelKey": "fakeLabelValue"})
 }
 
@@ -89,7 +89,7 @@ func DefineCrdWithoutStatusSubresource(kind, group string) *apiextv1.CustomResou
 }
 
 func CreateAndWaitUntilCrdIsReady(crd *apiextv1.CustomResourceDefinition, timeout time.Duration) error {
-	_, err := globalhelper.APIClient.CustomResourceDefinitions().Create(
+	_, err := globalhelper.GetAPIClient().CustomResourceDefinitions().Create(
 		context.Background(),
 		crd,
 		metav1.CreateOptions{},
@@ -99,7 +99,7 @@ func CreateAndWaitUntilCrdIsReady(crd *apiextv1.CustomResourceDefinition, timeou
 	}
 
 	Eventually(func() bool {
-		runningCrd, err := globalhelper.APIClient.CustomResourceDefinitions().Get(
+		runningCrd, err := globalhelper.GetAPIClient().CustomResourceDefinitions().Get(
 			context.Background(),
 			crd.Name,
 			metav1.GetOptions{},
@@ -124,14 +124,14 @@ func CreateAndWaitUntilCrdIsReady(crd *apiextv1.CustomResourceDefinition, timeou
 }
 
 func DeleteCrdAndWaitUntilIsRemoved(crd string, timeout time.Duration) {
-	err := globalhelper.APIClient.CustomResourceDefinitions().Delete(
+	err := globalhelper.GetAPIClient().CustomResourceDefinitions().Delete(
 		context.Background(),
 		crd,
 		metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	Eventually(func() bool {
-		_, err := globalhelper.APIClient.CustomResourceDefinitions().Get(
+		_, err := globalhelper.GetAPIClient().CustomResourceDefinitions().Get(
 			context.Background(),
 			crd,
 			metav1.GetOptions{})
@@ -185,7 +185,7 @@ func createContainerSpecsFromStdoutBuffers(stdoutBuffers []string) []corev1.Cont
 		containerSpecs = append(containerSpecs,
 			corev1.Container{
 				Name:    fmt.Sprintf("%s-%d", tsparams.TestContainerBaseName, index),
-				Image:   globalhelper.Configuration.General.TestImage,
+				Image:   globalhelper.GetConfiguration().General.TestImage,
 				Command: getContainerCommandWithStdout(stdoutLines),
 			},
 		)
@@ -201,7 +201,7 @@ func createContainerSpecsFromTerminationMsgPolicies(policies []corev1.Terminatio
 	for index := 0; index < numContainers; index++ {
 		container := corev1.Container{
 			Name:    fmt.Sprintf("%s-%d", tsparams.TestContainerBaseName, index),
-			Image:   globalhelper.Configuration.General.TestImage,
+			Image:   globalhelper.GetConfiguration().General.TestImage,
 			Command: tsparams.TestContainerNormalCommand,
 		}
 
@@ -220,7 +220,7 @@ func defineDeploymentWithContainerSpecs(name string, replicas int,
 	containerSpecs []corev1.Container) *appsv1.Deployment {
 	// Define base deployment
 	dep := deployment.DefineDeployment(name, tsparams.TestNamespace,
-		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+		globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 	// Customize its replicas and container specs.
 	deployment.RedefineWithReplicaNumber(dep, int32(replicas))
@@ -233,7 +233,7 @@ func defineStatefulSetWithContainerSpecs(name string, replicas int,
 	containerSpecs []corev1.Container) *appsv1.StatefulSet {
 	// Define base statefulSet
 	sts := statefulset.DefineStatefulSet(name, tsparams.TestNamespace,
-		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+		globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 	// Customize its replicas and container specs.
 	statefulset.RedefineWithReplicaNumber(sts, int32(replicas))
@@ -246,7 +246,7 @@ func defineDaemonSetWithContainerSpecs(name string,
 	containerSpecs []corev1.Container) *appsv1.DaemonSet {
 	// Define base daemonSet
 	daemonSet := daemonset.DefineDaemonSet(tsparams.TestNamespace,
-		globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels, name)
+		globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels, name)
 
 	// Customize its container specs.
 	daemonset.RedefineWithContainerSpecs(daemonSet, containerSpecs)

--- a/tests/observability/observability_suite_test.go
+++ b/tests/observability/observability_suite_test.go
@@ -22,9 +22,9 @@ import (
 func TestObservability(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert observability tests", reporterConfig)
@@ -33,7 +33,7 @@ func TestObservability(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	By(fmt.Sprintf("Create %s namespace", tsparams.TestNamespace))
-	err := namespaces.Create(tsparams.TestNamespace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.TestNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
@@ -49,7 +49,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.TestNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.TestNamespace,
 		tsparams.NsResourcesDeleteTimeoutMins,
 	)

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -17,13 +17,13 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace " + tsparams.TestNamespace + " before each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace " + tsparams.TestNamespace + " after each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -18,13 +18,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -36,7 +36,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, tsparams.TestNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 1)
 
@@ -65,7 +65,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, tsparams.TestNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 
@@ -94,7 +94,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		By("Create statefulSet")
 		sf := statefulset.DefineStatefulSet(tsparams.TestStatefulSetBaseName, tsparams.TestNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		statefulset.RedefineWithReplicaNumber(sf, 1)
 
@@ -123,7 +123,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, tsparams.TestNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 
@@ -152,7 +152,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, tsparams.TestNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -18,13 +18,13 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace " + tsparams.TestNamespace + " before each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace " + tsparams.TestNamespace + " after each test")
-		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.TestNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/performance/helper/helper.go
+++ b/tests/performance/helper/helper.go
@@ -148,7 +148,7 @@ func ExecCommandContainer(
 	logrus.Trace(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s",
 		podNamespace, podName, container, strings.Join(commandStr, " ")))
 
-	req := globalhelper.APIClient.CoreV1Interface.RESTClient().
+	req := globalhelper.GetAPIClient().CoreV1Interface.RESTClient().
 		Post().
 		Namespace(podNamespace).
 		Resource("pods").
@@ -163,7 +163,7 @@ func ExecCommandContainer(
 			TTY:       false,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(globalhelper.APIClient.Config, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(globalhelper.GetAPIClient().Config, "POST", req.URL())
 	if err != nil {
 		logrus.Error(err)
 
@@ -191,7 +191,7 @@ func ExecCommandContainer(
 }
 
 func DeleteRunTimeClass(rtcName string) error {
-	err := globalhelper.APIClient.RuntimeClasses().Delete(context.Background(), rtcName,
+	err := globalhelper.GetAPIClient().RuntimeClasses().Delete(context.Background(), rtcName,
 		metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
 	if err != nil {
 		return fmt.Errorf("failed to delete RunTimeClasses %w", err)
@@ -203,19 +203,20 @@ func DeleteRunTimeClass(rtcName string) error {
 func ConfigurePrivilegedServiceAccount(namespace string) error {
 	aRole, aRoleBinding, aServiceAccount := getPrivilegedServiceAccountObjects(namespace)
 	// create role
-	_, err := globalhelper.APIClient.RbacV1Interface.Roles(namespace).Create(context.TODO(), &aRole, metav1.CreateOptions{})
+	_, err := globalhelper.GetAPIClient().RbacV1Interface.Roles(namespace).Create(context.TODO(), &aRole, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating role, err=%w", err)
 	}
 
 	// create rolebinding
-	_, err = globalhelper.APIClient.RbacV1Interface.RoleBindings(namespace).Create(context.TODO(), &aRoleBinding, metav1.CreateOptions{})
+	//nolint:lll
+	_, err = globalhelper.GetAPIClient().RbacV1Interface.RoleBindings(namespace).Create(context.TODO(), &aRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating role bindings, err=%w", err)
 	}
 
 	// create service account
-	_, err = globalhelper.APIClient.CoreV1Interface.ServiceAccounts(namespace).Create(context.TODO(),
+	_, err = globalhelper.GetAPIClient().CoreV1Interface.ServiceAccounts(namespace).Create(context.TODO(),
 		&aServiceAccount, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating service account, err=%w", err)

--- a/tests/performance/performance_suite_test.go
+++ b/tests/performance/performance_suite_test.go
@@ -22,9 +22,9 @@ import (
 func TestPerformance(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert performance tests", reporterConfig)
@@ -33,7 +33,7 @@ func TestPerformance(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	By("Create namespace")
-	err := namespaces.Create(tsparams.PerformanceNamespace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create service account and roles and roles binding
@@ -53,7 +53,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.PerformanceNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.PerformanceNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -15,20 +15,20 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("One pod with only exclusive containers", func() {
 		By("Define pod")
 		testPod := tshelper.DefineExclusivePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -48,7 +48,7 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 
 		By("Define pod")
 		testPod := tshelper.DefineExclusivePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		tshelper.RedefinePodWithSharedContainer(testPod, 0)
 
@@ -70,7 +70,7 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 
 		By("Define pod")
 		testPod := tshelper.DefineExclusivePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		pod.RedefineWithCPUResources(testPod, "0.75", "0.5")
 

--- a/tests/performance/tests/rt_app_no_exec_probes.go
+++ b/tests/performance/tests/rt_app_no_exec_probes.go
@@ -15,13 +15,13 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -78,7 +78,7 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		pod.RedefineWithCPUResources(testPod, "1", "1")
 		pod.RedefineWithMemoryResources(testPod, "512Mi", "512Mi")

--- a/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
+++ b/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
@@ -16,13 +16,13 @@ var _ = Describe("performance-exclusive-cpu-pool-rt-scheduling-policy",
 
 		BeforeEach(func() {
 			By("Clean namespace before each test")
-			err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+			err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			By("Clean namespace after each test")
-			err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+			err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -104,7 +104,7 @@ var _ = Describe("performance-exclusive-cpu-pool-rt-scheduling-policy",
 		It("One pod running in shared cpu pool", func() {
 			By("Define pod")
 			testPod := pod.DefinePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-				globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+				globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 			err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/performance/tests/rt_isolated_cpu_pool.go
+++ b/tests/performance/tests/rt_isolated_cpu_pool.go
@@ -15,13 +15,13 @@ var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test in order to enable RunTimeClass deletion.")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Delete all RTC's that were created by the previous test case.")
@@ -87,7 +87,7 @@ var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", func() {
 	It("One pod running in shared cpu pool", func() {
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
+++ b/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
@@ -14,13 +14,13 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", func() 
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PerformanceNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -28,7 +28,7 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", func() 
 
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -50,7 +50,7 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", func() 
 
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.PerformanceNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		pod.RedefineWithCPUResources(testPod, "1", "1")
 		pod.RedefineWithMemoryResources(testPod, "512Mi", "512Mi")

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -22,9 +22,9 @@ import (
 func TestPlatformAlteration(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.Configuration.General.VerificationLogLevel)
+	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.Configuration.GetReportPath(currentFile)
+	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert platform-alteration tests", reporterConfig)
@@ -33,7 +33,7 @@ func TestPlatformAlteration(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	By("Create namespace")
-	err := namespaces.Create(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+	err := namespaces.Create(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Define TNF config file")
@@ -49,7 +49,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.PlatformAlterationNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.APIClient,
+		globalhelper.GetAPIClient(),
 		tsparams.PlatformAlterationNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -18,13 +18,13 @@ var _ = Describe("platform-alteration-base-image", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -34,7 +34,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		By("Define deployment")
 		deployment := deployment.DefineDeployment(tsparams.TestDeploymentName,
 			tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
@@ -58,7 +58,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 
 		By("Define daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
@@ -82,7 +82,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 
 		By("Define first deployment")
 		deploymenta := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithPrivilegedContainer(deploymenta)
 
@@ -99,7 +99,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		By("Define second deployment")
 		deploymentb := deployment.DefineDeployment("platform-alteration-dpb",
 			tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		By("Define statefulSet")
 		statefulSet := statefulset.DefineStatefulSet(tsparams.TestStatefulSetName,
 			tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 		statefulset.RedefineWithPrivilegedContainer(statefulSet)
 

--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -19,20 +19,20 @@ var _ = Describe("platform-alteration-boot-params", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51302
 	It("unchanged boot params", func() {
 		By("Create daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
@@ -53,10 +53,10 @@ var _ = Describe("platform-alteration-boot-params", func() {
 
 	// 51305
 	It("change boot params using MCO", func() {
-		machineConfigList, err := globalhelper.APIClient.MachineConfigs().List(context.Background(), metav1.ListOptions{})
+		machineConfigList, err := globalhelper.GetAPIClient().MachineConfigs().List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		machineConfigPoolList, err := globalhelper.APIClient.MachineConfigPools().List(context.Background(),
+		machineConfigPoolList, err := globalhelper.GetAPIClient().MachineConfigPools().List(context.Background(),
 			metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -66,7 +66,7 @@ var _ = Describe("platform-alteration-boot-params", func() {
 					machineConfig.Spec.KernelArguments = []string{"skew_tick=1", "nohz=off"}
 
 					By("Update the current machineConfig")
-					_, err := globalhelper.APIClient.MachineConfigs().Update(context.TODO(), &machineConfig, metav1.UpdateOptions{})
+					_, err := globalhelper.GetAPIClient().MachineConfigs().Update(context.TODO(), &machineConfig, metav1.UpdateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -16,13 +16,13 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -30,7 +30,7 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith1GiHugepages(dep, 1)
 
@@ -51,7 +51,7 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 	It("One pod with 1Gi hugepages", func() {
 
 		By("Define pod with 1Gi hugepages")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 		pod.RedefineWithCPUResources(put, "500m", "250m")
 		pod.RedefineWith1GiHugepages(put, 1)
@@ -73,10 +73,10 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith1GiHugepages(dep, 1)
-		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -96,8 +96,8 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 
 		By("Define pod")
 		put := pod.DefinePod(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
-		globalhelper.AppendContainersToPod(put, 1, globalhelper.Configuration.General.TestImage)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
+		globalhelper.AppendContainersToPod(put, 1, globalhelper.GetConfiguration().General.TestImage)
 		pod.RedefineWithCPUResources(put, "500m", "250m")
 
 		err := pod.RedefineFirstContainerWith1GiHugepages(put, 1)
@@ -124,8 +124,8 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 
 		By("Define pod")
 		put := pod.DefinePod(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
-		globalhelper.AppendContainersToPod(put, 1, globalhelper.Configuration.General.TestImage)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
+		globalhelper.AppendContainersToPod(put, 1, globalhelper.GetConfiguration().General.TestImage)
 		pod.RedefineWithCPUResources(put, "500m", "250m")
 
 		err := pod.RedefineFirstContainerWith2MiHugepages(put, 4)

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -16,13 +16,13 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -31,7 +31,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith2MiHugepages(dep, 4)
 
@@ -53,7 +53,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 	It("One pod with 2Mi hugepages", func() {
 
 		By("Define pod with 2Mi hugepages")
-		puta := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		puta := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 		pod.RedefineWithCPUResources(puta, "500m", "250m")
 		pod.RedefineWith2MiHugepages(puta, 4)
@@ -76,10 +76,10 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 
 		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith2MiHugepages(dep, 4)
-		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -100,8 +100,8 @@ var _ = Describe("platform-alteration-hugepages-2m-only", func() {
 
 		By("Define pod")
 		put := pod.DefinePod(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
-		globalhelper.AppendContainersToPod(put, 1, globalhelper.Configuration.General.TestImage)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
+		globalhelper.AppendContainersToPod(put, 1, globalhelper.GetConfiguration().General.TestImage)
 		pod.RedefineWithCPUResources(put, "500m", "250m")
 
 		err := pod.RedefineFirstContainerWith2MiHugepages(put, 4)

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -19,13 +19,13 @@ var _ = Describe("platform-alteration-hugepages-config", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -59,7 +59,7 @@ var _ = Describe("platform-alteration-hugepages-config", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -16,13 +16,13 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -31,9 +31,9 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 
 		By("Define deployment")
 		deployment := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage, tsparams.TnfTargetPodLabels)
+			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
-		globalhelper.AppendContainersToDeployment(deployment, 3, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(deployment, 3, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 
 		By("Define daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace,
-			globalhelper.Configuration.General.TestImage,
+			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
@@ -82,7 +82,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 		dep := tshelper.DefineDeploymentWithNonUBIContainer()
 
 		// Append UBI-based container.
-		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.Configuration.General.TestImage)
+		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -23,19 +23,19 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 51310
 	It("SELinux is enforcing on all nodes", func() {
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
@@ -71,7 +71,7 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 
 	// 51311
 	It("SELinux is permissive on one node [negative]", func() {
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -39,22 +39,22 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 56594
 	It("istio is installed", func() {
 		By("Define a test pod with istio container")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
-		tshelper.AppendIstioContainerToPod(put, globalhelper.Configuration.General.TestImage)
+		tshelper.AppendIstioContainerToPod(put, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(put, WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -71,7 +71,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
 	// 56596
 	It("istio is installed but proxy containers does not exist [negative]", func() {
 		By("Define a test pod without istio container")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(put, WaitingTime)
@@ -89,14 +89,14 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
 	// 56597
 	It("istio is installed but proxy container exist on one pod only [negative]", func() {
 		By("Define first pod with istio container")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
-		tshelper.AppendIstioContainerToPod(put, globalhelper.Configuration.General.TestImage)
+		tshelper.AppendIstioContainerToPod(put, globalhelper.GetConfiguration().General.TestImage)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(put, WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		putb := pod.DefinePod("lifecycle-putb", tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		putb := pod.DefinePod("lifecycle-putb", tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(putb, WaitingTime)
@@ -116,13 +116,13 @@ var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", func() {
 		By("Check if Istio resource exists")
 		gvr := schema.GroupVersionResource{Group: "install.istio.io", Version: "v1alpha1", Resource: "istiooperators"}
 
-		_, err := globalhelper.APIClient.DynamicClient.Resource(gvr).Namespace(istioNamespace).Get(context.TODO(),
+		_, err := globalhelper.GetAPIClient().DynamicClient.Resource(gvr).Namespace(istioNamespace).Get(context.TODO(),
 			"installed-state", metav1.GetOptions{})
 
 		if err == nil {
@@ -145,9 +145,9 @@ var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", func() {
 		}
 
 		By("Define a test pod with istio container")
-		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		put := pod.DefinePod(tsparams.TestPodName, tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
-		tshelper.AppendIstioContainerToPod(put, globalhelper.Configuration.General.TestImage)
+		tshelper.AppendIstioContainerToPod(put, globalhelper.GetConfiguration().General.TestImage)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -21,13 +21,13 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -35,7 +35,7 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 	It("unchanged sysctl config", func() {
 
 		By("Create daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
@@ -56,7 +56,7 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 	It("change sysctl config using MCO", func() {
 
 		By("Create daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
@@ -67,15 +67,15 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		node, err := globalhelper.APIClient.Nodes().Get(context.Background(), podList.Items[0].Spec.NodeName, metav1.GetOptions{})
+		node, err := globalhelper.GetAPIClient().Nodes().Get(context.Background(), podList.Items[0].Spec.NodeName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		value, exists := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		value, exists := node.Annotations["machineGetConfiguration().openshift.io/currentConfig"]
 		if !exists {
 			Fail("didn't get node's machine config")
 		}
 
-		mcObj, err := globalhelper.APIClient.MachineConfigs().Get(context.Background(), value, metav1.GetOptions{})
+		mcObj, err := globalhelper.GetAPIClient().MachineConfigs().Get(context.Background(), value, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		mcKernelArgs := mcObj.Spec.KernelArguments
@@ -94,7 +94,7 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 		}
 		mcObj.Spec.KernelArguments = mcKernelArgs
 
-		_, err = globalhelper.APIClient.MachineConfigs().Update(context.TODO(), mcObj, metav1.UpdateOptions{})
+		_, err = globalhelper.GetAPIClient().MachineConfigs().Update(context.TODO(), mcObj, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-sysctl-config test")

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -15,13 +15,13 @@ var _ = Describe("platform-alteration-tainted-node-kernel", func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.APIClient)
+		err := namespaces.Clean(tsparams.PlatformAlterationNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -44,7 +44,7 @@ var _ = Describe("platform-alteration-tainted-node-kernel", func() {
 	It("Tainted node [negative]", func() {
 
 		By("Define daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.Configuration.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(tsparams.PlatformAlterationNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
@@ -78,12 +78,12 @@ var _ = Describe("platform-alteration-tainted-node-kernel", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Wait for the node to become not ready")
-		err = tshelper.WaitForSpecificNodeCondition(globalhelper.APIClient,
+		err = tshelper.WaitForSpecificNodeCondition(globalhelper.GetAPIClient(),
 			tsparams.RebootWaitingTime, tsparams.RetryInterval, podList.Items[0].Spec.NodeName, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Wait for the node to become ready")
-		err = tshelper.WaitForSpecificNodeCondition(globalhelper.APIClient,
+		err = tshelper.WaitForSpecificNodeCondition(globalhelper.GetAPIClient(),
 			tsparams.RebootWaitingTime, tsparams.RetryInterval, podList.Items[0].Spec.NodeName, true)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -21,7 +21,7 @@ const (
 	DevTestFileConfigPath = "config/testconfig.yaml" // Used only for dev/testing purpose only
 )
 
-// Config type keeps general configuration.
+// Config type keeps general GetConfiguration().
 type Config struct {
 	General struct {
 		ReportDirAbsPath     string `yaml:"report" envconfig:"REPORT_DIR_NAME"`

--- a/tests/utils/crd/crd.go
+++ b/tests/utils/crd/crd.go
@@ -65,7 +65,7 @@ func DefineCustomResourceDefinition(names apiextv1.CustomResourceDefinitionNames
 }
 
 func EnsureCrdExists(name string) (bool, error) {
-	_, err := globalhelper.APIClient.CustomResourceDefinitions().Get(context.Background(),
+	_, err := globalhelper.GetAPIClient().CustomResourceDefinitions().Get(context.Background(),
 		name, metav1.GetOptions{})
 
 	if err != nil {


### PR DESCRIPTION
Trying to add unit tests to the QE repo to solve a problem and it is trying to run the `init()` function which is populating a list of clients which is not needed during unit test time.  

Bonus:
- Fixed the `make unit-tests` to work with this change.
- Modified the yamllint linter config based on the `cnf-certification-test` repo.
- Check out the `cnf-certification-test` repo because we need the TNF_REPO_PATH var set for the unit tests.