### PR TITLE
Add access-control helper unit tests

### DIFF
--- a/tests/accesscontrol/access_control_suite_test.go
+++ b/tests/accesscontrol/access_control_suite_test.go
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 			parameters.InvalidNamespace,
 			parameters.TestAnotherNamespace,
 		},
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		parameters.Timeout,
 	)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/accesscontrol/helper/helper_test.go
+++ b/tests/accesscontrol/helper/helper_test.go
@@ -1,0 +1,241 @@
+package helper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testDeploymentName = "test-deployment"
+)
+
+func TestDeleteNamespaces(t *testing.T) {
+	namespacesToDelete := []string{"test1", "test2"}
+
+	// Create fake namespace objects
+	var runtimeObjects []runtime.Object
+	for _, namespace := range namespacesToDelete {
+		runtimeObjects = append(runtimeObjects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})
+	}
+
+	// Create a fake clientset
+	client := k8sfake.NewSimpleClientset(runtimeObjects...)
+
+	err := DeleteNamespaces(namespacesToDelete, client.CoreV1(), parameters.Timeout)
+	assert.Nil(t, err)
+
+	// Check that all of the namespaces have been deleted
+	namespaces, err := client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(namespaces.Items))
+}
+
+func assertDeployment(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	assert.Equal(t, testDeploymentName, deployment.Name)
+	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
+	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
+	assert.Equal(t, parameters.TestDeploymentLabels, deployment.Spec.Template.Labels)
+	assert.Equal(t, globalhelper.GetConfiguration().General.TestImage, deployment.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestDefineDeployment(t *testing.T) {
+	// Define a deployment with 1 replica and 1 container
+	deployment, err := DefineDeployment(1, 1, testDeploymentName)
+	assert.Nil(t, err)
+
+	assertDeployment(t, deployment)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Namespace)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Spec.Template.Namespace)
+}
+
+func TestDefineDeploymentWithClusterRoleBindingWithServiceAccount(t *testing.T) {
+	// Define a deployment with 1 replica and 1 container
+	deployment, err := DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, testDeploymentName, "my-service-account")
+	assert.Nil(t, err)
+
+	assertDeployment(t, deployment)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Namespace)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Spec.Template.Namespace)
+}
+
+func TestDefineDeploymentWithNamespace(t *testing.T) {
+	// Define a deployment with 1 replica and 1 container
+	deployment, err := DefineDeploymentWithNamespace(1, 1, testDeploymentName, "test-namespace")
+	assert.Nil(t, err)
+
+	assertDeployment(t, deployment)
+	assert.Equal(t, "test-namespace", deployment.Namespace)
+	assert.Equal(t, "test-namespace", deployment.Spec.Template.Namespace)
+}
+
+func TestDefineDeploymentWithContainerPorts(t *testing.T) {
+	// Define a deployment with 1 replica and 1 container
+	deployment, err := DefineDeploymentWithContainerPorts(testDeploymentName, 1, []corev1.ContainerPort{
+		{
+			Name:          "test-port",
+			ContainerPort: 80,
+		},
+	})
+	assert.Nil(t, err)
+
+	assertDeployment(t, deployment)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Namespace)
+	assert.Equal(t, parameters.TestAccessControlNameSpace, deployment.Spec.Template.Namespace)
+	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers[0].Ports))
+	assert.Equal(t, "test-port", deployment.Spec.Template.Spec.Containers[0].Ports[0].Name)
+	assert.Equal(t, int32(80), deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+}
+
+func TestSetServiceAccountAutomountServiceAccountToken(t *testing.T) {
+	// generate test serviceaccount objects
+	generateServiceAccount := func() *corev1.ServiceAccount {
+		return &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-service-account",
+				Namespace: parameters.TestAccessControlNameSpace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testValue   string
+		expectedErr error
+	}{
+		{
+			testValue:   "true",
+			expectedErr: nil,
+		},
+		{
+			testValue:   "false",
+			expectedErr: nil,
+		},
+		{
+			testValue:   "invalid",
+			expectedErr: errors.New("invalid value for token value"),
+		},
+		{
+			testValue:   "nil",
+			expectedErr: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		client := k8sfake.NewSimpleClientset(generateServiceAccount())
+
+		// Set the globalhelper client to the fake client
+		globalhelper.SetTestK8sAPIClient(client)
+		defer globalhelper.UnsetTestK8sAPIClient()
+
+		// Set the automountServiceAccountToken to the test value
+		err := SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace, "my-service-account", testCase.testValue)
+
+		// Check if the error is as expected
+		assert.Equal(t, testCase.expectedErr, err)
+
+		// Get the serviceaccount from the fake client and check if the automountServiceAccountToken is set to the test value
+		serviceAccount, err := client.CoreV1().
+			ServiceAccounts(parameters.TestAccessControlNameSpace).Get(context.TODO(), "my-service-account", metav1.GetOptions{})
+		assert.Nil(t, err)
+
+		if err == nil {
+			switch testCase.testValue {
+			case "true":
+				assert.Equal(t, true, *serviceAccount.AutomountServiceAccountToken)
+			case "false":
+				assert.Equal(t, false, *serviceAccount.AutomountServiceAccountToken)
+			case "nil":
+				assert.Nil(t, serviceAccount.AutomountServiceAccountToken)
+			}
+		}
+	}
+}
+
+func TestDefineAndCreateResourceQuota(t *testing.T) {
+	// create a fake namespace object as it needs to exist before creating a resource quota
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: parameters.TestAccessControlNameSpace,
+		},
+	}
+
+	// Create a fake clientset
+	client := k8sfake.NewSimpleClientset(namespace)
+
+	// Set the globalhelper client to the fake client
+	globalhelper.SetTestK8sAPIClient(client)
+	defer globalhelper.UnsetTestK8sAPIClient()
+
+	// Define a resource quota
+	err := DefineAndCreateResourceQuota(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
+	assert.Nil(t, err)
+
+	// Get the resource quota from the fake client and check if it exists
+	_, err = client.CoreV1().ResourceQuotas(parameters.TestAccessControlNameSpace).Get(context.TODO(), "quota1", metav1.GetOptions{})
+	assert.Nil(t, err)
+}
+
+func TestDefineAndCreateServiceOnCluster(t *testing.T) {
+	testCases := []struct {
+		ipFamilyDesired string
+		ipFams          []corev1.IPFamily
+		withNodePort    bool
+	}{
+		{
+			ipFamilyDesired: "IPv4",
+			ipFams:          []corev1.IPFamily{corev1.IPv4Protocol},
+			withNodePort:    false,
+		},
+		{
+			ipFamilyDesired: "IPv6",
+			ipFams:          []corev1.IPFamily{corev1.IPv6Protocol},
+			withNodePort:    false,
+		},
+		{
+			ipFamilyDesired: "IPv4",
+			ipFams:          []corev1.IPFamily{corev1.IPv4Protocol},
+			withNodePort:    true,
+		},
+		{
+			ipFamilyDesired: "IPv6",
+			ipFams:          []corev1.IPFamily{corev1.IPv6Protocol},
+			withNodePort:    true,
+		},
+		{
+			ipFamilyDesired: "",
+			ipFams:          []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+			withNodePort:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset()
+
+		// Set the globalhelper client to the fake client
+		globalhelper.SetTestK8sAPIClient(client)
+		defer globalhelper.UnsetTestK8sAPIClient()
+
+		// Define a service
+		err := DefineAndCreateServiceOnCluster("service-name", 8080, 8080, testCase.withNodePort, testCase.ipFams, testCase.ipFamilyDesired)
+		assert.Nil(t, err)
+
+		// Get the service from the fake client and check if it exists
+		_, err = client.CoreV1().Services(parameters.TestAccessControlNameSpace).Get(context.TODO(), "service-name", metav1.GetOptions{})
+		assert.Nil(t, err)
+	}
+}

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -60,8 +60,12 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 	})
 
 	It("one deployment, one pod, does  have cluster role binding [negative]", func() {
+		By("Create cluster role binding")
+		err := globalhelper.CreateClusterRoleBinding(tsparams.TestAccessControlNameSpace, "my-service-account")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Define deployment with cluster role binding ")
-		dep, err := tshelper.DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, "accesscontroldeployment", "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)

--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -62,7 +62,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.TestCertificationNameSpace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.TestCertificationNameSpace,
 		tsparams.Timeout,
 	)

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -31,7 +31,7 @@ var _ = Describe("Affiliated-certification helm chart certification,", func() {
 
 	AfterEach(func() {
 		By("Remove the project")
-		err := namespaces.DeleteAndWait(globalhelper.GetAPIClient(), tsparams.TestHelmChartCertified, tsparams.Timeout)
+		err := namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, tsparams.TestHelmChartCertified, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred(), "Error delete ns affiliated-certification-helmchart-is-certified")
 	})
 

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -6,12 +6,31 @@ import (
 	"github.com/golang/glog"
 	testclient "github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
 	apiclient *testclient.ClientSet
 	conf      *config.Config
 )
+
+func SetTestK8sAPIClient(client kubernetes.Interface) {
+	if apiclient == nil {
+		apiclient = &testclient.ClientSet{}
+	}
+
+	//nolint:godox
+	// TODO: Add more client interfaces as needed
+	apiclient.CoreV1Interface = client.CoreV1()
+	apiclient.AppsV1Interface = client.AppsV1()
+	apiclient.RbacV1Interface = client.RbacV1()
+	apiclient.NodeV1Interface = client.NodeV1()
+	apiclient.K8sClient = client
+}
+
+func UnsetTestK8sAPIClient() {
+	apiclient = nil
+}
 
 func GetAPIClient() *testclient.ClientSet {
 	if apiclient != nil {

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.LifecycleNamespace))
-	err := namespaces.DeleteAndWait(globalhelper.GetAPIClient(), tsparams.LifecycleNamespace, tsparams.WaitingTime)
+	err := namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, tsparams.LifecycleNamespace, tsparams.WaitingTime)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Remove reports from reports directory")

--- a/tests/manageability/manageability_suite_test.go
+++ b/tests/manageability/manageability_suite_test.go
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.ManageabilityNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.ManageabilityNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -67,14 +67,14 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("Remove networking test namespaces")
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.TestNetworkingNameSpace,
 		tsparams.WaitingTime,
 	)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.AdditionalNetworkingNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/observability/observability_suite_test.go
