### PR TITLE
Add slice safeguards

### DIFF
--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -92,6 +92,8 @@ var _ = Describe("platform-alteration-base-image", Serial, func() {
 		podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(len(podsList.Items)).NotTo(BeZero())
+
 		By("Change container base image")
 		_, err = globalhelper.ExecCommand(podsList.Items[0], []string{"/bin/bash", "-c", "touch /usr/lib/testfile"})
 		Expect(err).ToNot(HaveOccurred())
@@ -131,6 +133,8 @@ var _ = Describe("platform-alteration-base-image", Serial, func() {
 
 		podsList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(podsList.Items)).NotTo(BeZero())
 
 		By("Change container base image")
 		_, err = globalhelper.ExecCommand(podsList.Items[0], []string{"/bin/bash", "-c", "touch /usr/lib/testfile"})

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -70,6 +70,8 @@ var _ = Describe("platform-alteration-hugepages-config", Serial, func() {
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(len(podList.Items)).NotTo(BeZero())
+
 		By("Get first hugepages file")
 		nrHugepagesFiles, err := globalhelper.ExecCommand(
 			podList.Items[0], []string{"/bin/bash", "-c", tsparams.FindHugePagesFiles})

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -75,6 +75,8 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", Serial, func() {
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(len(podList.Items)).NotTo(BeZero())
+
 		By("Set SELinux permissive on the node")
 		_, err = globalhelper.ExecCommand(podList.Items[0], []string{"/bin/bash", "-c", tsparams.SetPermissive})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -67,6 +67,8 @@ var _ = Describe("platform-alteration-sysctl-config", Serial, func() {
 		podList, err := globalhelper.GetListOfPodsInNamespace(tsparams.PlatformAlterationNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(len(podList.Items)).NotTo(BeZero())
+
 		node, err := globalhelper.GetAPIClient().Nodes().Get(context.TODO(), podList.Items[0].Spec.NodeName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
We expect the `List` of items to not be empty so I put some `Expect` commands to prevent panics in these situations.