### PR TITLE
Revert changes for runtimeClass Create()

### DIFF
--- a/tests/globalhelper/runtimeclass.go
+++ b/tests/globalhelper/runtimeclass.go
@@ -12,19 +12,7 @@ import (
 )
 
 func CreateRunTimeClass(rtc *nodev1.RuntimeClass) error {
-	// Check for existing runtimeclass first
-	rtcCreated, err := isRtcCreated(rtc)
-	if err != nil {
-		return fmt.Errorf("failed to check if runtimeclass %q (ns %s) exists: %w", rtc.Name, rtc.Namespace, err)
-	}
-
-	if rtcCreated {
-		glog.V(5).Info(fmt.Sprintf("runtimeclass %q (ns %s) already exists", rtc.Name, rtc.Namespace))
-
-		return nil
-	}
-
-	rtc, err = GetAPIClient().RuntimeClasses().Create(context.Background(), rtc, metav1.CreateOptions{})
+	rtc, err := GetAPIClient().RuntimeClasses().Create(context.TODO(), rtc, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create runtimeclass %q (ns %s): %w", rtc.Name, rtc.Namespace, err)
 	}


### PR DESCRIPTION
Removing changes from #397 

The `Get` was issuing a failure which was causing fresh runs to fail:

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/e54e28d4-de5a-4592-aff7-67613aa05c57)
