### PR TITLE
Switch to NumberAvailable

### DIFF
--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -50,7 +50,7 @@ func isDaemonSetReady(namespace string, name string) (bool, error) {
 		return false, err
 	}
 
-	if daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled && daemonSet.Status.NumberUnavailable == 0 {
+	if daemonSet.Status.NumberAvailable == daemonSet.Status.DesiredNumberScheduled && daemonSet.Status.NumberUnavailable == 0 {
 		return true, nil
 	}
 

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -25,7 +25,7 @@ func IsDeploymentReady(operatorNamespace string, deploymentName string) (bool, e
 	}
 
 	// Ensure the number of ready replicas matches the desired number of replicas.
-	if testDeployment.Status.ReadyReplicas == *testDeployment.Spec.Replicas {
+	if testDeployment.Status.AvailableReplicas == *testDeployment.Spec.Replicas {
 		return true, nil
 	}
 

--- a/tests/globalhelper/replicaset.go
+++ b/tests/globalhelper/replicaset.go
@@ -48,7 +48,7 @@ func isReplicaSetReady(namespace, replicaSetName string) (bool, error) {
 		return false, err
 	}
 
-	if *testReplicaSet.Spec.Replicas == testReplicaSet.Status.ReadyReplicas {
+	if *testReplicaSet.Spec.Replicas == testReplicaSet.Status.AvailableReplicas {
 		return true, nil
 	}
 

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -96,6 +96,8 @@ func IsTestCaseSkippedInJunitReport(report *globalparameters.JUnitTestSuites, te
 
 // RemoveContentsFromReportDir removes all files from report dir.
 func RemoveContentsFromReportDir() error {
+	glog.V(5).Info(fmt.Sprintf("removing all files from %s directory", GetConfiguration().General.TnfReportDir))
+
 	tnfReportDir, err := os.Open(GetConfiguration().General.TnfReportDir)
 	if err != nil {
 		return fmt.Errorf("failed to open report directory: %w", err)


### PR DESCRIPTION
Switching the logic to look at the NumberAvailable.

NumberReady doesn't wait for the `minReadySeconds` added in #475 

https://docs.okd.io/latest/rest_api/workloads_apis/daemonset-apps-v1.html#status

`The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)`