### PR TITLE
Cleanup 'local-storage' storageclass

### DIFF
--- a/tests/lifecycle/helper/helper.go
+++ b/tests/lifecycle/helper/helper.go
@@ -183,3 +183,18 @@ func CreateStorageClass(storageClassName string) error {
 
 	return err
 }
+
+func DeleteStorageClass(storageClassName string) error {
+	err := globalhelper.GetAPIClient().K8sClient.StorageV1().StorageClasses().Delete(context.Background(),
+		storageClassName, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
+
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("storageclass %s already deleted", storageClassName))
+
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to delete storageclass %w", err)
+	}
+
+	return nil
+}

--- a/tests/lifecycle/tests/lifecycle_storage_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_storage_required_pods.go
@@ -25,7 +25,7 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 		err = namespaces.Clean(tsparams.LifecycleNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Create local PVC")
+		By("Create local-storage storageclass")
 		err = tshelper.CreateStorageClass("local-storage")
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -41,6 +41,10 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 			err := tshelper.DeletePV(pv, tsparams.WaitingTime)
 			Expect(err).ToNot(HaveOccurred())
 		}
+
+		By("Delete local-storage storageclass")
+		err = tshelper.DeleteStorageClass("local-storage")
+		Expect(err).ToNot(HaveOccurred())
 
 		// clear the list.
 		pvNames = []string{}


### PR DESCRIPTION
Add a cleanup in the `AfterEach` section of these tests to cleanup the `local-storage` storageclass.