### PR TITLE
Fix affiliated-certification

### DIFF
--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -114,6 +114,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 	})
 
 	AfterEach(func() {
+		Skip("Impractical to test under current circumstances")
 		By("Remove labels from operators")
 		for _, info := range installedLabeledOperators {
 			err := tshelper.DeleteLabelFromInstalledCSV(


### PR DESCRIPTION
Skip the `AfterEach` since we're already skipping this whole section in `BeforeAll`.

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/3fb5ca7c-edeb-4a6a-b61b-81ed9c812009)
