### PR TITLE
updated container certification config field names

### DIFF
--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -145,9 +145,9 @@ func defineCertifiedContainersInfo(config *globalparameters.TnfConfig, certified
 	}
 
 	for _, certifiedContainerFields := range certifiedContainerInfo {
-		nameRepositoryTagDigest := strings.Split(certifiedContainerFields, ";")
+		repositoryRegistryTagDigest := strings.Split(certifiedContainerFields, ";")
 
-		if len(nameRepositoryTagDigest) == 1 {
+		if len(repositoryRegistryTagDigest) == 1 {
 			// certifiedContainerInfo item does not contain separation character
 			// use this to add only the Certifiedcontainerinfo field with no sub fields
 			var emptyInfo globalparameters.CertifiedContainerRepoInfo
@@ -156,20 +156,20 @@ func defineCertifiedContainersInfo(config *globalparameters.TnfConfig, certified
 			return nil
 		}
 
-		if len(nameRepositoryTagDigest) != 4 {
+		if len(repositoryRegistryTagDigest) != 4 {
 			return fmt.Errorf(fmt.Sprintf("certified container info %s is invalid", certifiedContainerFields))
 		}
 
-		name := strings.TrimSpace(nameRepositoryTagDigest[0])
-		repo := strings.TrimSpace(nameRepositoryTagDigest[1])
-		tag := strings.TrimSpace(nameRepositoryTagDigest[2])
-		digest := strings.TrimSpace(nameRepositoryTagDigest[3])
+		repo := strings.TrimSpace(repositoryRegistryTagDigest[0])
+		registry := strings.TrimSpace(repositoryRegistryTagDigest[1])
+		tag := strings.TrimSpace(repositoryRegistryTagDigest[2])
+		digest := strings.TrimSpace(repositoryRegistryTagDigest[3])
 
-		glog.V(5).Info(fmt.Sprintf("Adding container name:%s repository:%s to configuration", name, repo))
+		glog.V(5).Info(fmt.Sprintf("Adding container repository:%s registry:%s to configuration", repo, registry))
 
 		config.Certifiedcontainerinfo = append(config.Certifiedcontainerinfo, globalparameters.CertifiedContainerRepoInfo{
-			Name:       name,
 			Repository: repo,
+			Registry:   registry,
 			Tag:        tag,
 			Digest:     digest,
 		})

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -26,8 +26,8 @@ type (
 	}
 
 	CertifiedContainerRepoInfo struct {
-		Name       string `yaml:"name" json:"name"`
 		Repository string `yaml:"repository" json:"repository"`
+		Registry   string `yaml:"registry" json:"registry"`
 		Tag        string `yaml:"tag" json:"tag"`
 		Digest     string `yaml:"digest" json:"digest"`
 	}


### PR DESCRIPTION
Updated field names to match this change: https://github.com/test-network-function/cnf-certification-test/pull/1313

We might also want to update the example tnf_config.yml here: https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/tnf_config.yml