### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,10 +14,10 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.7
+          go-version: 1.21.0
 
       - uses: actions/checkout@v3
       - uses: nosborn/github-action-markdown-cli@v3.3.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,13 +24,13 @@ linters-settings:
     statements: 85
   unused:
     check-exported: true
-    go: "1.20"
+    go: "1.21"
   stylecheck:
     dot-import-whitelist:
       - github.com/onsi/gomega
       - github.com/onsi/ginkgo/v2
     # Select the Go version to target. The default is '1.13'.
-    go: "1.20"
+    go: "1.21"
     # https://staticcheck.io/docs/options#checks
     checks: [ "all", "-ST1001"]
 

--- a/scripts/install-latest-go.sh
+++ b/scripts/install-latest-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REQUIRED_GO_VERSION=1.20.7
+REQUIRED_GO_VERSION=1.21.0
 INSTALLED_GO_VERSION="$(
 	go version | {
 		read -r _ _ v _


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344