### PR TITLE
Enable parallel manageability suite

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -27,7 +27,7 @@ function run_tests {
 			fi
 		done
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
+		ginkgo -timeout=24h -v -p --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
 		;;
 	features)
 		if [ -z "$FEATURES" ]; then
@@ -44,7 +44,7 @@ function run_tests {
 		done
 
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
+		ginkgo -timeout=24h -v -p --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
 		;;
 	*)
 		echo "Unknown case"

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	appsv1 "k8s.io/api/apps/v1"
@@ -360,4 +362,20 @@ func CopyFiles(src string, dst string) error {
 	}
 
 	return nil
+}
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func GenerateRandomString(length int) string {
+	charset := "abcdefghijklmnopqrstuvwxyz"
+
+	//nolint:varnamelen
+	b := make([]byte, length)
+
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+
+	return string(b)
 }

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -12,6 +12,26 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/container"
 )
 
+// OverrideReportDir overrides the report directory.
+func OverrideReportDir(reportDir string) {
+	err := os.MkdirAll(reportDir, os.ModePerm)
+	if err != nil {
+		glog.Error("could not create dest directory= %s, err=%s", reportDir, err)
+	}
+
+	GetConfiguration().General.TnfReportDir = reportDir
+}
+
+// OverrideTnfConfigDir overrides the TNF config directory.
+func OverrideTnfConfigDir(configDir string) {
+	err := os.MkdirAll(configDir, os.ModePerm)
+	if err != nil {
+		glog.Error("could not create dest directory= %s, err=%s", configDir, err)
+	}
+
+	GetConfiguration().General.TnfConfigDir = configDir
+}
+
 // LaunchTests stats tests based on given parameters.
 func LaunchTests(testCaseName string, tcNameForReport string) error {
 	containerEngine, err := container.SelectEngine()

--- a/tests/manageability/manageability_suite_test.go
+++ b/tests/manageability/manageability_suite_test.go
@@ -4,18 +4,15 @@ package performance
 
 import (
 	"flag"
-	"fmt"
 	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 
-	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/manageability/parameters"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/manageability/tests"
 
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
 func TestManageability(t *testing.T) {
@@ -28,34 +25,3 @@ func TestManageability(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CNFCert performance tests", reporterConfig)
 }
-
-var _ = BeforeSuite(func() {
-
-	By("Create namespace")
-	err := namespaces.Create(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Define TNF config file")
-	err = globalhelper.DefineTnfConfig(
-		[]string{tsparams.ManageabilityNamespace},
-		[]string{tsparams.TestPodLabel},
-		[]string{},
-		[]string{},
-		[]string{})
-	Expect(err).ToNot(HaveOccurred())
-})
-
-var _ = AfterSuite(func() {
-
-	By(fmt.Sprintf("Remove %s namespace", tsparams.ManageabilityNamespace))
-	err := namespaces.DeleteAndWait(
-		globalhelper.GetAPIClient().CoreV1Interface,
-		tsparams.ManageabilityNamespace,
-		tsparams.WaitingTime,
-	)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Remove reports from reports directory")
-	err = globalhelper.RemoveContentsFromReportDir()
-	Expect(err).ToNot(HaveOccurred())
-})

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -1,15 +1,12 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/manageability/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/manageability/parameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
 var _ = Describe("manageability-container-port-name", func() {
@@ -18,24 +15,11 @@ var _ = Describe("manageability-container-port-name", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.ManageabilityNamespace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.ManageabilityNamespace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -45,19 +29,7 @@ var _ = Describe("manageability-container-port-name", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	It("One pod with valid port name", func() {

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
@@ -10,24 +12,58 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("manageability-container-port-name", Serial, func() {
+var _ = Describe("manageability-container-port-name", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
+		randomNamespace = tsparams.ManageabilityNamespace + "-" + globalhelper.GenerateRandomString(10)
+
+		By(fmt.Sprintf("Create %s namespace", randomNamespace))
+		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Override default report directory")
+		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
+		reportDir := origReportDir + "/" + randomNamespace
+		globalhelper.OverrideReportDir(reportDir)
+
+		By("Override default TNF config directory")
+		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
+		configDir := origTnfConfigDir + "/" + randomNamespace
+		globalhelper.OverrideTnfConfigDir(configDir)
+
+		By("Define TNF config file")
+		err = globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.ManageabilityNamespace, globalhelper.GetAPIClient())
+		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
+		err := namespaces.DeleteAndWait(
+			globalhelper.GetAPIClient().CoreV1Interface,
+			randomNamespace,
+			tsparams.WaitingTime,
+		)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Restore default report directory")
+		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
+
+		By("Restore default TNF config directory")
+		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	It("One pod with valid port name", func() {
 
 		By("Define pod")
-		testPod := tshelper.DefineManageabilityPod(tsparams.TestPodName, tsparams.ManageabilityNamespace,
+		testPod := tshelper.DefineManageabilityPod(tsparams.TestPodName, randomNamespace,
 			tsparams.TestImageWithValidTag, tsparams.TnfTargetPodLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
@@ -47,7 +83,7 @@ var _ = Describe("manageability-container-port-name", Serial, func() {
 	It("One pod with invalid port name", func() {
 
 		By("Define pod")
-		testPod := tshelper.DefineManageabilityPod(tsparams.TestPodName, tsparams.ManageabilityNamespace,
+		testPod := tshelper.DefineManageabilityPod(tsparams.TestPodName, randomNamespace,
 			tsparams.TestImageWithValidTag, tsparams.TnfTargetPodLabels)
 
 		tshelper.RedefinePodWithContainerPort(testPod, 0, tsparams.InvalidPortName)

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -1,14 +1,11 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/manageability/parameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
@@ -18,24 +15,11 @@ var _ = Describe("manageability-containers-image-tag", func() {
 	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		randomNamespace = tsparams.ManageabilityNamespace + "-" + globalhelper.GenerateRandomString(10)
-
-		By(fmt.Sprintf("Create %s namespace", randomNamespace))
-		err := namespaces.Create(randomNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Override default report directory")
-		origReportDir = globalhelper.GetConfiguration().General.TnfReportDir
-		reportDir := origReportDir + "/" + randomNamespace
-		globalhelper.OverrideReportDir(reportDir)
-
-		By("Override default TNF config directory")
-		origTnfConfigDir = globalhelper.GetConfiguration().General.TnfConfigDir
-		configDir := origTnfConfigDir + "/" + randomNamespace
-		globalhelper.OverrideTnfConfigDir(configDir)
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(tsparams.ManageabilityNamespace)
 
 		By("Define TNF config file")
-		err = globalhelper.DefineTnfConfig(
+		err := globalhelper.DefineTnfConfig(
 			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
@@ -45,19 +29,7 @@ var _ = Describe("manageability-containers-image-tag", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
 	})
 
 	It("One pod with valid image tag", func() {


### PR DESCRIPTION
Enables parallel runs in the `manageability` suite.

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/8787f435-93f8-42fc-a6e1-8ec6fe04819e)

- Builds on #444 and removes the `Serial` label from these tests.
- Similar to the changes learned in #445.