+++ b/tests/observability/observability_suite_test.go
@@ -49,7 +49,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.TestNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.TestNamespace,
 		tsparams.NsResourcesDeleteTimeoutMins,
 	)

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.OperatorNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.OperatorNamespace,
 		tsparams.Timeout,
 	)

--- a/tests/performance/performance_suite_test.go
+++ b/tests/performance/performance_suite_test.go
@@ -53,7 +53,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.PerformanceNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.PerformanceNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -49,7 +49,7 @@ var _ = AfterSuite(func() {
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.PlatformAlterationNamespace))
 	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient(),
+		globalhelper.GetAPIClient().CoreV1Interface,
 		tsparams.PlatformAlterationNamespace,
 		tsparams.WaitingTime,
 	)

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -20,7 +20,8 @@ func DefineDeployment(deploymentName string, namespace string, image string, lab
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
-			Namespace: namespace},
+			Namespace: namespace,
+		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32(1),
 			Selector: &metav1.LabelSelector{
@@ -28,8 +29,9 @@ func DefineDeployment(deploymentName string, namespace string, image string, lab
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "testpod-",
-					Labels: label,
+					Name:      "testpod-",
+					Labels:    label,
+					Namespace: namespace,
 				},
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: pointer.Int64(0),

--- a/tests/utils/namespaces/namespaces.go
+++ b/tests/utils/namespaces/namespaces.go
@@ -13,11 +13,12 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1Typed "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/pointer"
 )
 
 // WaitForDeletion waits until the namespace will be removed from the cluster.
