### PR TITLE
removed report cleanup from BeforeEach and AfterEach of nodeport service tests

### DIFF
--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -29,19 +29,11 @@ var _ = Describe("Access control custom namespace, custom deployment,", Serial, 
 		By("Clean namespace before each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		By("Clean namespace after each test")
 		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Remove reports from report directory")
-		err = globalhelper.RemoveContentsFromReportDir()
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
This is already taken care of in access_control_suite_test and was causing issues when running the nodeport testcases.