### PR TITLE
Enable parallel access-control suite

### DIFF
--- a/tests/accesscontrol/access_control_suite_test.go
+++ b/tests/accesscontrol/access_control_suite_test.go
@@ -11,11 +11,8 @@ import (
 	"runtime"
 	"testing"
 
-	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	_ "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/tests"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
 func TestAccessControl(t *testing.T) {
@@ -30,30 +27,6 @@ func TestAccessControl(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	By("Create namespace")
-	err := namespaces.Create(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
+	err := globalhelper.AllowAuthenticatedUsersRunPrivilegedContainers()
 	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
-
-	err = globalhelper.AllowAuthenticatedUsersRunPrivilegedContainers()
-	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
-
-})
-
-var _ = AfterSuite(func() {
-
-	By("Remove test namespaces")
-	err := tshelper.DeleteNamespaces(
-		[]string{parameters.TestAccessControlNameSpace,
-			parameters.AdditionalValidNamespace,
-			parameters.InvalidNamespace,
-			parameters.TestAnotherNamespace,
-		},
-		globalhelper.GetAPIClient().CoreV1Interface,
-		parameters.Timeout,
-	)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Remove reports from report directory")
-	err = globalhelper.RemoveContentsFromReportDir()
-	Expect(err).ToNot(HaveOccurred())
 })

--- a/tests/accesscontrol/helper/helper_test.go
+++ b/tests/accesscontrol/helper/helper_test.go
@@ -55,7 +55,7 @@ func assertDeployment(t *testing.T, deployment *appsv1.Deployment) {
 
 func TestDefineDeployment(t *testing.T) {
 	// Define a deployment with 1 replica and 1 container
-	deployment, err := DefineDeployment(1, 1, testDeploymentName)
+	deployment, err := DefineDeployment(1, 1, testDeploymentName, parameters.TestAccessControlNameSpace)
 	assert.Nil(t, err)
 
 	assertDeployment(t, deployment)
@@ -65,7 +65,8 @@ func TestDefineDeployment(t *testing.T) {
 
 func TestDefineDeploymentWithClusterRoleBindingWithServiceAccount(t *testing.T) {
 	// Define a deployment with 1 replica and 1 container
-	deployment, err := DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, testDeploymentName, "my-service-account")
+	deployment, err := DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, testDeploymentName,
+		parameters.TestAccessControlNameSpace, "my-service-account")
 	assert.Nil(t, err)
 
 	assertDeployment(t, deployment)
@@ -85,12 +86,13 @@ func TestDefineDeploymentWithNamespace(t *testing.T) {
 
 func TestDefineDeploymentWithContainerPorts(t *testing.T) {
 	// Define a deployment with 1 replica and 1 container
-	deployment, err := DefineDeploymentWithContainerPorts(testDeploymentName, 1, []corev1.ContainerPort{
-		{
-			Name:          "test-port",
-			ContainerPort: 80,
-		},
-	})
+	deployment, err := DefineDeploymentWithContainerPorts(testDeploymentName,
+		parameters.TestAccessControlNameSpace, 1, []corev1.ContainerPort{
+			{
+				Name:          "test-port",
+				ContainerPort: 80,
+			},
+		})
 	assert.Nil(t, err)
 
 	assertDeployment(t, deployment)
@@ -139,7 +141,6 @@ func TestSetServiceAccountAutomountServiceAccountToken(t *testing.T) {
 
 		// Set the globalhelper client to the fake client
 		globalhelper.SetTestK8sAPIClient(client)
-		defer globalhelper.UnsetTestK8sAPIClient()
 
 		// Set the automountServiceAccountToken to the test value
 		err := SetServiceAccountAutomountServiceAccountToken(parameters.TestAccessControlNameSpace, "my-service-account", testCase.testValue)
@@ -162,6 +163,8 @@ func TestSetServiceAccountAutomountServiceAccountToken(t *testing.T) {
 				assert.Nil(t, serviceAccount.AutomountServiceAccountToken)
 			}
 		}
+
+		globalhelper.UnsetTestK8sAPIClient()
 	}
 }
 
@@ -228,14 +231,16 @@ func TestDefineAndCreateServiceOnCluster(t *testing.T) {
 
 		// Set the globalhelper client to the fake client
 		globalhelper.SetTestK8sAPIClient(client)
-		defer globalhelper.UnsetTestK8sAPIClient()
 
 		// Define a service
-		err := DefineAndCreateServiceOnCluster("service-name", 8080, 8080, testCase.withNodePort, testCase.ipFams, testCase.ipFamilyDesired)
+		err := DefineAndCreateServiceOnCluster("service-name", parameters.TestAccessControlNameSpace,
+			8080, 8080, testCase.withNodePort, testCase.ipFams, testCase.ipFamilyDesired)
 		assert.Nil(t, err)
 
 		// Get the service from the fake client and check if it exists
 		_, err = client.CoreV1().Services(parameters.TestAccessControlNameSpace).Get(context.TODO(), "service-name", metav1.GetOptions{})
 		assert.Nil(t, err)
+
+		globalhelper.UnsetTestK8sAPIClient()
 	}
 }

--- a/tests/accesscontrol/tests/access_control_bpf_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_bpf_capability_check.go
@@ -9,39 +9,35 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
+var _ = Describe("Access-control bpf-capability-check,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	It("one deployment, one pod, one container, does not have BPF capability", func() {
 		By("Define deployment without BPF")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -62,7 +58,7 @@ var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
 
 	It("one deployment, one pod, one container, does have BPF capability [negative]", func() {
 		By("Define deployment with BPF")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextBpf(dep)
@@ -85,13 +81,13 @@ var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
 
 	It("two deployments, one pod each, one container each, does not have BPF capability", func() {
 		By("Define deployments without BPF")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -112,7 +108,7 @@ var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
 
 	It("two deployments, one pod each, one container each, one does have BPF capability [negative]", func() {
 		By("Define deployments with varying BPF capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextBpf(dep)
@@ -120,7 +116,7 @@ var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -138,5 +134,4 @@ var _ = Describe("Access-control bpf-capability-check,", Serial, func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control non-root user,", Serial, func() {
+var _ = Describe("Access-control non-root user,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 56427
 	It("one deployment, one pod, does not have securityContext RunAsUser 0", func() {
 		By("Define deployment with securityContext RunAsUser not specified")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control non-root user,", Serial, func() {
 	// 56428
 	It("one deployment, one pod, does have securityContext RunAsUser 0 [negative]", func() {
 		By("Define deployment with securityContext RunAsUser set as 0")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 0)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control non-root user,", Serial, func() {
 	// 56429
 	It("two deployments, one pod each, does not have securityContext RunAsUser 0", func() {
 		By("Define deployments with securityContext RunAsUser not specified or not 0")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1338)
@@ -118,7 +114,7 @@ var _ = Describe("Access-control non-root user,", Serial, func() {
 	// 56430
 	It("two deployments, one pod each, one does have securityContext RunAsUser 0 [negative]", func() {
 		By("Define deployments with varying securityContext RunAsUser values")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 0)
@@ -126,7 +122,7 @@ var _ = Describe("Access-control non-root user,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
+var _ = Describe("Access-control ipc-lock-capability-check,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 63736
 	It("one deployment, one pod, one container, does not have ipc lock capability", func() {
 		By("Define deployment without ipc lock")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
 	// 63737
 	It("one deployment, one pod, one container, does have ipc lock capability [negative]", func() {
 		By("Define deployment with ipc lock")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextIpcLock(dep)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
 	// 63738
 	It("two deployments, one pod each, one container each, does not have ipc lock capability", func() {
 		By("Define deployments without ipc lock")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -116,7 +112,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
 	// 63739
 	It("two deployments, one pod each, one container each, one does have ipc lock capability [negative]", func() {
 		By("Define deployments with varying ipc lock capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextIpcLock(dep)
@@ -124,7 +120,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
+var _ = Describe("Access-control net-admin-capability-check,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 63466
 	It("one deployment, one pod, one container, does not have net admin capability", func() {
 		By("Define deployment without net admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
 	// 63467
 	It("one deployment, one pod, one container, does have net admin capability [negative]", func() {
 		By("Define deployment with net admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextNetAdmin(dep)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
 	// 63468
 	It("two deployments, one pod each, one container each, does not have net admin capability", func() {
 		By("Define deployments without net admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -116,7 +112,7 @@ var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
 	// 63469
 	It("two deployments, one pod each, one container each, one does have net admin capability [negative]", func() {
 		By("Define deployments with varying net admin capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextNetAdmin(dep)
@@ -124,7 +120,7 @@ var _ = Describe("Access-control net-admin-capability-check,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
+var _ = Describe("Access-control net-raw-capability-check,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 63647
 	It("one deployment, one pod, one container, does not have net raw capability", func() {
 		By("Define deployment without net raw")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 	// 63648
 	It("one deployment, one pod, one container, does have net raw capability [negative]", func() {
 		By("Define deployment with net raw")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextNetRaw(dep)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 	// 63649
 	It("two deployments, one pod each, one container each, does not have net raw capability", func() {
 		By("Define deployments without net raw")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -116,7 +112,7 @@ var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 	// 63650
 	It("two deployments, one pod each, one container each, one does have net raw capability [negative]", func() {
 		By("Define deployments with varying net raw capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextNetRaw(dep)
@@ -124,7 +120,7 @@ var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -142,5 +138,4 @@ var _ = Describe("Access-control net-raw-capability-check,", Serial, func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control no-1337-uid,", Serial, func() {
+var _ = Describe("Access-control no-1337-uid,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 56427
 	It("one deployment, one pod, does not have securityContext RunAsUser 1337", func() {
 		By("Define deployment with securityContext RunAsUser not specified")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 	// 56428
 	It("one deployment, one pod, does have securityContext RunAsUser 1337 [negative]", func() {
 		By("Define deployment with securityContext RunAsUser set as 1337")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1337)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 	// 56429
 	It("two deployments, one pod each, does not have securityContext RunAsUser 1337", func() {
 		By("Define deployments with securityContext RunAsUser not specified or not 1337")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1338)
@@ -118,7 +114,7 @@ var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 	// 56430
 	It("two deployments, one pod each, one does have securityContext RunAsUser 1337 [negative]", func() {
 		By("Define deployments with varying securityContext RunAsUser values")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1337)
@@ -126,7 +122,7 @@ var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -144,5 +140,4 @@ var _ = Describe("Access-control no-1337-uid,", Serial, func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -8,40 +8,36 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod cluster role binding,", Serial, func() {
+var _ = Describe("Access-control pod cluster role binding,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 56427
 	It("one deployment, one pod, does not have cluster role binding", func() {
 		By("Define deployment that do not have rolebinding")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -62,11 +58,12 @@ var _ = Describe("Access-control pod cluster role binding,", Serial, func() {
 
 	It("one deployment, one pod, does  have cluster role binding [negative]", func() {
 		By("Create cluster role binding")
-		err := globalhelper.CreateClusterRoleBinding(tsparams.TestAccessControlNameSpace, "my-service-account")
+		err := globalhelper.CreateClusterRoleBinding(randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with cluster role binding ")
-		dep, err := tshelper.DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, "accesscontroldeployment", "my-service-account")
+		dep, err := tshelper.DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, "accesscontroldeployment",
+			randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -85,11 +82,11 @@ var _ = Describe("Access-control pod cluster role binding,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Delete service account")
-		err = globalhelper.DeleteClusterRoleBinding(tsparams.TestAccessControlNameSpace, "my-cluster-role-binding")
+		err = globalhelper.DeleteClusterRoleBinding(randomNamespace, "my-cluster-role-binding")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Delete cluster role binding")
-		err = globalhelper.DeleteServiceAccount(tsparams.TestAccessControlNameSpace, "my-service-account")
+		err = globalhelper.DeleteServiceAccount(randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -5,59 +5,56 @@ import (
 	. "github.com/onsi/gomega"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-ipc, ", Serial, func() {
+var _ = Describe("Access-control pod-host-ipc, ", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{parameters.TestAccessControlNameSpace},
-			[]string{parameters.TestPodLabel},
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 	})
 
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
-
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 53140
 	It("one deployment, one pod, HostIpc false", func() {
 		By("Define deployment with hostIPC set to false")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -65,23 +62,23 @@ var _ = Describe("Access-control pod-host-ipc, ", Serial, func() {
 	// 53141
 	It("one deployment, one pod, HostIpc true [negative]", func() {
 		By("Define deployment with hostIPC set to true")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep, true)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -89,31 +86,31 @@ var _ = Describe("Access-control pod-host-ipc, ", Serial, func() {
 	// 53142
 	It("two deployments, one pod each, HostIpcs false", func() {
 		By("Define deployments with hostIPC set to false")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep2, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -121,31 +118,31 @@ var _ = Describe("Access-control pod-host-ipc, ", Serial, func() {
 	// 53143
 	It("two deployments, one pod each, one HostIpc true [negative]", func() {
 		By("Define deployments with hostIPC set to different values")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep, true)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep2, false)
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostIpc,
+			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -5,52 +5,54 @@ import (
 	. "github.com/onsi/gomega"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control pod-host-path, ", Serial, func() {
+var _ = Describe("Access-control pod-host-path, ", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{parameters.TestAccessControlNameSpace},
-			[]string{parameters.TestPodLabel},
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 	})
 
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(parameters.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 53939
 	It("one deployment, one pod, HostPath not set", func() {
 		By("Define deployment with hostPath set to false")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -58,23 +60,23 @@ var _ = Describe("Access-control pod-host-path, ", Serial, func() {
 	// 53940
 	It("one deployment, one pod, HostPath set [negative]", func() {
 		By("Define deployment with hostPath set to true")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostPath(dep, "volume", "mnt/data")
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -82,27 +84,27 @@ var _ = Describe("Access-control pod-host-path, ", Serial, func() {
 	// 53941
 	It("two deployments, one pod each, HostPath not set", func() {
 		By("Define deployments with hostPath set to false")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -110,29 +112,29 @@ var _ = Describe("Access-control pod-host-path, ", Serial, func() {
 	// 53946
 	It("two deployments, one pod each, one HostPath set [negative]", func() {
 		By("Define deployments with hostPath set to different values")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostPath(dep2, "volume", "mnt/data")
 
-		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, parameters.Timeout)
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(
-			parameters.TestCaseNameAccessControlPodHostPath,
+			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/accesscontrol/tests/access_control_pod_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_role_bindings.go
@@ -6,50 +6,54 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-func setupInitialRbacConfiguration() {
+func setupInitialRbacConfiguration(namespace string) {
 	By("Create service account")
 
-	err := globalhelper.CreateServiceAccount(tsparams.TestServiceAccount, tsparams.TestAccessControlNameSpace)
+	err := globalhelper.CreateServiceAccount(tsparams.TestServiceAccount, namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = globalhelper.CreateRole(tsparams.TestRoleName, tsparams.TestAccessControlNameSpace)
+	err = globalhelper.CreateRole(tsparams.TestRoleName, namespace)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = globalhelper.CreateRoleBindingWithServiceAccountSubject(tsparams.TestRoleBindingName, tsparams.TestRoleName,
-		tsparams.TestServiceAccount, tsparams.TestAccessControlNameSpace, tsparams.TestAccessControlNameSpace)
+		tsparams.TestServiceAccount, namespace, namespace)
 	Expect(err).ToNot(HaveOccurred())
 }
 
-var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
-
-	execute.BeforeAll(func() {
-
-		By("Create additional namespace for testing")
-		// these namespaces will only be used for the access-control-namespace tests
-		err := namespaces.Create(tsparams.TestAnotherNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
+var _ = Describe("Access-control pod-role-bindings,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
 
-		err = namespaces.Clean(tsparams.TestAnotherNamespace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		By("Define tnf config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
+		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		setupInitialRbacConfiguration()
+		setupInitialRbacConfiguration(randomNamespace)
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	It("one pod with valid role binding", func() {
 		By("Define pod")
 
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
@@ -73,7 +77,7 @@ var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 	It("one pod with no specified service account (default SA) [negative]", func() {
 		By("Define pod")
 
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
@@ -95,18 +99,23 @@ var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 	It("one pod with service account in different namespace", func() {
 		By("Define pod")
 
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create 'another' namespace")
+		anotherNamespace := tsparams.TestAnotherNamespace + "-" + globalhelper.GenerateRandomString(5)
+		err = namespaces.Create(anotherNamespace, globalhelper.GetAPIClient())
+		Expect(err).ToNot(HaveOccurred())
+
 		// Delete service account
-		err = globalhelper.DeleteServiceAccount(tsparams.TestServiceAccount, tsparams.TestAccessControlNameSpace)
+		err = globalhelper.DeleteServiceAccount(tsparams.TestServiceAccount, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 		// Create the service account in a new namespace
-		err = globalhelper.CreateServiceAccount(tsparams.TestServiceAccount, tsparams.TestAnotherNamespace)
+		err = globalhelper.CreateServiceAccount(tsparams.TestServiceAccount, anotherNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start pod-role-bindings")
@@ -120,11 +129,14 @@ var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 			tsparams.TnfPodRoleBindings,
 			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, anotherNamespace, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("one pod with role binding in different namespace", func() {
 		By("Define pod")
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		pod.RedefineWithServiceAccount(testPod, tsparams.TestServiceAccount)
@@ -132,11 +144,17 @@ var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Delete role binding
-		err = globalhelper.DeleteRoleBinding(tsparams.TestRoleBindingName, tsparams.TestAccessControlNameSpace)
+		err = globalhelper.DeleteRoleBinding(tsparams.TestRoleBindingName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Create 'another' namespace")
+		anotherNamespace := tsparams.TestAnotherNamespace + "-" + globalhelper.GenerateRandomString(5)
+		err = namespaces.Create(anotherNamespace, globalhelper.GetAPIClient())
+		Expect(err).ToNot(HaveOccurred())
+
 		// Create role binding in a new namespace
 		err = globalhelper.CreateRoleBindingWithServiceAccountSubject(tsparams.TestRoleBindingName,
-			tsparams.TestRoleName, tsparams.TestServiceAccount, tsparams.TestAccessControlNameSpace, tsparams.TestAnotherNamespace)
+			tsparams.TestRoleName, tsparams.TestServiceAccount, randomNamespace, anotherNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start pod-role-bindings")
@@ -149,6 +167,9 @@ var _ = Describe("Access-control pod-role-bindings,", Serial, func() {
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfPodRoleBindings,
 			globalparameters.TestCaseFailed)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, anotherNamespace, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -9,16 +9,21 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control requests-and-limits,", Serial, func() {
+var _ = Describe("Access-control requests-and-limits,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
@@ -26,22 +31,14 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 	})
 
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
-
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 55021
 	It("one deployment, one container with all requests and limits set", func() {
 		By("Define deployment with requests and limits set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
@@ -66,7 +63,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55022
 	It("one deployment, one container with no limits set [negative]", func() {
 		By("Define deployment with no limits set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithResourceRequests(dep, tsparams.MemoryRequest, tsparams.CPURequest)
@@ -90,7 +87,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55023
 	It("one deployment, one container with no limits or requests set [negative]", func() {
 		By("Define deployment with no limits or requests set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -112,7 +109,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55025
 	It("one deployment, one container with CPU limits not set [negative]", func() {
 		By("Define deployment with CPU limits not set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithMemoryRequestsAndLimitsAndCPURequest(dep, tsparams.MemoryLimit,
@@ -137,7 +134,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55026
 	It("one deployment, one container with memory limits not set [negative]", func() {
 		By("Define deployment with memory limits not set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithMemoryRequestAndCPURequestsAndLimits(dep, tsparams.CPULimit,
@@ -162,7 +159,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55027
 	It("two deployments, one container each with all limits and requests set", func() {
 		By("Define deployments with requests and limits set")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
@@ -171,7 +168,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithAllRequestsAndLimits(dep2, tsparams.MemoryLimit, tsparams.CPULimit,
@@ -196,7 +193,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 	// 55028
 	It("two deployments, one container each, one with memory limits not set [negative]", func() {
 		By("Define deployments with memory limits not set on one")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
@@ -205,7 +202,7 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithMemoryRequestAndCPURequestsAndLimits(dep2, tsparams.CPULimit,
@@ -226,5 +223,4 @@ var _ = Describe("Access-control requests-and-limits,", Serial, func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control security-context-privilege-escalation,", Serial, func() {
+var _ = Describe("Access-control security-context-privilege-escalation,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 63992
 	It("one deployment, one pod, one container, does not allow privilege escalation", func() {
 		By("Define deployment without privilege escalation")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", Serial
 	// 63993
 	It("one deployment, one pod, one container, does allow privilege escalation [negative]", func() {
 		By("Define deployment with privilege escalation")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, true)
@@ -88,7 +84,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", Serial
 	// 63994
 	It("two deployments, one pod each, one container each, does not allow privilege escalation", func() {
 		By("Define deployments without privilege escalation")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, false)
@@ -96,7 +92,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", Serial
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -118,7 +114,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", Serial
 	// 63995
 	It("two deployments, one pod each, one container each, one does allow privilege escalation [negative]", func() {
 		By("Define deployments with varying privilege escalation capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, true)
@@ -126,7 +122,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", Serial
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_ssh_daemons.go
+++ b/tests/accesscontrol/tests/access_control_ssh_daemons.go
@@ -6,22 +6,37 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/pod"
 )
 
-var _ = Describe("Access-control ssh-daemons,", Serial, func() {
+var _ = Describe("Access-control ssh-daemons,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
+		By("Define tnf config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{})
+		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	It("one pod with no ssh running", func() {
 		By("Define pod")
 
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.Timeout)
@@ -43,7 +58,7 @@ var _ = Describe("Access-control ssh-daemons,", Serial, func() {
 	It("one pod with ssh daemon running", func() {
 		By("Define pod")
 
-		testPod := pod.DefinePod(tsparams.TestPodName, tsparams.TestAccessControlNameSpace,
+		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestDeploymentLabels)
 
 		err := pod.RedefineWithContainerExecCommand(testPod, tsparams.SSHDaemonStartContainerCommand, 0)

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
+var _ = Describe("Access-control sys-admin-capability-check,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 63835
 	It("one deployment, one pod, one container, does not have sys admin capability", func() {
 		By("Define deployment without sys admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -64,7 +60,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
 	// 63836
 	It("one deployment, one pod, one container, does have sys admin capability [negative]", func() {
 		By("Define deployment with sys admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextSysAdmin(dep)
@@ -88,13 +84,13 @@ var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
 	// 63837
 	It("two deployments, one pod each, one container each, does not have sys admin capability", func() {
 		By("Define deployments without sys admin")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -116,7 +112,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
 	// 63838
 	It("two deployments, one pod each, one container each, one does have sys admin capability [negative]", func() {
 		By("Define deployments with varying sys admin capabilities")
-		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithContainersSecurityContextSysAdmin(dep)
@@ -124,7 +120,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -9,40 +9,36 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
+var _ = Describe("Access-control sys-ptrace-capability ", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
-	execute.BeforeAll(func() {
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestAccessControlNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestAccessControlNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
-
-	})
-
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestAccessControlNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 54657
 	It("one deployment, one pod, namespace sharing not enabled [skip]", func() {
 		By("Define deployment with shareProcessNamespace set to false")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, false)
@@ -66,7 +62,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 	// 54658
 	It("one deployment, one pod with namespace sharing enabled, one container with SYS_PTRACE allowed", func() {
 		By("Define deployment with shareProcessNamespace set to true and SYS_PTRACE enabled")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
@@ -92,7 +88,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 	// 54659
 	It("one deployment, one pod with namespace sharing enabled, one container with SYS_PTRACE not allowed [negative]", func() {
 		By("Define deployment with shareProcessNamespace set to true and SYS_PTRACE not enabled")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
@@ -116,7 +112,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 	// 54660
 	It("two deployments, one pod each with namespace sharing enabled, one container each with SYS_PTRACE allowed", func() {
 		By("Define deployments with shareProcessNamespace set to true and SYS_PTRACE enabled")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
@@ -126,7 +122,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep2, true)
@@ -152,7 +148,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 	// 54662
 	It("two deployments, one pod each with namespace sharing enabled, one container with SYS_PTRACE not allowed [negative]", func() {
 		By("Define deployments with shareProcessNamespace set to true and one with SYS_PTRACE not enabled")
-		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
@@ -162,7 +158,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep2, true)
@@ -182,5 +178,4 @@ var _ = Describe("Access-control sys-ptrace-capability ", Serial, func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -104,17 +104,17 @@ func AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origCon
 	err := RemoveContentsFromReportDir()
 	Expect(err).ToNot(HaveOccurred())
 
+	By("Remove configs from config directory")
+
+	err = RemoveContentsFromConfigDir()
+	Expect(err).ToNot(HaveOccurred())
+
 	By(fmt.Sprintf("Remove %s namespace", randomNamespace))
 	err = namespaces.DeleteAndWait(
 		GetAPIClient().CoreV1Interface,
 		randomNamespace,
 		waitingTime,
 	)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Remove configs from config directory")
-
-	err = RemoveContentsFromConfigDir()
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Restore directories")


### PR DESCRIPTION
Enables the access-control suite to run in parallel 🥳 

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/3d216722-8754-4e68-a724-7e1b06f4bed0)

* The two skipped tests are planned because we skip tests requiring SELinux.  See #438 

Notable changes for reviewers:
- Added `k8s.IsAlreadyExists` checks to installplan and subscription Create() funcs.
- Had to change some of the ports to not overlap for the NodePort tests.
- Left the `Serial` flag on the access-control-namespace set of tests because it tests the entire cluster's worth of namespaces for each test so there is overlap.  Unavoidable.