-func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {
+func WaitForDeletion(cs corev1Typed.CoreV1Interface, nsName string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
 			_, err := cs.Namespaces().Get(ctx, nsName, metav1.GetOptions{})
@@ -49,7 +50,7 @@ func Create(namespace string, cs *testclient.ClientSet) error {
 }
 
 // DeleteAndWait deletes a namespace and waits until delete.
-func DeleteAndWait(clientSet *testclient.ClientSet, namespace string, timeout time.Duration) error {
+func DeleteAndWait(clientSet corev1Typed.CoreV1Interface, namespace string, timeout time.Duration) error {
 	err := clientSet.Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		glog.V(5).Info(fmt.Sprintf("namespaces %s is not found", namespace))


### PR DESCRIPTION
Adds unit tests to all of the access-control suite of helper functions.  One of the things I'm noticing is that we pass around the entire `clientset` struct when we only need certain interfaces which makes it harder to spoof/test certain functions.

I also added a func to completely override the `apiclient` that we return from `globalhelper.GetAPIClient` to return a client that's pre-loaded with the `fake` k8s client.

See `UnsetTestK8sAPIClient` and `SetTestK8sAPIClient` funcs.

Notable changes:
- `DefineDeploymentWithClusterRoleBindingWithServiceAccount` had its call to create a cluster role binding moved outside of the func.