### PR TITLE
Enable affiliated-certification in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ make test
 ## Test exceptions on local kind cluster
 
 * access-control-security-context
+* affiliated-certification-container-is-certified-digest
+* affiliated-certification-operator-is-certified
 
 ## Contribution Guidelines
 

--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -68,10 +68,6 @@ var _ = AfterSuite(func() {
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	By("Remove reports from report directory")
-	err = globalhelper.RemoveContentsFromReportDir()
-	Expect(err).ToNot(HaveOccurred())
-
 	if isCloudCasaAlreadyLabeled {
 		By("Re-label operator used in other suites")
 		err = tshelper.AddLabelToInstalledCSV(

--- a/tests/affiliatedcertification/helper/helper.go
+++ b/tests/affiliatedcertification/helper/helper.go
@@ -15,13 +15,13 @@ import (
 	utils "github.com/test-network-function/cnfcert-tests-verification/tests/utils/operator"
 )
 
-func SetUpAndRunContainerCertTest(tcName string, containersInfo []string, expectedResult string) error {
+func SetUpAndRunContainerCertTest(tcName, namespace string, containersInfo []string, expectedResult string) error {
 	var err error
 
 	ginkgo.By("Add container information to " + globalparameters.DefaultTnfConfigFileName)
 
 	err = globalhelper.DefineTnfConfig(
-		[]string{tsparams.TestCertificationNameSpace},
+		[]string{namespace},
 		[]string{tsparams.TestPodLabel},
 		[]string{},
 		containersInfo,

--- a/tests/affiliatedcertification/tests/affiliated_certification_container.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container.go
@@ -6,26 +6,30 @@ import (
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification container certification,", Serial, func() {
-
-	execute.BeforeAll(func() {
-
-	})
+var _ = Describe("Affiliated-certification container certification,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
 
 	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestCertificationNameSpace)
+	})
 
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 46562
 	It("one container to test, container is certified", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.CertifiedContainerCockroachDB}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -33,7 +37,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46563
 	It("one container to test, container is not certified [negative]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.UncertifiedContainerNodeJs12}, globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -41,7 +45,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46564
 	It("two containers to test, both are certified", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.CertifiedContainerCockroachDB,
 				tsparams.CertifiedContainer5gc}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
@@ -50,7 +54,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46565
 	It("two containers to test, one is certified, one is not [negative]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.UncertifiedContainerNodeJs12,
 				tsparams.CertifiedContainerCockroachDB}, globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
@@ -59,7 +63,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46566
 	It("certifiedcontainerinfo field exists in tnf_config but has no value [skip]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{""}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -67,7 +71,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46567
 	It("certifiedcontainerinfo field does not exist in tnf_config [skip]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -75,7 +79,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46578
 	It("name and repository fields exist in certifiedcontainerinfo field but are empty [skip]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.EmptyFieldsContainer}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -83,7 +87,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46579
 	It("name field in certifiedcontainerinfo field is populated but repository field is not [skip]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.ContainerNameOnlyCockroachDB}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -91,7 +95,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	// 46580
 	It("repository field in certifiedcontainerinfo field is populated but name field is not [skip]", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.ContainerRepoOnlyRedHatRegistry}, globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -100,7 +104,7 @@ var _ = Describe("Affiliated-certification container certification,", Serial, fu
 	It("two containers listed in certifiedcontainerinfo field, one is certified, one has empty name and "+
 		"repository fields", func() {
 		err := tshelper.SetUpAndRunContainerCertTest(
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomNamespace,
 			[]string{tsparams.CertifiedContainer5gc,
 				tsparams.EmptyFieldsContainer}, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -7,17 +7,23 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification container-is-certified-digest,", Serial, func() {
-	execute.BeforeAll(func() {
+var _ = Describe("Affiliated-certification container-is-certified-digest,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestCertificationNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestCertificationNameSpace},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
@@ -25,22 +31,18 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 	})
 
-	BeforeEach(func() {
-		By("Clean namespace before each test")
-		err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
-	})
-
 	AfterEach(func() {
-		By("Clean namespace after each test")
-		err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred())
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	// 66765
-	It("one container to test, container is certified", func() {
+	It("one container to test, container is certified digest", func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skip test due to image pull missing credentials in Kind")
+		}
+
 		By("Define deployment with certified container")
-		dep := deployment.DefineDeployment("affiliated-cert-deployment", tsparams.TestCertificationNameSpace,
+		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -60,10 +62,10 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 	})
 
 	// 66766
-	It("one container to test, container is not certified [negative]", func() {
+	It("one container to test, container is not certified digest [negative]", func() {
 		By("Define deployment with uncertified container")
 
-		dep := deployment.DefineDeployment("affiliated-cert-deployment", tsparams.TestCertificationNameSpace,
+		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.UncertifiedContainerURLCnfTest, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
@@ -83,15 +85,19 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 	})
 
 	// 66767
-	It("two containers to test, both are certified", func() {
+	It("two containers to test, both are certified digest", func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skip test due to image pull missing credentials in Kind")
+		}
+
 		By("Define deployments with certified containers")
-		dep := deployment.DefineDeployment("affiliated-cert-deployment", tsparams.TestCertificationNameSpace,
+		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", tsparams.TestCertificationNameSpace,
+		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", randomNamespace,
 			tsparams.CertifiedContainerURLCockroachDB, tsparams.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
@@ -111,15 +117,19 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 	})
 
 	// 66768
-	It("two containers to test, one is certified, one is not [negative]", func() {
+	It("two containers to test, one is certified, one is not digest [negative]", func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skip test due to image pull missing credentials in Kind")
+		}
+
 		By("Define deployments with different container certification statuses")
-		dep := deployment.DefineDeployment("affiliated-cert-deployment", tsparams.TestCertificationNameSpace,
+		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.UncertifiedContainerURLCnfTest, tsparams.TestDeploymentLabels)
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", tsparams.TestCertificationNameSpace,
+		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", randomNamespace,
 			tsparams.CertifiedContainerURLCockroachDB, tsparams.TestDeploymentLabels)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -23,7 +23,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 
 	execute.BeforeAll(func() {
 		Skip("Impractical to test under current circumstances")
-		preConfigureAffiliatedCertificationEnvironment()
+		preConfigureAffiliatedCertificationEnvironment(tsparams.TestCertificationNameSpace)
 
 		By("Deploy instana-agent-operator for testing")
 		// instana-agent-operator: in certified-operators group and version is certified
@@ -122,6 +122,10 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 				info.Label)
 			Expect(err).ToNot(HaveOccurred(), "Error removing label from operator "+info.OperatorPrefix)
 		}
+
+		By("Remove reports from report directory")
+		err := globalhelper.RemoveContentsFromReportDir()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	// 46695

--- a/tests/affiliatedcertification/tests/affiliated_common.go
+++ b/tests/affiliatedcertification/tests/affiliated_common.go
@@ -17,12 +17,12 @@ import (
 	utils "github.com/test-network-function/cnfcert-tests-verification/tests/utils/operator"
 )
 
-func preConfigureAffiliatedCertificationEnvironment() {
+func preConfigureAffiliatedCertificationEnvironment(namespace string) {
 	By("Clean test namespace")
 
-	err := namespaces.Clean(tsparams.TestCertificationNameSpace, globalhelper.GetAPIClient())
+	err := namespaces.Clean(namespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred(),
-		"Error cleaning namespace "+tsparams.TestCertificationNameSpace)
+		"Error cleaning namespace "+namespace)
 	By("Ensure default catalog source is enabled")
 
 	catalogEnabled, err := globalhelper.IsCatalogSourceEnabled(
@@ -51,11 +51,11 @@ func preConfigureAffiliatedCertificationEnvironment() {
 	By("Deploy OperatorGroup if not already deployed")
 
 	if globalhelper.IsOperatorGroupInstalled(tsparams.OperatorGroupName,
-		tsparams.TestCertificationNameSpace) != nil {
-		err = globalhelper.DeployOperatorGroup(tsparams.TestCertificationNameSpace,
+		namespace) != nil {
+		err = globalhelper.DeployOperatorGroup(namespace,
 			utils.DefineOperatorGroup(tsparams.OperatorGroupName,
-				tsparams.TestCertificationNameSpace,
-				[]string{tsparams.TestCertificationNameSpace}),
+				namespace,
+				[]string{namespace}),
 		)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operatorgroup")
 	}
@@ -63,7 +63,7 @@ func preConfigureAffiliatedCertificationEnvironment() {
 	By("Define config file " + globalparameters.DefaultTnfConfigFileName)
 
 	err = globalhelper.DefineTnfConfig(
-		[]string{tsparams.TestCertificationNameSpace},
+		[]string{namespace},
 		[]string{tsparams.TestPodLabel},
 		[]string{},
 		[]string{},
@@ -104,7 +104,7 @@ func approveInstallPlanWhenReady(csvName, namespace string) {
 		}
 
 		if installPlan.Status.Phase == v1alpha1.InstallPlanPhaseRequiresApproval {
-			err = globalhelper.ApproveInstallPlan(tsparams.TestCertificationNameSpace,
+			err = globalhelper.ApproveInstallPlan(namespace,
 				installPlan)
 
 			return err == nil

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -8,15 +8,22 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/namespaces"
 )
 
-var _ = Describe("Affiliated-certification helm chart certification,", Serial, func() {
-	execute.BeforeAll(func() {
+var _ = Describe("Affiliated-certification helm chart certification,", func() {
+	var randomNamespace string
+	var origReportDir string
+	var origTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, origReportDir, origTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.TestCertificationNameSpace)
+
 		By("Define tnf config file")
 		err := globalhelper.DefineTnfConfig(
-			[]string{tsparams.TestHelmChartCertified},
+			[]string{randomNamespace},
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
@@ -24,16 +31,8 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial, f
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 	})
 
-	BeforeEach(func() {
-		By("Create namespace")
-		err := namespaces.Create(tsparams.TestHelmChartCertified, globalhelper.GetAPIClient())
-		Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
-	})
-
 	AfterEach(func() {
-		By("Remove the project")
-		err := namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, tsparams.TestHelmChartCertified, tsparams.Timeout)
-		Expect(err).ToNot(HaveOccurred(), "Error delete ns affiliated-certification-helmchart-is-certified")
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.Timeout)
 	})
 
 	It("One helm to test, are certified", func() {


### PR DESCRIPTION
![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/b3225d00-4897-4f8a-bc79-fb57c2b3e036)

There are a lot of tests in the affiliated-certification suite that rely on running on OCP and having operator hub available.  Also because of the OCP requirement there are pull secrets that are available in OCP vs normal kubernetes so I'm avoiding tests that have to pull certified images from `registry.connect.redhat.com`.

Tests that won't run properly in Kind:
* affiliated-certification-container-is-certified-digest
* affiliated-certification-operator-is-certified
These have been added to the README list of tests that get skipped in Kind.