### PR TITLE
Skip operator tests if Kind cluster

### DIFF
--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -31,6 +31,10 @@ func TestOperator(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 
+	if globalhelper.IsKindCluster() {
+		Skip("Skipping operator tests on kind cluster")
+	}
+
 	By(fmt.Sprintf("Create %s namespace", tsparams.OperatorNamespace))
 	err := namespaces.Create(tsparams.OperatorNamespace, globalhelper.GetAPIClient())
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Adding a check for Kind clusters in the `operator` suite of tests to disable them if ran on Kind.