### PR TITLE
Fixes for networking tests

### DIFF
--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -122,8 +122,12 @@ func ExecCmdOnAllPodInNamespace(command []string) error {
 	return execCmdOnPodsListInNamespace(command, "all")
 }
 
+func RedefineServiceToHeadless(service *corev1.Service) {
+	service.Spec.ClusterIP = corev1.ClusterIPNone
+}
+
 // DefineAndCreateServiceOnCluster defines service resource and creates it on cluster.
-func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, withNodePort bool,
+func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, withNodePort, headless bool,
 	ipFams []corev1.IPFamily, ipFamPolicy string) error {
 	var testService *corev1.Service
 
@@ -158,6 +162,10 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 		if err != nil {
 			return err
 		}
+	}
+
+	if headless {
+		RedefineServiceToHeadless(testService)
 	}
 
 	_, err := globalhelper.GetAPIClient().Services(tsparams.TestNetworkingNameSpace).Create(

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -13,6 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
@@ -41,11 +42,19 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Ensure all nodes are labeled with 'worker-cnf' label")
+		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Remove reports from report directory")
 		err = globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Clean namespace after each test")
+		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,12 +74,15 @@ var _ = Describe("Networking dual-stack-service,", func() {
 	})
 
 	// 62507
-	It("service with ipFamilyPolicy PreferDualStack and zero ClusterIPs [negative]", func() {
+	FIt("service with ipFamilyPolicy PreferDualStack and zero ClusterIPs [negative]", func() {
 
 		By("Define and create service")
 		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false,
 			[]corev1.IPFamily{"IPv4"}, "PreferDualStack")
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Sleep for 3 minutes")
+		time.Sleep(3 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,7 +55,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 	It("service with ipFamilyPolicy SingleStack and ip version ipv4 [negative]", func() {
 
 		By("Define and create service")
-		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false,
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -74,15 +73,11 @@ var _ = Describe("Networking dual-stack-service,", func() {
 	})
 
 	// 62507
-	FIt("service with ipFamilyPolicy PreferDualStack and zero ClusterIPs [negative]", func() {
+	It("service with ipFamilyPolicy PreferDualStack and zero ClusterIPs [negative]", func() {
 
 		By("Define and create service")
-		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false,
-			[]corev1.IPFamily{"IPv4"}, "PreferDualStack")
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, true, []corev1.IPFamily{"IPv4"}, "PreferDualStack")
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Sleep for 3 minutes")
-		time.Sleep(3 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -103,7 +98,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 		func() {
 
 			By("Define and create service")
-			err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, []corev1.IPFamily{"IPv4"}, "")
+			err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, false, []corev1.IPFamily{"IPv4"}, "")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Start tests")

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,7 +106,6 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TnfMultusIpv4TcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-		time.Sleep(30 * time.Second)
 	})
 
 	// 48331

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -159,7 +159,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -214,7 +214,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -160,7 +160,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -215,7 +215,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Changes:
- Add safeguard into `addControlPlaneTaint` to check for existing taints to avoid error.
- Changes to `removeControlPlaneTaint` to modify the existing object to avoid error.
- Add `IsAlreadyExists` checks to `DefineAndCreateServiceOnCluster` function.
- Add `IsAlreadyExists` checks to `DefineAndCreateNadOnCluster` function.
- Add `EnsureAllNodesAreLabeled` to `tests/networking/tests/networking_default_network.go` tests.
- Added `RedefineServiceToHeadless` function to designate a headless service (no ClusterIP designation).