### PR TITLE
Check for existing runtime class to avoid error

### DIFF
--- a/tests/globalhelper/runtimeclass.go
+++ b/tests/globalhelper/runtimeclass.go
@@ -12,7 +12,19 @@ import (
 )
 
 func CreateRunTimeClass(rtc *nodev1.RuntimeClass) error {
-	rtc, err := GetAPIClient().RuntimeClasses().Create(context.TODO(), rtc, metav1.CreateOptions{})
+	// Check for existing runtimeclass first
+	rtcCreated, err := isRtcCreated(rtc)
+	if err != nil {
+		return fmt.Errorf("failed to check if runtimeclass %q (ns %s) exists: %w", rtc.Name, rtc.Namespace, err)
+	}
+
+	if rtcCreated {
+		glog.V(5).Info(fmt.Sprintf("runtimeclass %q (ns %s) already exists", rtc.Name, rtc.Namespace))
+
+		return nil
+	}
+
+	rtc, err = GetAPIClient().RuntimeClasses().Create(context.Background(), rtc, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create runtimeclass %q (ns %s): %w", rtc.Name, rtc.Namespace, err)
 	}


### PR DESCRIPTION
Issuing the `Create()` without checking first if runtimeClass exists ends in an error if it has already been created.

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/352cb310-e765-41dd-93f4-44a3ff9a1b97)
