### PR TITLE
Skip operator tests cleanup

### DIFF
--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -50,6 +50,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	if globalhelper.IsKindCluster() {
+		Skip("Skipping operator tests cleanup on kind cluster")
+	}
 
 	By(fmt.Sprintf("Remove %s namespace", tsparams.OperatorNamespace))
 	err := namespaces.DeleteAndWait(


### PR DESCRIPTION
Follow up to: https://github.com/test-network-function/cnfcert-tests-verification/pull/485

Skip the cleanup if this is Kind cluster as well.