### PR TITLE
Add 'make coverage-html' path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .vscode
 reports
+cover.out
+cover.out.tmp

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ install: deps-update install-ginkgo
 	@echo "Installing needed dependencies"
 
 unit-tests:
-	UNIT_TEST=true go test ./... -tags=utest
+	UNIT_TEST=true go test ./... -tags=utest -coverprofile=cover.out
+
+coverage-html: test
+	go tool cover -html cover.out
 
 


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/49 

Creates a coverage report for unit tests.