### PR TITLE
Add 'Serial' delimiter to Describe blocks

### DIFF
--- a/tests/accesscontrol/tests/access_control_container_host_port.go
+++ b/tests/accesscontrol/tests/access_control_container_host_port.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Access-control container-host-port,", func() {
+var _ = Describe("Access-control container-host-port,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control non-root user,", func() {
+var _ = Describe("Access-control non-root user,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control ipc-lock-capability-check,", func() {
+var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control namespace, ", func() {
+var _ = Describe("Access-control namespace, ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Clean test suite namespace before tests")

--- a/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
+++ b/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control namespace-resource-quota,", func() {
+var _ = Describe("Access-control namespace-resource-quota,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control net-admin-capability-check,", func() {
+var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control net-raw-capability-check,", func() {
+var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control no-1337-uid,", func() {
+var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -15,7 +15,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 )
 
-var _ = Describe("Access control custom namespace, custom deployment,", func() {
+var _ = Describe("Access control custom namespace, custom deployment,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Clean namespace before all tests")

--- a/tests/accesscontrol/tests/access_control_one_process_per_container.go
+++ b/tests/accesscontrol/tests/access_control_one_process_per_container.go
@@ -15,7 +15,7 @@ import (
 
 var commandToLaunchTwoProcesses = []string{"/bin/bash", "-c", "seq 998 999| xargs -n 1 -P 2 sleep"}
 
-var _ = Describe("Access-control one-process-per-container,", func() {
+var _ = Describe("Access-control one-process-per-container,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-automount-service-account-token, ", func() {
+var _ = Describe("Access-control pod-automount-service-account-token, ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod cluster role binding,", func() {
+var _ = Describe("Access-control pod cluster role binding,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-ipc, ", func() {
+var _ = Describe("Access-control pod-host-ipc, ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-network ", func() {
+var _ = Describe("Access-control pod-host-network ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-path, ", func() {
+var _ = Describe("Access-control pod-host-path, ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-pid ", func() {
+var _ = Describe("Access-control pod-host-pid ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_pod_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_role_bindings.go
@@ -25,7 +25,7 @@ func setupInitialRbacConfiguration() {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-var _ = Describe("Access-control pod-role-bindings,", func() {
+var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 
 	execute.BeforeAll(func() {
 

--- a/tests/accesscontrol/tests/access_control_pod_service_account.go
+++ b/tests/accesscontrol/tests/access_control_pod_service_account.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("Access-control pod-service-account,", func() {
+var _ = Describe("Access-control pod-service-account,", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/accesscontrol/tests/access_control_projected_volume_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_projected_volume_service_account_token.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control projected-volume-service-account-token,", func() {
+var _ = Describe("Access-control projected-volume-service-account-token,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control requests-and-limits,", func() {
+var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control security-context,", func() {
+var _ = Describe("Access-control security-context,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control security-context-privilege-escalation,", func() {
+var _ = Describe("Access-control security-context-privilege-escalation,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_ssh_daemons.go
+++ b/tests/accesscontrol/tests/access_control_ssh_daemons.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("Access-control ssh-daemons,", func() {
+var _ = Describe("Access-control ssh-daemons,", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control sys-admin-capability-check,", func() {
+var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control sys-ptrace-capability ", func() {
+var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 
 	execute.BeforeAll(func() {
 		By("Define tnf config file")

--- a/tests/affiliatedcertification/tests/affiliated_certification_container.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container.go
@@ -12,7 +12,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification container certification,", func() {
+var _ = Describe("Affiliated-certification container certification,", Serial, func() {
 
 	execute.BeforeAll(func() {
 

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification container-is-certified-digest,", func() {
+var _ = Describe("Affiliated-certification container-is-certified-digest,", Serial, func() {
 	execute.BeforeAll(func() {
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -15,7 +15,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification invalid operator certification,", func() {
+var _ = Describe("Affiliated-certification invalid operator certification,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification operator certification,", func() {
+var _ = Describe("Affiliated-certification operator certification,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Affiliated-certification helm chart certification,", func() {
+var _ = Describe("Affiliated-certification helm chart certification,", Serial, func() {
 	execute.BeforeAll(func() {
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-affinity-required-pods", func() {
+var _ = Describe("lifecycle-affinity-required-pods", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-container-shutdown", func() {
+var _ = Describe("lifecycle-container-shutdown", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -19,7 +19,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
 )
 
-var _ = Describe("lifecycle-container-startup", func() {
+var _ = Describe("lifecycle-container-startup", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -24,7 +24,7 @@ var (
 	rtcNames = []string{}
 )
 
-var _ = Describe("lifecycle-cpu-isolation", func() {
+var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_crd_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_crd_scaling.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-crd-scaling", func() {
+var _ = Describe("lifecycle-crd-scaling", Serial, func() {
 	execute.BeforeAll(func() {
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-deployment-scaling", func() {
+var _ = Describe("lifecycle-deployment-scaling", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -19,7 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("lifecycle-image-pull-policy", func() {
+var _ = Describe("lifecycle-image-pull-policy", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -21,7 +21,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-liveness", func() {
+var _ = Describe("lifecycle-liveness", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -27,7 +27,7 @@ var (
 	pvNames = []string{}
 )
 
-var _ = Describe("lifecycle-persistent-volume-reclaim-policy", func() {
+var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-pod-high-availability", func() {
+var _ = Describe("lifecycle-pod-high-availability", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-pod-owner-type", func() {
+var _ = Describe("lifecycle-pod-owner-type", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -20,7 +20,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-pod-recreation", func() {
+var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -19,7 +19,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-pod-scheduling", func() {
+var _ = Describe("lifecycle-pod-scheduling", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -17,7 +17,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 )
 
-var _ = Describe("Lifecycle pod-toleration-bypass", func() {
+var _ = Describe("Lifecycle pod-toleration-bypass", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -21,7 +21,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-readiness", func() {
+var _ = Describe("lifecycle-readiness", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -21,7 +21,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-startup-probe", func() {
+var _ = Describe("lifecycle-startup-probe", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-statefulset-scaling", func() {
+var _ = Describe("lifecycle-statefulset-scaling", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/lifecycle/tests/lifecycle_storage_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_storage_required_pods.go
@@ -16,7 +16,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-storage-required-pods", func() {
+var _ = Describe("lifecycle-storage-required-pods", Serial, func() {
 	BeforeEach(func() {
 		err := tshelper.WaitUntilClusterIsStable()
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("manageability-container-port-name", func() {
+var _ = Describe("manageability-container-port-name", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("manageability-containers-image-tag", func() {
+var _ = Describe("manageability-containers-image-tag", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -19,7 +19,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking custom namespace, custom deployment,", func() {
+var _ = Describe("Networking custom namespace, custom deployment,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -19,7 +19,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking dual-stack-service,", func() {
+var _ = Describe("Networking dual-stack-service,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -17,7 +17,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking custom namespace,", func() {
+var _ = Describe("Networking custom namespace,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -18,7 +18,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking network-policy-deny-all,", func() {
+var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -19,7 +19,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
+var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -19,7 +19,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking reserved-partner-ports,", func() {
+var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -20,7 +20,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking undeclared-container-ports-usage,", func() {
+var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -12,7 +12,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/observability/parameters"
 )
 
-var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
+var _ = Describe(tsparams.TnfContainerLoggingTcName, Serial, func() {
 	const tnfTestCaseName = tsparams.TnfContainerLoggingTcName
 
 	BeforeEach(func() {

--- a/tests/observability/tests/crd_status.go
+++ b/tests/observability/tests/crd_status.go
@@ -18,7 +18,7 @@ var (
 	crdNames = []string{}
 )
 
-var _ = Describe(tsparams.TnfCrdStatusTcName, func() {
+var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 	const tnfTestCaseName = tsparams.TnfCrdStatusTcName
 
 	AfterEach(func() {

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
+var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -12,7 +12,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/observability/parameters"
 )
 
-var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
+var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, Serial, func() {
 	const tnfTestCaseName = tsparams.TnfTerminationMsgPolicyTcName
 	qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
 

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Operator install-source,", func() {
+var _ = Describe("Operator install-source,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Operator install-source,", func() {
+var _ = Describe("Operator install-source,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -13,7 +13,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Operator install-status-no-privileges,", func() {
+var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -11,7 +11,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("performance-exclusive-cpu-pool", func() {
+var _ = Describe("performance-exclusive-cpu-pool", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/performance/tests/rt_app_no_exec_probes.go
+++ b/tests/performance/tests/rt_app_no_exec_probes.go
@@ -11,7 +11,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("performance-rt-apps-no-exec-probes", func() {
+var _ = Describe("performance-rt-apps-no-exec-probes", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
+++ b/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("performance-exclusive-cpu-pool-rt-scheduling-policy",
-	func() {
+	Serial, func() {
 
 		BeforeEach(func() {
 			By("Clean namespace before each test")

--- a/tests/performance/tests/rt_isolated_cpu_pool.go
+++ b/tests/performance/tests/rt_isolated_cpu_pool.go
@@ -11,7 +11,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", func() {
+var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
+++ b/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", func() {
+var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -14,7 +14,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/statefulset"
 )
 
-var _ = Describe("platform-alteration-base-image", func() {
+var _ = Describe("platform-alteration-base-image", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("platform-alteration-boot-params", func() {
+var _ = Describe("platform-alteration-boot-params", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("platform-alteration-hugepages-1g-only", func() {
+var _ = Describe("platform-alteration-hugepages-1g-only", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("platform-alteration-hugepages-2m-only", func() {
+var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("platform-alteration-hugepages-config", func() {
+var _ = Describe("platform-alteration-hugepages-config", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("platform-alteration-is-redhat-release", func() {
+var _ = Describe("platform-alteration-is-redhat-release", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
+var _ = Describe("platform-alteration-is-selinux-enforcing", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
+++ b/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 )
 
-var _ = Describe("platform-alteration-ocp-lifecycle", func() {
+var _ = Describe("platform-alteration-ocp-lifecycle", Serial, func() {
 
 	It("OCP version should be supported", func() {
 		By("Start platform-alteration-ocp-lifecycle test")

--- a/tests/platformalteration/tests/platform_alteration_ocp_node_os.go
+++ b/tests/platformalteration/tests/platform_alteration_ocp_node_os.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("platform-alteration-ocp-node-os", func() {
 
-	It("Nodes OS should be compatible with OCP version", func() {
+	It("Nodes OS should be compatible with OCP version", Serial, func() {
 		By("Start platform-alteration-ocp-node-os test")
 		err := globalhelper.LaunchTests(tsparams.TnfOCPNodeOsName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -25,7 +25,7 @@ const (
 	istioNamespace = "istio-system"
 )
 
-var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
+var _ = Describe("platform-alteration-service-mesh-usage-installed", Serial, func() {
 
 	execute.BeforeAll(func() {
 		if _, exists := os.LookupEnv("NON_LINUX_ENV"); !exists {
@@ -112,7 +112,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", func() {
 	})
 })
 
-var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", func() {
+var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("platform-alteration-sysctl-config", func() {
+var _ = Describe("platform-alteration-sysctl-config", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("platform-alteration-tainted-node-kernel", func() {
+var _ = Describe("platform-alteration-tainted-node-kernel", Serial, func() {
 
 	BeforeEach(func() {
 		By("Clean namespace before each test")


### PR DESCRIPTION
Adding `Serial` to the `Describe` sections of ginkgo blocks for future parallel runs to be enabled.  Adding the `Serial` flag to these blocks prevents them from running in parallel if `-p` is enabled (in the future it will be).

https://onsi.github.io/ginkgo/#serial-specs

When we enable parallel runs, it will be as easy as remove the `Serial` from the `Describe` line once we get the individual test suites setup to run in parallel. 