### PR TITLE
Add 'manageability' to the list of suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following test features are can run selectively or altogether.
 * *accesscontrol*
 * *affiliatedcertification*
 * *lifecycle*
+* *manageability*
 * *networking*
 * *observability*
 * *platformalteration*


### PR DESCRIPTION
The README.md was missing the manageability suite.