### PR TITLE
Add checks in namespace cleanup

### DIFF
--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -43,6 +43,7 @@ var _ = Describe("Access-control security-context,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment")
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create and wait until deployment is ready")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Adds checks to namespace cleanup logic.  
* Makes sure that a namespace exists before performing the `Clean()` operation.
* Edits `DeleteAndWait` function to handle IsNotFound errors.