### PR TITLE
Add ENABLE_PARALLEL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following environment variables are used to configure the test setup.
 | TEST_IMAGE | Test image that is going to be used for all test resources such as deployments, daemonsets and so on. Default is quay.io/testnetworkfunction/cnf-test-partner
 | DEBUG_TNF | Generate `Debug` folder that will contain TNF suites folders with TNF logs for each test.
 | TNF_LOG_LEVEL | Log level. Default is 4
+| DISABLE_INTRUSIVE_TESTS | Turns off the intrusive tests for faster execution. Default is `false`.
+| ENABLE_PARALLEL | Enable ginkgo -p parallel flags (experimental). Default is `false`.
 
 ## Steps to run the tests
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -11,6 +11,13 @@ if [[ "${GINKGO_SEED_NUMBER}" != "" ]]; then
 	GINKGO_SEED_FLAG="--seed=${GINKGO_SEED_NUMBER}"
 fi
 
+# Check if the user has specified to run in parallel
+PFLAG=""
+if [[ ${ENABLE_PARALLEL} == "true" ]]; then
+	echo "Running tests in parallel"
+	PFLAG="-p"
+fi
+
 function run_tests {
 	case $1 in
 	all)
@@ -27,7 +34,7 @@ function run_tests {
 			fi
 		done
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
+		ginkgo -timeout=24h -v ${PFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
 		;;
 	features)
 		if [ -z "$FEATURES" ]; then
@@ -44,7 +51,7 @@ function run_tests {
 		done
 
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
+		ginkgo -timeout=24h -v ${PFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
 		;;
 	*)
 		echo "Unknown case"


### PR DESCRIPTION
Adds an environment variable that turns on parallel flag in ginkgo if its set to true.

`ENABLE_PARALLEL=true` to turn it on.

Follow up to #458 where some suites are not acting correctly when parallel is enabled by default.