### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cnfcert-tests-verification
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/golang/glog v1.1.2


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1392