### PR TITLE
Adjust func name for manageability

### DIFF
--- a/tests/manageability/manageability_suite_test.go
+++ b/tests/manageability/manageability_suite_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-func TestPerformance(t *testing.T) {
+func TestManageability(t *testing.T) {
 	_, currentFile, _, _ := runtime.Caller(0)
 	_ = flag.Lookup("logtostderr").Value.Set("true")
 	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)


### PR DESCRIPTION
`TestPerformance` --> `TestManageability`

This looks to have been a copy paste error.