### PR TITLE
Remove report dir after runs

### DIFF
--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -99,8 +99,13 @@ func BeforeEachSetupWithRandomNamespace(incomingNamespace string) (randomNamespa
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origConfigDir string, waitingTime time.Duration) {
+	By("Remove reports from report directory")
+
+	err := RemoveContentsFromReportDir()
+	Expect(err).ToNot(HaveOccurred())
+
 	By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-	err := namespaces.DeleteAndWait(
+	err = namespaces.DeleteAndWait(
 		GetAPIClient().CoreV1Interface,
 		randomNamespace,
 		waitingTime,

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -119,6 +119,12 @@ func RemoveContentsFromReportDir() error {
 			GetConfiguration().General.TnfReportDir))
 	}
 
+	// Delete the report directory
+	err = os.Remove(GetConfiguration().General.TnfReportDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove report directory: %w", err)
+	}
+
 	return nil
 }
 

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -10,7 +10,6 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/config"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
@@ -43,22 +42,6 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 
 	AfterEach(func() {
 		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
-	})
-
-	AfterEach(func() {
-		By(fmt.Sprintf("Remove %s namespace", randomNamespace))
-		err := namespaces.DeleteAndWait(
-			globalhelper.GetAPIClient().CoreV1Interface,
-			randomNamespace,
-			tsparams.WaitingTime,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Restore default report directory")
-		globalhelper.GetConfiguration().General.TnfReportDir = origReportDir
-
-		By("Restore default TNF config directory")
-		globalhelper.GetConfiguration().General.TnfConfigDir = origTnfConfigDir
 	})
 
 	// 55327


### PR DESCRIPTION
Adds the `By("Remove reports from report directory")` back to the `AfterEachCleanupWithRandomNamespace` func.

I accidentally removed this step.