### PR TITLE
Use object references instead of global variables

### DIFF
--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -72,7 +72,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
 
@@ -83,7 +83,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
-		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, tsparams.TestPVCName)
+		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, pvc.Name)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
 
@@ -118,7 +118,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Define pod")
 		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
-		pod.RedefineWithPVC(put, tsparams.TestVolumeName, tsparams.TestPVCName)
+		pod.RedefineWithPVC(put, tsparams.TestVolumeName, pvc.Name)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -143,7 +143,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
 
@@ -153,7 +153,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Define replicaSet")
 		rs := replicaset.DefineReplicaSet(tsparams.TestReplicaSetName, tsparams.LifecycleNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
-		replicaset.RedefineWithPVC(rs, tsparams.TestVolumeName, tsparams.TestPVCName)
+		replicaset.RedefineWithPVC(rs, tsparams.TestVolumeName, pvc.Name)
 
 		err = globalhelper.CreateAndWaitUntilReplicaSetIsReady(rs, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -178,7 +178,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
 
@@ -189,7 +189,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
-		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, tsparams.TestPVCName)
+		deployment.RedefineWithPVC(dep, tsparams.TestVolumeName, pvc.Name)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -214,7 +214,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
 
@@ -224,7 +224,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Define pod")
 		put := pod.DefinePod(tsparams.TestPodName, tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
-		pod.RedefineWithPVC(put, tsparams.TestVolumeName, tsparams.TestPVCName)
+		pod.RedefineWithPVC(put, tsparams.TestVolumeName, pvc.Name)
 
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolumea, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolumea.Name)
 
 		By("Define and create second pv")
 		persistentVolumeb := persistentvolume.DefinePersistentVolume("lifecycle-pvb", tsparams.LifecycleNamespace)
@@ -277,12 +277,12 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		depa := deployment.DefineDeployment(tsparams.TestDeploymentName, tsparams.LifecycleNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
-		deployment.RedefineWithPVC(depa, tsparams.TestVolumeName, tsparams.TestPVCName)
+		deployment.RedefineWithPVC(depa, tsparams.TestVolumeName, pvca.Name)
 
 		depb := deployment.DefineDeployment("lifecycle-dpb", tsparams.LifecycleNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels)
 
-		deployment.RedefineWithPVC(depb, tsparams.TestVolumeName, "lifecycle-pvcb")
+		deployment.RedefineWithPVC(depb, tsparams.TestVolumeName, pvcb.Name)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(depa, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_storage_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_storage_required_pods.go
@@ -58,17 +58,17 @@ var _ = Describe("lifecycle-storage-required-pods", Serial, func() {
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, persistentVolume.Name)
 
 		By("Define PVC")
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(persistentVolume.Name, tsparams.LifecycleNamespace)
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, tsparams.LifecycleNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define pod with a pvc")
 		testPod := tshelper.DefinePod(tsparams.TestPodName)
 
-		pod.RedefineWithPVC(testPod, tsparams.TestPVCName, tsparams.TestPVCName)
+		pod.RedefineWithPVC(testPod, persistentVolume.Name, pvc.Name)
 		err = globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -91,10 +91,10 @@ var _ = Describe("lifecycle-storage-required-pods", Serial, func() {
 		err := tshelper.CreatePersistentVolume(testPv, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		pvNames = append(pvNames, tsparams.TestPVName)
+		pvNames = append(pvNames, testPv.Name)
 
 		By("Define PVC")
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, tsparams.LifecycleNamespace)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(testPv.Name, tsparams.LifecycleNamespace)
 		persistentvolumeclaim.RedefineWithStorageClass(pvc, tsparams.TestLocalStorageClassName)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, tsparams.LifecycleNamespace, tsparams.WaitingTime, testPv.Name)
@@ -103,7 +103,7 @@ var _ = Describe("lifecycle-storage-required-pods", Serial, func() {
 		By("Define pod with a pvc")
 		testPod := tshelper.DefinePod(tsparams.TestPodName)
 
-		pod.RedefineWithPVC(testPod, tsparams.TestPVCName, tsparams.TestPVCName)
+		pod.RedefineWithPVC(testPod, testPv.Name, pvc.Name)
 		err = globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
For example, if you use `DefinePersistentVolume` and it hands you a PV object, we should use the object's `Name` field rather than the global variable parameter incase something happens (in a future PR 😉 ) to the objects themselves.