### PR TITLE
Add minReadySeconds to specs

### DIFF
--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -50,7 +50,7 @@ func isDaemonSetReady(namespace string, name string) (bool, error) {
 		return false, err
 	}
 
-	if daemonSet.Status.NumberReady > 0 && daemonSet.Status.NumberUnavailable == 0 {
+	if daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled && daemonSet.Status.NumberUnavailable == 0 {
 		return true, nil
 	}
 

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -24,10 +24,9 @@ func IsDeploymentReady(operatorNamespace string, deploymentName string) (bool, e
 		return false, err
 	}
 
-	if testDeployment.Status.ReadyReplicas > 0 {
-		if testDeployment.Status.Replicas == testDeployment.Status.ReadyReplicas {
-			return true, nil
-		}
+	// Ensure the number of ready replicas matches the desired number of replicas.
+	if testDeployment.Status.ReadyReplicas == *testDeployment.Spec.Replicas {
+		return true, nil
 	}
 
 	return false, nil

--- a/tests/globalhelper/statefulset.go
+++ b/tests/globalhelper/statefulset.go
@@ -49,7 +49,7 @@ func isStatefulSetReady(namespace string, statefulSetName string) (bool, error) 
 		return false, err
 	}
 
-	if *testStatefulSet.Spec.Replicas == testStatefulSet.Status.ReadyReplicas {
+	if *testStatefulSet.Spec.Replicas == testStatefulSet.Status.ReadyReplicas && testStatefulSet.Status.ReadyReplicas > 0 {
 		return true, nil
 	}
 

--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -16,6 +16,7 @@ func DefineDaemonSet(namespace string, image string, label map[string]string, na
 			Name:      name,
 			Namespace: namespace},
 		Spec: appsv1.DaemonSetSpec{
+			MinReadySeconds: 30,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -23,7 +23,8 @@ func DefineDeployment(deploymentName string, namespace string, image string, lab
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:        pointer.Int32(1),
+			MinReadySeconds: 30,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},

--- a/tests/utils/replicaset/replicaset.go
+++ b/tests/utils/replicaset/replicaset.go
@@ -14,7 +14,8 @@ func DefineReplicaSet(replicaSetName string, namespace string, image string, lab
 			Name:      replicaSetName,
 			Namespace: namespace},
 		Spec: appsv1.ReplicaSetSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:        pointer.Int32(1),
+			MinReadySeconds: 30,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},


### PR DESCRIPTION
In the `globalhelper` package, we have a bunch of these funcs that `CreateAndWait...` and for the most part I think they do their job waiting for the number of Running replicas to be "up" but I don't think the resources are truly up and running before the tests are kicked off which is generally right after we create the resources.

Adding these sleeps seems to fix the instability I've been seeing in my test runs:
https://github.com/test-network-function/cnf-certification-test/actions/runs/6053059734?pr=1377 (for example)

EDIT:

I have taken @jmontesi's advice and switched to `minReadySeconds: 30` for deployments, daemonsets, and replicasets.  This seems to have cleared up the random failures I have been seeing in my testing.  I also changed the conditional statements for how to determine if a resource is "ready".  See the individual files for the changes.