### PR TITLE
Add daemonset unit tests

### DIFF
--- a/tests/globalhelper/daemonset_test.go
+++ b/tests/globalhelper/daemonset_test.go
@@ -1,0 +1,127 @@
+package globalhelper
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateAndWaitUntilDaemonSetIsReady(t *testing.T) {
+	generateDaemonset := func(numAvailable, numScheduled, numUnavailable int) *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-daemonset",
+				Namespace: "default",
+			},
+			Status: appsv1.DaemonSetStatus{
+				NumberAvailable:        int32(numAvailable),
+				DesiredNumberScheduled: int32(numScheduled),
+				NumberUnavailable:      int32(numUnavailable),
+			},
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		numAvailable   int
+		numScheduled   int
+		numUnavailable int
+		wantErr        bool
+	}{
+		{
+			name:           "Daemonset is ready",
+			numAvailable:   1,
+			numScheduled:   1,
+			numUnavailable: 0,
+			wantErr:        false,
+		},
+		{
+			name:           "Daemonset is not ready",
+			numAvailable:   0,
+			numScheduled:   1,
+			numUnavailable: 1,
+			wantErr:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Create fake daemonset
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, generateDaemonset(testCase.numAvailable, testCase.numScheduled, testCase.numUnavailable))
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+
+		t.Run(testCase.name, func(t *testing.T) {
+			err := CreateAndWaitUntilDaemonSetIsReady(client.AppsV1(),
+				generateDaemonset(testCase.numAvailable, testCase.numScheduled, testCase.numUnavailable), 5)
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("CreateAndWaitUntilDaemonSetIsReady() error = %v, wantErr %v", err, testCase.wantErr)
+
+				return
+			}
+		})
+	}
+}
+
+func TestIsDaemonsetReady(t *testing.T) {
+	generateDaemonset := func(numAvailable, numScheduled, numUnavailable int) *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-daemonset",
+				Namespace: "default",
+			},
+			Status: appsv1.DaemonSetStatus{
+				NumberAvailable:        int32(numAvailable),
+				DesiredNumberScheduled: int32(numScheduled),
+				NumberUnavailable:      int32(numUnavailable),
+			},
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		numAvailable   int
+		numScheduled   int
+		numUnavailable int
+		wantErr        bool
+		expectedOutput bool
+	}{
+		{
+			name:           "Daemonset is ready",
+			numAvailable:   1,
+			numScheduled:   1,
+			numUnavailable: 0,
+			wantErr:        false,
+			expectedOutput: true,
+		},
+		{
+			name:           "Daemonset is not ready",
+			numAvailable:   0,
+			numScheduled:   1,
+			numUnavailable: 1,
+			wantErr:        false,
+			expectedOutput: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Create fake daemonset
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, generateDaemonset(testCase.numAvailable, testCase.numScheduled, testCase.numUnavailable))
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := isDaemonSetReady(client.AppsV1(), "default", "test-daemonset")
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("isDaemonsetReady() error = %v, wantErr %v", err, testCase.wantErr)
+
+				return
+			}
+			if got != testCase.expectedOutput {
+				t.Errorf("isDaemonsetReady() = %v, want %v", got, testCase.expectedOutput)
+			}
+		})
+	}
+}

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -132,7 +132,8 @@ var _ = Describe("lifecycle-container-startup", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-container-startup test")

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -190,7 +190,8 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-cpu-isolation test")
@@ -219,7 +220,8 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-cpu-isolation test")

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -103,7 +103,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
@@ -123,19 +124,22 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSeta := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSeta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetb := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsb",
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSetb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		daemonSetc := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsc",
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSetc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
@@ -157,7 +161,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace, "registry.access.redhat.com/ubi8/ubi",
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-image-pull-policy test")
@@ -252,7 +257,8 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullNever)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -134,7 +134,8 @@ var _ = Describe("lifecycle-liveness", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-liveness test")

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -154,7 +154,8 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-pod-scheduling test")

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -132,7 +132,8 @@ var _ = Describe("lifecycle-readiness", func() {
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-readiness test")

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -156,7 +156,8 @@ var _ = Describe("lifecycle-startup-probe", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-startup-probe test")

--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -341,7 +341,8 @@ func defineDaemonSetBasedOnArgs(nadName, namespace, daemonsetName string, labels
 		daemonset.RedefineDaemonSetWithLabel(testDaemonset, labels)
 	}
 
-	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(testDaemonset, tsparams.WaitingTime)
+	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+		testDaemonset, tsparams.WaitingTime)
 }
 
 func defineAndCreatePrivilegedDaemonset(namespace string) error {
@@ -350,7 +351,8 @@ func defineAndCreatePrivilegedDaemonset(namespace string) error {
 	daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{globalhelper.GetConfiguration().General.WorkerNodeLabel: ""})
 	daemonset.RedefineWithPrivilegeAndHostNetwork(daemonSet)
 
-	err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+	err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+		daemonSet, tsparams.WaitingTime)
 	if err != nil {
 		return err
 	}

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -74,7 +74,8 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{configSuite.General.CnfNodeLabel: ""})
 
 		By("Create DaemonSet on cluster")
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")
@@ -165,7 +166,8 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		daemonset.RedefineDaemonSetWithNodeSelector(daemonSet, map[string]string{configSuite.General.CnfNodeLabel: ""})
 
 		By("Create DaemonSet on cluster")
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start tests")

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -115,7 +115,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		daemonSet := tshelper.DefineDaemonSetWithStdoutBuffers(
 			tsparams.TestDaemonSetBaseName, randomNamespace, logLines)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet,
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(), daemonSet,
 			tsparams.DaemonSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -90,7 +90,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 				corev1.TerminationMessageFallbackToLogsOnError,
 			})
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.DaemonSetDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.DaemonSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
@@ -243,7 +244,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 			randomNamespace,
 			[]corev1.TerminationMessagePolicy{tsparams.UseDefaultTerminationMsgPolicy})
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.DaemonSetDeployTimeoutMins)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.DaemonSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -61,7 +61,8 @@ var _ = Describe("platform-alteration-base-image", Serial, func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-base-image test")

--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -37,7 +37,8 @@ var _ = Describe("platform-alteration-boot-params", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-boot-params test")

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -64,7 +64,8 @@ var _ = Describe("platform-alteration-hugepages-config", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -59,7 +59,8 @@ var _ = Describe("platform-alteration-is-redhat-release", Serial, func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-is-redhat-release test")

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -33,7 +33,8 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
@@ -69,7 +70,8 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -40,7 +40,8 @@ var _ = Describe("platform-alteration-sysctl-config", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start platform-alteration-sysctl-config test")
@@ -61,7 +62,8 @@ var _ = Describe("platform-alteration-sysctl-config", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -49,7 +49,8 @@ var _ = Describe("platform-alteration-tainted-node-kernel", Serial, func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
-		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
+		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(globalhelper.GetAPIClient().K8sClient.AppsV1(),
+			daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)


### PR DESCRIPTION
Similar to #426 where I added some unit tests for the accesscontrol helper funcs.

I changed the function definition for the `CreateAndWaitUntilDaemonSetIsReady` function to accept an interface to be able to unit test these funcs in an isolated environment.

Eventually the goal would be to migrate all of the helper funcs to have some level of unit testing so we're able to determine if code is doing what it is supposed to be doing.