### PR TITLE
Skip if crd-operator-scaling is not found

### DIFF
--- a/tests/lifecycle/tests/lifecycle_crd_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_crd_scaling.go
@@ -37,10 +37,14 @@ var _ = Describe("lifecycle-crd-scaling", Serial, func() {
 			[]string{tsparams.TnfTargetCrdFilters})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
+		// We have to pre-install the crd-operator-scaling resources prior to running these tests.
 		By("Check if crd-scaling-operator is installed")
 		exists, err := namespaces.Exists(tsparams.TnfTargetOperatorNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred(), "crd-scaling-operator is not installed")
-		Expect(exists).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred(), "error checking if crd-scaling-operator is installed")
+		if !exists {
+			// Skip the test if crd-scaling-operator is not installed
+			Skip("crd-scaling-operator is not installed, skipping test")
+		}
 	})
 
 	It("Crd deployed, scale in and out", func() {


### PR DESCRIPTION
Since the QE repo is not installing the `crd-operator-scaling` resources first as part of the code, we should properly skip the test since there is nothing to test against.

I added a comment to add the operator install.