### PR TITLE
Enable parallel networking suite

### DIFF
--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -26,16 +26,16 @@ import (
 )
 
 // DefineAndCreateDeploymentOnCluster defines deployment resource and creates it on cluster.
-func DefineAndCreateDeploymentOnCluster(replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, tsparams.TestNetworkingNameSpace,
+func DefineAndCreateDeploymentOnCluster(replicaNumber int32, namespace string) error {
+	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, namespace,
 		replicaNumber, false, nil, nil)
 
 	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
 // DefineAndCreateDeploymentWithMultusOnCluster defines deployment resource and creates it on cluster.
-func DefineAndCreateDeploymentWithMultusOnCluster(name string, nadNames []string, replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(name, tsparams.TestNetworkingNameSpace,
+func DefineAndCreateDeploymentWithMultusOnCluster(name, namespace string, nadNames []string, replicaNumber int32) error {
+	deploymentUnderTest := defineDeploymentBasedOnArgs(name, namespace,
 		replicaNumber, true, nadNames, nil)
 
 	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
@@ -43,9 +43,9 @@ func DefineAndCreateDeploymentWithMultusOnCluster(name string, nadNames []string
 
 // DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster defines deployment resource and creates it on cluster.
 func DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
-	name string, nadNames []string, replicaNumber int32) error {
+	name, namespace string, nadNames []string, replicaNumber int32) error {
 	deploymentUnderTest := defineDeploymentBasedOnArgs(
-		name, tsparams.TestNetworkingNameSpace,
+		name, namespace,
 		replicaNumber,
 		false,
 		nadNames,
@@ -55,8 +55,8 @@ func DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
 }
 
 // DefineAndCreatePrivilegedDeploymentOnCluster defines deployment resource and creates it on cluster.
-func DefineAndCreatePrivilegedDeploymentOnCluster(replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, tsparams.TestNetworkingNameSpace,
+func DefineAndCreatePrivilegedDeploymentOnCluster(replicaNumber int32, namespace string) error {
+	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, namespace,
 		replicaNumber, true,
 		nil, nil)
 
@@ -64,8 +64,8 @@ func DefineAndCreatePrivilegedDeploymentOnCluster(replicaNumber int32) error {
 }
 
 // DefineAndCreateDeploymentWithSkippedLabelOnCluster defines deployment resource and creates it on cluster.
-func DefineAndCreateDeploymentWithSkippedLabelOnCluster(replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, tsparams.TestNetworkingNameSpace,
+func DefineAndCreateDeploymentWithSkippedLabelOnCluster(replicaNumber int32, namespace string) error {
+	deploymentUnderTest := defineDeploymentBasedOnArgs(tsparams.TestDeploymentAName, namespace,
 		replicaNumber,
 		true, nil, tsparams.NetworkingTestSkipLabel)
 
@@ -84,24 +84,24 @@ func DefineAndCreateDeploymentWithNamespace(namespace string, replicaNumber int3
 	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
-func DefineAndCreateDeployment(deploymentName string, replicaNumber int32) error {
-	deploymentUnderTest := defineDeploymentBasedOnArgs(deploymentName, tsparams.TestNetworkingNameSpace,
+func DefineAndCreateDeployment(deploymentName, namespace string, replicaNumber int32) error {
+	deploymentUnderTest := defineDeploymentBasedOnArgs(deploymentName, namespace,
 		replicaNumber, false, nil, nil)
 
 	return globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentUnderTest, tsparams.WaitingTime)
 }
 
-func DefineAndCreateDaemonsetWithMultusOnCluster(nadName string) error {
-	return defineDaemonSetBasedOnArgs(nadName, nil)
+func DefineAndCreateDaemonsetWithMultusOnCluster(nadName, namespace, daemonsetName string) error {
+	return defineDaemonSetBasedOnArgs(nadName, namespace, daemonsetName, nil)
 }
 
-func DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(nadName string) error {
-	return defineDaemonSetBasedOnArgs(nadName, tsparams.NetworkingTestMultusSkipLabel)
+func DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(nadName, namespace, daemonsetName string) error {
+	return defineDaemonSetBasedOnArgs(nadName, namespace, daemonsetName, tsparams.NetworkingTestMultusSkipLabel)
 }
 
 // DefineAndCreateDeploymentOnCluster defines deployment resource and creates it on cluster.
-func DefineAndCreateDeploymentWithContainerPorts(replicaNumber int32, ports []corev1.ContainerPort) error {
-	deploymentUnderTest, err := DefineDeploymentWithContainers(replicaNumber, len(ports), tsparams.TestDeploymentAName)
+func DefineAndCreateDeploymentWithContainerPorts(replicaNumber int32, ports []corev1.ContainerPort, namespace string) error {
+	deploymentUnderTest, err := DefineDeploymentWithContainers(replicaNumber, len(ports), tsparams.TestDeploymentAName, namespace)
 	if err != nil {
 		return err
 	}
@@ -114,12 +114,12 @@ func DefineAndCreateDeploymentWithContainerPorts(replicaNumber int32, ports []co
 }
 
 // ExecCmdOnOnePodInNamespace runs command on the first available pod in namespace.
-func ExecCmdOnOnePodInNamespace(command []string) error {
-	return execCmdOnPodsListInNamespace(command, "first")
+func ExecCmdOnOnePodInNamespace(command []string, namespace string) error {
+	return execCmdOnPodsListInNamespace(command, "first", namespace)
 }
 
-func ExecCmdOnAllPodInNamespace(command []string) error {
-	return execCmdOnPodsListInNamespace(command, "all")
+func ExecCmdOnAllPodInNamespace(command []string, namespace string) error {
+	return execCmdOnPodsListInNamespace(command, "all", namespace)
 }
 
 func RedefineServiceToHeadless(service *corev1.Service) {
@@ -127,14 +127,14 @@ func RedefineServiceToHeadless(service *corev1.Service) {
 }
 
 // DefineAndCreateServiceOnCluster defines service resource and creates it on cluster.
-func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, withNodePort, headless bool,
+func DefineAndCreateServiceOnCluster(name, namespace string, port int32, targetPort int32, withNodePort, headless bool,
 	ipFams []corev1.IPFamily, ipFamPolicy string) error {
 	var testService *corev1.Service
 
 	if ipFamPolicy == "" {
 		testService = service.DefineService(
 			name,
-			tsparams.TestNetworkingNameSpace,
+			namespace,
 			port,
 			targetPort,
 			corev1.ProtocolTCP,
@@ -146,7 +146,7 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 
 		testService = service.DefineService(
 			name,
-			tsparams.TestNetworkingNameSpace,
+			namespace,
 			port,
 			targetPort,
 			corev1.ProtocolTCP,
@@ -168,7 +168,7 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 		RedefineServiceToHeadless(testService)
 	}
 
-	_, err := globalhelper.GetAPIClient().Services(tsparams.TestNetworkingNameSpace).Create(
+	_, err := globalhelper.GetAPIClient().Services(namespace).Create(
 		context.TODO(),
 		testService, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -180,8 +180,8 @@ func DefineAndCreateServiceOnCluster(name string, port int32, targetPort int32, 
 	return nil
 }
 
-func DefineAndCreateNadOnCluster(name string, network string) error {
-	nadOneInterface := nad.DefineNad(name, tsparams.TestNetworkingNameSpace)
+func DefineAndCreateNadOnCluster(name, namespace string, network string) error {
+	nadOneInterface := nad.DefineNad(name, namespace)
 
 	if network != "" {
 		nadOneInterface = nad.RedefineNadWithWhereaboutsIpam(nadOneInterface, network)
@@ -198,13 +198,13 @@ func DefineAndCreateNadOnCluster(name string, network string) error {
 	return nil
 }
 
-func GetClusterMultusInterfaces() ([]string, error) {
-	err := defineAndCreatePrivilegedDaemonset()
+func GetClusterMultusInterfaces(namespace string) ([]string, error) {
+	err := defineAndCreatePrivilegedDaemonset(namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.TestNetworkingNameSpace)
+	podsList, err := globalhelper.GetListOfPodsInNamespace(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -317,12 +317,12 @@ func defineDeploymentBasedOnArgs(
 }
 
 func DefineDeploymentWithContainers(replica int32, containers int,
-	name string) (*appsv1.Deployment, error) {
+	name, namespace string) (*appsv1.Deployment, error) {
 	if containers < 1 {
 		return nil, errors.New("invalid containers number")
 	}
 
-	deploymentStruct := defineDeploymentBasedOnArgs(name, tsparams.TestNetworkingNameSpace, replica, false, nil, nil)
+	deploymentStruct := defineDeploymentBasedOnArgs(name, namespace, replica, false, nil, nil)
 
 	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, globalhelper.GetConfiguration().General.TestImage)
 	deployment.RedefineWithReplicaNumber(deploymentStruct, replica)
@@ -330,9 +330,9 @@ func DefineDeploymentWithContainers(replica int32, containers int,
 	return deploymentStruct, nil
 }
 
-func defineDaemonSetBasedOnArgs(nadName string, labels map[string]string) error {
-	testDaemonset := daemonset.DefineDaemonSet(tsparams.TestNetworkingNameSpace,
-		globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels, "daemonsetnetworkingput")
+func defineDaemonSetBasedOnArgs(nadName, namespace, daemonsetName string, labels map[string]string) error {
+	testDaemonset := daemonset.DefineDaemonSet(namespace,
+		globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels, daemonsetName)
 	daemonset.RedefineWithMultus(testDaemonset, nadName)
 	//nolint:lll
 	daemonset.RedefineDaemonSetWithNodeSelector(testDaemonset, map[string]string{globalhelper.GetConfiguration().General.CnfNodeLabel: ""})
@@ -344,8 +344,8 @@ func defineDaemonSetBasedOnArgs(nadName string, labels map[string]string) error 
 	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(testDaemonset, tsparams.WaitingTime)
 }
 
-func defineAndCreatePrivilegedDaemonset() error {
-	daemonSet := daemonset.DefineDaemonSet(tsparams.TestNetworkingNameSpace, globalhelper.GetConfiguration().General.TestImage,
+func defineAndCreatePrivilegedDaemonset(namespace string) error {
+	daemonSet := daemonset.DefineDaemonSet(namespace, globalhelper.GetConfiguration().General.TestImage,
 		tsparams.TestDeploymentLabels, "daemonsetnetworkingput")
 	daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{globalhelper.GetConfiguration().General.WorkerNodeLabel: ""})
 	daemonset.RedefineWithPrivilegeAndHostNetwork(daemonSet)
@@ -358,8 +358,8 @@ func defineAndCreatePrivilegedDaemonset() error {
 	return nil
 }
 
-func execCmdOnPodsListInNamespace(command []string, execOn string) error {
-	runningTestPods, err := globalhelper.GetAPIClient().Pods(tsparams.TestNetworkingNameSpace).List(
+func execCmdOnPodsListInNamespace(command []string, execOn, namespace string) error {
+	runningTestPods, err := globalhelper.GetAPIClient().Pods(namespace).List(
 		context.TODO(),
 		metav1.ListOptions{})
 	if err != nil {
@@ -409,12 +409,13 @@ func createContainerSpecsFromContainerPorts(ports []corev1.ContainerPort) []core
 	return containerSpecs
 }
 
-func DefineDeploymentWithContainerPorts(name string, replicaNumber int32, ports []corev1.ContainerPort) (*appsv1.Deployment, error) {
+func DefineDeploymentWithContainerPorts(name, namespace string,
+	replicaNumber int32, ports []corev1.ContainerPort) (*appsv1.Deployment, error) {
 	if len(ports) < 1 {
 		return nil, errors.New("invalid number of containers")
 	}
 
-	deploymentStruct := deployment.DefineDeployment(name, tsparams.TestNetworkingNameSpace,
+	deploymentStruct := deployment.DefineDeployment(name, namespace,
 		globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 	globalhelper.AppendContainersToDeployment(deploymentStruct, len(ports)-1, globalhelper.GetConfiguration().General.TestImage)

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
@@ -11,57 +10,69 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking custom namespace, custom deployment,", Serial, func() {
-
+var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
 		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
 	}
 
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
-		Expect(err).ToNot(HaveOccurred())
-	})
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Clean namespace after each test")
-		err = namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
+
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 45440
 	It("3 custom pods on Default network networking-icmpv4-connectivity", func() {
 		By("Define deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -80,11 +91,11 @@ var _ = Describe("Networking custom namespace, custom deployment,", Serial, func
 	// 45441
 	It("custom daemonset, 4 custom pods on Default network", func() {
 		By("Define deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentOnCluster(2)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(2, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.TestNetworkingNameSpace, configSuite.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(randomNamespace, configSuite.General.TestImage,
 			tsparams.TestDeploymentLabels, "daemonsetnetworkingput")
 		daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{configSuite.General.CnfNodeLabel: ""})
 
@@ -109,11 +120,11 @@ var _ = Describe("Networking custom namespace, custom deployment,", Serial, func
 	It("3 custom pods on Default network networking-icmpv4-connectivity fail when "+
 		"one pod is disconnected [negative]", func() {
 		By("Define deployment and create it on cluster")
-		err = tshelper.DefineAndCreatePrivilegedDeploymentOnCluster(2)
+		err := tshelper.DefineAndCreatePrivilegedDeploymentOnCluster(2, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Close communication between deployment pods")
-		podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.TestNetworkingNameSpace)
+		podsList, err := globalhelper.GetListOfPodsInNamespace(randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		for index := range podsList.Items {
@@ -141,12 +152,12 @@ var _ = Describe("Networking custom namespace, custom deployment,", Serial, func
 	It("2 custom pods on Default network networking-icmpv4-connectivity skip when label "+
 		"test-network-function.com/skip_connectivity_tests is set in deployment [skip]", func() {
 		By("Define deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
+		err := tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove ping binary from test pod")
 		err = tshelper.ExecCmdOnOnePodInNamespace(
-			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"})
+			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -166,16 +177,16 @@ var _ = Describe("Networking custom namespace, custom deployment,", Serial, func
 	It("custom daemonset, 4 custom pods on Default network networking-icmpv4-connectivity pass when label "+
 		"test-network-function.com/skip_connectivity_tests is set in deployment only", func() {
 		By("Define deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2)
+		err := tshelper.DefineAndCreateDeploymentWithSkippedLabelOnCluster(2, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Remove ping binary from test pod")
 		err = tshelper.ExecCmdOnAllPodInNamespace(
-			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"})
+			[]string{"rm", "-rf", "/usr/bin/ping", "/usr/sbin/ping"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonSet")
-		daemonSet := daemonset.DefineDaemonSet(tsparams.TestNetworkingNameSpace, configSuite.General.TestImage,
+		daemonSet := daemonset.DefineDaemonSet(randomNamespace, configSuite.General.TestImage,
 			tsparams.TestDeploymentLabels, "daemonsetnetworkingput")
 		daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{configSuite.General.CnfNodeLabel: ""})
 

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -2,73 +2,71 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking dual-stack-service,", Serial, func() {
-
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
-
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Networking dual-stack-service,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 62506
 	It("service with ipFamilyPolicy SingleStack and ip version ipv4 [negative]", func() {
 
 		By("Define and create service")
-		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, false,
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", randomNamespace, 3022, 3022, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -89,7 +87,8 @@ var _ = Describe("Networking dual-stack-service,", Serial, func() {
 	It("service with ipFamilyPolicy PreferDualStack and zero ClusterIPs [negative]", func() {
 
 		By("Define and create service")
-		err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, true, []corev1.IPFamily{"IPv4"}, "PreferDualStack")
+		err := tshelper.DefineAndCreateServiceOnCluster("testservice", randomNamespace, 3023, 3023,
+			false, true, []corev1.IPFamily{"IPv4"}, "PreferDualStack")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -111,7 +110,8 @@ var _ = Describe("Networking dual-stack-service,", Serial, func() {
 		func() {
 
 			By("Define and create service")
-			err := tshelper.DefineAndCreateServiceOnCluster("testservice", 3022, 3022, false, false, []corev1.IPFamily{"IPv4"}, "")
+			err := tshelper.DefineAndCreateServiceOnCluster("testservice", randomNamespace, 3024,
+				3024, false, false, []corev1.IPFamily{"IPv4"}, "")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Start tests")

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -1,13 +1,10 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
@@ -20,24 +17,11 @@ var _ = Describe("Networking dual-stack-service,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -47,19 +31,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	// 62506

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -3,67 +3,74 @@ package tests
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking custom namespace,", Serial, func() {
-
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
-
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Networking custom namespace,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
+
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 48328
 	It("custom deployment 3 pods, 1 NAD, connectivity via Multus secondary interface", func() {
 		By("Define and create Network-attachment-definition")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -86,18 +93,18 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 		// see https://github.com/test-network-function/cnfcert-tests-verification/pull/263
 
 		By("Define and create Network-attachment-definition")
-		err = tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+		err := tshelper.DefineAndCreateNadOnCluster(
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define first deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -117,21 +124,21 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 	It("custom deployment and daemonset 3 pods, 2 NADs, connectivity via Multus secondary interfaces", func() {
 		By("Define and create Network-attachment-definition")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameB, tsparams.TestIPamIPNetworkB)
+			tsparams.TestNadNameB, randomNamespace, tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define first deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameB}, 3)
+			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -150,12 +157,12 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 	// 48334
 	It("custom deployment 3 pods, 1 NAD missing IP, connectivity via Multus secondary interface[skip]", func() {
 		By("Define and create Network-attachment-definition")
-		err := tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameA, "")
+		err := tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameA, randomNamespace, "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -176,20 +183,20 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create Network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, "")
+		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, randomNamespace, "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment-a and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 1)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment-b and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentBName, []string{tsparams.TestNadNameB}, 3)
+			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -211,20 +218,20 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, "")
+		err = tshelper.DefineAndCreateNadOnCluster(tsparams.TestNadNameB, randomNamespace, "")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
 
-		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds1")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -245,11 +252,11 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds2")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -270,16 +277,16 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds3")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -300,16 +307,16 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds4")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -330,16 +337,16 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameB, tsparams.TestIPamIPNetworkB)
+			tsparams.TestNadNameB, randomNamespace, tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA, tsparams.TestNadNameB}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA, tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -361,16 +368,16 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create Network-attachment-definition")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Put one deployment's pod  interface down")
-		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		By("Put one deployment's pod interface down")
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -391,24 +398,24 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 		"interface[negative]", func() {
 
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameB, tsparams.TestIPamIPNetworkB)
+			tsparams.TestNadNameB, randomNamespace, tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Put one deployment's pod interface down")
-		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds5")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -430,24 +437,24 @@ var _ = Describe("Networking custom namespace,", Serial, func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameA, tsparams.TestIPamIPNetworkA)
+			tsparams.TestNadNameA, randomNamespace, tsparams.TestIPamIPNetworkA)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tshelper.DefineAndCreateNadOnCluster(
-			tsparams.TestNadNameB, tsparams.TestIPamIPNetworkB)
+			tsparams.TestNadNameB, randomNamespace, tsparams.TestIPamIPNetworkB)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
-			tsparams.TestDeploymentAName, []string{tsparams.TestNadNameB, tsparams.TestNadNameA}, 3)
+			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameB, tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Put one deployment's pod interface down")
-		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"})
+		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define daemonset and create it on cluster")
-		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB)
+		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds6")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -1,13 +1,10 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
@@ -19,24 +16,11 @@ var _ = Describe("Networking custom namespace,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -46,19 +30,7 @@ var _ = Describe("Networking custom namespace,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	// 48328

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
@@ -19,24 +17,11 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -46,19 +31,7 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	// 59740

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -2,82 +2,75 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
-
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
-
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Create additional namespaces for testing")
-		// this namespace will only be used for the networking-network-policy-deny-all tests
-		err = namespaces.Create(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Networking network-policy-deny-all,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespaces before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespaces after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = namespaces.Clean(tsparams.AdditionalNetworkingNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 59740
 	It("one deployment, one pod in a namespace with deny all ingress and egress network policy", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define and create network policy")
 		err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
-			tsparams.TestNetworkingNameSpace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+			randomNamespace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -98,12 +91,12 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 	It("one deployment, one pod in a namespace with only deny all ingress network policy [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define and create network policy")
 		err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
-			tsparams.TestNetworkingNameSpace, []string{"Ingress"}, tsparams.TestDeploymentLabels)
+			randomNamespace, []string{"Ingress"}, tsparams.TestDeploymentLabels)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -124,12 +117,12 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 	It("one deployment, one pod in a namespace with only deny all egress network policy [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define and create network policy")
 		err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
-			tsparams.TestNetworkingNameSpace, []string{"Egress"}, tsparams.TestDeploymentLabels)
+			randomNamespace, []string{"Egress"}, tsparams.TestDeploymentLabels)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -149,7 +142,7 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 	It("one deployment, one pod in a namespace with neither deny all ingress or egress network policy [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -171,26 +164,31 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 		func() {
 
 			By("Define first deployment and create it on cluster")
-			err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+			err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define and create first network policy")
 			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
-				tsparams.TestNetworkingNameSpace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+				randomNamespace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create additional namespaces for testing")
+			randomSecondaryNamespace := tsparams.AdditionalNetworkingNamespace + "-" + globalhelper.GenerateRandomString(5)
+			err = namespaces.Create(randomSecondaryNamespace, globalhelper.GetAPIClient())
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define second deployment and create it on cluster")
-			err = tshelper.DefineAndCreateDeploymentWithNamespace(tsparams.AdditionalNetworkingNamespace, 1)
+			err = tshelper.DefineAndCreateDeploymentWithNamespace(randomSecondaryNamespace, 1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define and create second network policy")
-			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy2",
-				tsparams.AdditionalNetworkingNamespace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
+				randomSecondaryNamespace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define TNF config file")
 			err = globalhelper.DefineTnfConfig(
-				[]string{tsparams.TestNetworkingNameSpace, tsparams.AdditionalNetworkingNamespace},
+				[]string{randomNamespace, randomSecondaryNamespace},
 				[]string{tsparams.TestPodLabel},
 				[]string{},
 				[]string{},
@@ -208,6 +206,14 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 				tsparams.TnfNetworkPolicyDenyAllTcName,
 				globalparameters.TestCasePassed)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Delete additional namespaces")
+			err = namespaces.DeleteAndWait(
+				globalhelper.GetAPIClient().CoreV1Interface,
+				randomSecondaryNamespace,
+				tsparams.WaitingTime,
+			)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 	// 59745
@@ -215,21 +221,35 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 		func() {
 
 			By("Define first deployment and create it on cluster")
-			err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+			err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define and create first network policy")
 			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
-				tsparams.TestNetworkingNameSpace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+				randomNamespace, []string{"Ingress", "Egress"}, tsparams.TestDeploymentLabels)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create additional namespaces for testing")
+			randomSecondaryNamespace := tsparams.AdditionalNetworkingNamespace + "-" + globalhelper.GenerateRandomString(5)
+			err = namespaces.Create(randomSecondaryNamespace, globalhelper.GetAPIClient())
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define second deployment and create it on cluster")
-			err = tshelper.DefineAndCreateDeploymentWithNamespace(tsparams.AdditionalNetworkingNamespace, 1)
+			err = tshelper.DefineAndCreateDeploymentWithNamespace(randomSecondaryNamespace, 1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Define and create second network policy")
-			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy2",
-				tsparams.AdditionalNetworkingNamespace, []string{"Egress"}, tsparams.TestDeploymentLabels)
+			err = tshelper.DefineAndCreateNetworkPolicy("netpolicy1",
+				randomSecondaryNamespace, []string{"Egress"}, tsparams.TestDeploymentLabels)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Define TNF config file")
+			err = globalhelper.DefineTnfConfig(
+				[]string{randomNamespace, randomSecondaryNamespace},
+				[]string{tsparams.TestPodLabel},
+				[]string{},
+				[]string{},
+				[]string{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Start tests")
@@ -242,6 +262,14 @@ var _ = Describe("Networking network-policy-deny-all,", Serial, func() {
 			err = globalhelper.ValidateIfReportsAreValid(
 				tsparams.TnfNetworkPolicyDenyAllTcName,
 				globalparameters.TestCaseFailed)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Delete additional namespaces")
+			err = namespaces.DeleteAndWait(
+				globalhelper.GetAPIClient().CoreV1Interface,
+				randomSecondaryNamespace,
+				tsparams.WaitingTime,
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 		})

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -2,67 +2,71 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
-
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
-
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
+
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 59536
 	It("one deployment, one pod, one container not declaring reserved ports", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -83,7 +87,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	It("one deployment, one pod, one container declaring reserved ports [negative]", func() {
 
 		By("Define and create deployment with container declaring reserved port")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22623}})
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22623}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -101,12 +105,15 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	})
 
 	// 59538
-	It("one deployment, one pod, two containers, neither declaring reserved ports", func() {
+	It("one deployment, one pod, two containers, neither declaring reserved ports 22222 and 22223", func() {
 
 		By("Define deployment with two containers")
 		ports := []corev1.ContainerPort{{ContainerPort: 22222}, {ContainerPort: 22223}}
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports)
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
+
+		// By("Sleep for 5 minutes")
+		// time.Sleep(5 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -126,7 +133,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 		ports := []corev1.ContainerPort{{ContainerPort: 22222}, {ContainerPort: 22623}}
 
 		By("Define deployment with two containers")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports)
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -144,10 +151,10 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	})
 
 	// 59540
-	It("one deployment, one pod not listening on reserved ports", func() {
+	It("one deployment, one pod not listening on reserved ports (OCP Ports)", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -167,11 +174,11 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	It("one deployment, one pod listening on reserved ports [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22624}})
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22624}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", randomNamespace, 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -193,11 +200,11 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	It("two deployments, one pod each not listening on reserved ports", func() {
 
 		By("Define first deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, 3)
+		err = tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, randomNamespace, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -218,15 +225,15 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 	It("two deployments, one pod each, one listening on reserved ports [negative]", func() {
 
 		By("Define first deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, 3)
+		err := tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, randomNamespace, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22624}})
+		err = tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 22624}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", randomNamespace, 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -241,7 +248,5 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", Serial, func() {
 			tsparams.TnfOcpReservedPortsUsageTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
-
 })

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -1,13 +1,10 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
@@ -20,24 +17,11 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -47,19 +31,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	// 59536
@@ -111,9 +83,6 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		ports := []corev1.ContainerPort{{ContainerPort: 22222}, {ContainerPort: 22223}}
 		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
-
-		// By("Sleep for 5 minutes")
-		// time.Sleep(5 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -2,67 +2,71 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
-
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
-
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Networking reserved-partner-ports,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
+
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 61487
 	It("one deployment, one pod, one container not declaring reserved ports", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(1)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(1, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -83,7 +87,7 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 	It("one deployment, one pod, one container declaring reserved ports [negative]", func() {
 
 		By("Define and create deployment with container declaring reserved port")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15443}})
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15443}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -101,12 +105,15 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 	})
 
 	// 61506
-	It("one deployment, one pod, two containers, neither declaring reserved ports", func() {
+	It("one deployment, one pod, two containers, neither declaring reserved ports 15002 and 15007", func() {
 
 		By("Define deployment with two containers")
 		ports := []corev1.ContainerPort{{ContainerPort: 15002}, {ContainerPort: 15007}}
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports)
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
+
+		// By("Sleep for 5 minutes")
+		// time.Sleep(5 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -126,7 +133,7 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 		ports := []corev1.ContainerPort{{ContainerPort: 15020}, {ContainerPort: 15019}}
 
 		By("Define deployment with two containers")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports)
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -144,10 +151,10 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 	})
 
 	// 61508
-	It("one deployment, one pod not listening on reserved ports", func() {
+	It("one deployment, one pod not listening on reserved ports (Reserved Partner Ports)", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -167,11 +174,11 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 	It("one deployment, one pod listening on reserved ports [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15021}})
+		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15021}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", randomNamespace, 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -186,18 +193,17 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	// 61510
 	It("two deployments, one pod each not listening on reserved ports", func() {
 
 		By("Define first deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeploymentOnCluster(3)
+		err := tshelper.DefineAndCreateDeploymentOnCluster(3, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, 3)
+		err = tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, randomNamespace, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -211,22 +217,21 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	// 61517
 	It("two deployments, one pod each, one listening on reserved ports [negative]", func() {
 
 		By("Define first deployment and create it on cluster")
-		err := tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, 3)
+		err := tshelper.DefineAndCreateDeployment(tsparams.TestDeploymentBName, randomNamespace, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define second deployment and create it on cluster")
-		err = tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15090}})
+		err = tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15090}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define service and create it on cluster")
-		err = tshelper.DefineAndCreateServiceOnCluster("test-service", 22624, 22624, false, false,
+		err = tshelper.DefineAndCreateServiceOnCluster("test-service", randomNamespace, 22624, 22624, false, false,
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -241,7 +246,5 @@ var _ = Describe("Networking reserved-partner-ports,", Serial, func() {
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
-
 })

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -1,13 +1,10 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
@@ -20,24 +17,11 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -47,19 +31,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	// 61487
@@ -111,9 +83,6 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		ports := []corev1.ContainerPort{{ContainerPort: 15002}, {ContainerPort: 15007}}
 		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(2, ports, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
-
-		// By("Sleep for 5 minutes")
-		// time.Sleep(5 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -2,57 +2,72 @@ package tests
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/networking/parameters"
 )
 
-var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() {
+var _ = Describe("Networking undeclared-container-ports-usage,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	configSuite, err := config.NewConfig()
-	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
-	}
+	BeforeEach(func() {
+		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
 
-	execute.BeforeAll(func() {
-		By("Clean namespace before all tests")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(globalparameters.PartnerNamespaceEnvVarName, tsparams.TestNetworkingNameSpace)
+
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
+
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestNetworkingNameSpace, globalhelper.GetAPIClient())
+	AfterEach(func() {
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
 
-		By("Ensure all nodes are labeled with 'worker-cnf' label")
-		err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
-		Expect(err).ToNot(HaveOccurred())
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	It("one deployment, one pod, container declares and uses port 8080", func() {
 
 		By("Define deployment and create it on cluster")
-		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", 1, []corev1.ContainerPort{{ContainerPort: 8080}})
+		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 1,
+			[]corev1.ContainerPort{{ContainerPort: 8080}})
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -77,7 +92,8 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 	It("one deployment, one pod, container declares port 8081 but does not use any", func() {
 
 		By("Define deployment and create it on cluster")
-		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", 1, []corev1.ContainerPort{{ContainerPort: 8081}})
+		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 1,
+			[]corev1.ContainerPort{{ContainerPort: 8081}})
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
@@ -100,7 +116,8 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 	It("one deployment, one pod, container declares port 8081 but uses port 8080 instead [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", 1, []corev1.ContainerPort{{ContainerPort: 8081}})
+		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 1,
+			[]corev1.ContainerPort{{ContainerPort: 8081}})
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -119,13 +136,12 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("one deployment, one pod, container uses port 8080 but does not declare any [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		dep, err := tshelper.DefineDeploymentWithContainers(1, 1, "networking-deployment")
+		dep, err := tshelper.DefineDeploymentWithContainers(1, 1, "networking-deployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -144,14 +160,13 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("one deployment, one pod, two containers, both containers declare used ports (8080, 8081)", func() {
 
 		By("Define deployment and create it on cluster")
 		ports := []corev1.ContainerPort{{ContainerPort: 8080}, {ContainerPort: 8081}}
-		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", 1, ports)
+		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 1, ports)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -174,7 +189,6 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	//nolint:lll
@@ -182,7 +196,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 
 		By("Define deployment and create it on cluster")
 		ports := []corev1.ContainerPort{{ContainerPort: 8080}, {ContainerPort: 8082}}
-		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", 2, ports)
+		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 2, ports)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -205,13 +219,12 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("one deployment, one pod, two containers, the second container uses port 8080 but does not declare any [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		dep, err := tshelper.DefineDeploymentWithContainers(1, 2, "networking-deployment")
+		dep, err := tshelper.DefineDeploymentWithContainers(1, 2, "networking-deployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 1, []string{})
 		Expect(err).ToNot(HaveOccurred())
@@ -230,7 +243,5 @@ var _ = Describe("Networking undeclared-container-ports-usage,", Serial, func() 
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
-
 })

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -1,14 +1,11 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/networking/helper"
@@ -21,24 +18,11 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.TestNetworkingNameSpace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.TestNetworkingNameSpace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -48,19 +32,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	It("one deployment, one pod, container declares and uses port 8080", func() {


### PR DESCRIPTION
Enables parallel runs in the `networking` suite!  🎉   This brings the amount of time to run the networking suite down from 30 minutes to ~80 seconds.  🤯 

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/12730045-853e-45d9-a913-39c7c462c3fd)


Notable changes for reviewers:
- Added a function in the `globalhelper` package named `GenerateRandomString` which helps randomize the namespaces in which the resources are deployed into.
- Added the `-p` to the calls to ginkgo in `scripts/run-tests.sh`.  This enables the parallel running.  Follow-up to #444.
- Added `OverrideReportDir` and `OverrideTnfConfigDir` funcs for overriding the default directories on the machine running the QE tests.
- Moved the `"Ensure all nodes are labeled with 'worker-cnf' label"` step to the `BeforeSuite` block for organization.