### PR TITLE
Debug daemonsets

### DIFF
--- a/scripts/delete-namespaces.sh
+++ b/scripts/delete-namespaces.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# A script that will pre-emptively delete namespaces that are used in QE testing to make
+# sure that the namespaces are not left behind after the test run.
+
+NAMESPACE_STRINGS_TO_GREP=(accesscontrol ac-test ac-rq-test cr-scale-operator-system my-ns affiliated lifecycle manageability networking net-tests observability operator-ns performance platform-alteration)
+
+for NS in "${NAMESPACE_STRINGS_TO_GREP[@]}"; do
+	for NAMESPACE in $(oc get namespaces | grep "$NS" | awk '{print $1}'); do
+		echo "Deleting namespace $NAMESPACE"
+		oc delete namespace "$NAMESPACE" --ignore-not-found=true
+	done
+done

--- a/tests/accesscontrol/tests/access_control_crd_roles.go
+++ b/tests/accesscontrol/tests/access_control_crd_roles.go
@@ -66,6 +66,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		err = globalhelper.CreateRole(testRole)
 		Expect(err).ToNot(HaveOccurred())
 
+		DeferCleanup(func() {
+			By("Delete role")
+			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -88,6 +94,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName})
 		err = globalhelper.CreateRole(testRole)
 		Expect(err).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			By("Delete role")
+			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,
@@ -112,6 +124,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		err = globalhelper.CreateRole(testRole)
 		Expect(err).ToNot(HaveOccurred())
 
+		DeferCleanup(func() {
+			By("Delete role")
+			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -134,6 +152,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName})
 		err = globalhelper.CreateRole(testRole)
 		Expect(err).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			By("Delete role")
+			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -61,6 +61,16 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		err := globalhelper.CreateClusterRoleBinding(randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 
+		DeferCleanup(func() {
+			By("Delete cluster role binding")
+			err = globalhelper.DeleteClusterRoleBinding(randomNamespace, "my-cluster-role-binding")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Delete service account")
+			err = globalhelper.DeleteServiceAccount(randomNamespace, "my-service-account")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		By("Define deployment with cluster role binding ")
 		dep, err := tshelper.DefineDeploymentWithClusterRoleBindingWithServiceAccount(1, 1, "accesscontroldeployment",
 			randomNamespace, "my-service-account")
@@ -79,14 +89,6 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalparameters.TestCaseFailed)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Delete service account")
-		err = globalhelper.DeleteClusterRoleBinding(randomNamespace, "my-cluster-role-binding")
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Delete cluster role binding")
-		err = globalhelper.DeleteServiceAccount(randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/globalhelper/rbac.go
+++ b/tests/globalhelper/rbac.go
@@ -90,6 +90,19 @@ func CreateRole(aRole rbacv1.Role) error {
 	return err
 }
 
+func DeleteRole(roleName, namespace string) error {
+	err :=
+		GetAPIClient().RbacV1Interface.Roles(namespace).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
+
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("role %s does not exist", roleName))
+
+		return nil
+	}
+
+	return err
+}
+
 func DeleteRoleBinding(bindingName, namespace string) error {
 	err :=
 		GetAPIClient().RbacV1Interface.RoleBindings(namespace).Delete(context.TODO(), bindingName, metav1.DeleteOptions{})

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -87,7 +87,6 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCPUIsolationTcName, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	// 54728

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -38,6 +38,11 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 	})
 
 	It("One pod with only exclusive containers", func() {
+		if globalhelper.IsKindCluster() {
+			// We cannot guarantee the number of available CPUs so we skip this test
+			Skip("Exclusive CPU pool is not supported on Kind cluster, skipping...")
+		}
+
 		By("Define pod")
 		testPod := tshelper.DefineExclusivePod(tsparams.TestPodName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -54,6 +54,9 @@ var _ = Describe("platform-alteration-tainted-node-kernel", func() {
 
 	// 51390
 	It("Tainted node [negative]", func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Tainting a node not support on Kind cluster, skipping...")
+		}
 
 		By("Define daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace, globalhelper.GetConfiguration().General.TestImage,

--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -43,6 +43,7 @@ func DefineDaemonSetWithContainerSpecs(name, namespace string, labels map[string
 			Name:      name,
 			Namespace: namespace},
 		Spec: appsv1.DaemonSetSpec{
+			MinReadySeconds: 30,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -51,7 +52,8 @@ func DefineDaemonSetWithContainerSpecs(name, namespace string, labels map[string
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					Containers: containerSpecs,
+					TerminationGracePeriodSeconds: pointer.Int64(0),
+					Containers:                    containerSpecs,
 				},
 			},
 		},

--- a/tests/utils/statefulset/statefulset.go
+++ b/tests/utils/statefulset/statefulset.go
@@ -15,7 +15,8 @@ func DefineStatefulSet(statefulSetName string, namespace string,
 			Name:      statefulSetName,
 			Namespace: namespace},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: pointer.Int32(1),
+			MinReadySeconds: 30,
+			Replicas:        pointer.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},


### PR DESCRIPTION
Found a couple of places where I missed adding `MinReadySeconds` and `TerminationGracePeriodSeconds` in both the daemonset code and the statefulset code.

Additional changes:
- Created a script to cleanup namespaces that may or may not be leftover from prior runs.
- Added some `DeferCleanup` functions to cleanup leftover `Role` objects.