### PR TITLE
Add 'Serial' decorator for cpu-isolation tests

### DIFF
--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -1,11 +1,12 @@
 package tests
 
 import (
+	"runtime"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
-	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
@@ -13,12 +14,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/runtimeclass"
 )
 
-var (
-	// Each tc will save the RTC that was created in order to delete them.
-	rtcNames = []string{}
-)
-
-var _ = Describe("lifecycle-cpu-isolation", func() {
+var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 	var randomNamespace string
 	var origReportDir string
 	var origTnfConfigDir string
@@ -35,20 +31,14 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 			[]string{},
 			[]string{})
 		Expect(err).ToNot(HaveOccurred())
+
+		if globalhelper.IsKindCluster() && runtime.NumCPU() <= 2 {
+			Skip("This test requires more than 2 CPU cores")
+		}
 	})
 
 	AfterEach(func() {
 		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origTnfConfigDir, tsparams.WaitingTime)
-
-		By("Delete all RTC's that were created by the previous test case.")
-		for _, rtc := range rtcNames {
-			By("Deleting rtc " + rtc)
-			err := tshelper.DeleteRunTimeClass(rtc)
-			Expect(err).ToNot(HaveOccurred())
-		}
-
-		// clear the list.
-		rtcNames = []string{}
 	})
 
 	const disableVar = "disable"
@@ -71,7 +61,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		pod.RedefineWithRunTimeClass(put, rtc.Name)
 		pod.RedefineWithCPUResources(put, "1", "1")
@@ -108,7 +102,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		pod.RedefineWithRunTimeClass(put, rtc.Name)
 		pod.RedefineWithCPUResources(put, "1", "1")
@@ -146,7 +144,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		deployment.RedefineWithRunTimeClass(dep, rtc.Name)
 		deployment.RedefineWithCPUResources(dep, "1", "1")
@@ -184,7 +186,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
@@ -214,7 +220,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
@@ -285,7 +295,11 @@ var _ = Describe("lifecycle-cpu-isolation", func() {
 		err := globalhelper.CreateRunTimeClass(rtc)
 		Expect(err).ToNot(HaveOccurred())
 
-		rtcNames = append(rtcNames, rtc.Name)
+		DeferCleanup(func() {
+			By("Deleting rtc " + rtc.Name)
+			err := globalhelper.DeleteRunTimeClass(rtc)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
 		By("Define runTimeClass for the first pod")
 		pod.RedefineWithRunTimeClass(puta, rtc.Name)

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -58,16 +58,14 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	// 54201
 	It("One deployment, one pod with a volume that uses a reclaim policy of delete", func() {
-
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimDelete)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolume.Name)
-
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -94,16 +92,14 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	// 54202
 	It("One pod with a volume that uses a reclaim policy of delete", func() {
-
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimDelete)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolume.Name)
-
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -129,16 +125,14 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	// 54203
 	It("One replicaSet with a volume that uses a reclaim policy of delete", func() {
-
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimDelete)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolume.Name)
-
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -164,16 +158,14 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	// 54204
 	It("One deployment, one pod with a volume that uses a reclaim policy of retain [negative]", func() {
-
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimRetain)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolume.Name)
-
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -200,16 +192,14 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 	// 54206
 	It("One pod with a volume that uses a reclaim policy of recycle [negative]", func() {
-
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimRecycle)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolume.Name)
-
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -237,31 +227,30 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 	It("Two deployments, one with reclaim policy of delete, other with recycle [negative]", func() {
 
 		By("Define and create first pv")
-		persistentVolumea := persistentvolume.DefinePersistentVolume(randomPV)
+		pvca := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentVolumea := persistentvolume.DefinePersistentVolume(randomPV, pvca.Name, pvca.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolumea, corev1.PersistentVolumeReclaimDelete)
-
 		err := tshelper.CreatePersistentVolume(persistentVolumea, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolumea.Name)
 
 		By("Define and create second pv")
-		persistentVolumeb := persistentvolume.DefinePersistentVolume("lifecycle-pvb-" + globalhelper.GenerateRandomString(10))
+		pvcb := persistentvolumeclaim.DefinePersistentVolumeClaim("lifecycle-pvcb", randomNamespace)
+		persistentVolumeb := persistentvolume.DefinePersistentVolume("lifecycle-pvb-"+globalhelper.GenerateRandomString(10),
+			pvcb.Name, pvcb.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolumeb, corev1.PersistentVolumeReclaimRecycle)
-
 		err = tshelper.CreatePersistentVolume(persistentVolumeb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, persistentVolumeb.Name)
 
-		By("Define and create first pvc")
-		pvca := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		By("create first pvc")
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvca, randomNamespace, tsparams.WaitingTime, persistentVolumea.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Define and create second pvc")
-		pvcb := persistentvolumeclaim.DefinePersistentVolumeClaim("lifecycle-pvcb", randomNamespace)
+		By("create second pvc")
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvcb, randomNamespace, tsparams.WaitingTime, persistentVolumeb.Name)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/lifecycle/tests/lifecycle_storage_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_storage_required_pods.go
@@ -62,8 +62,10 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 	})
 
 	It("One pod with a storage, PVC with no storageclass defined", func() {
+		By("Define PVC")
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 		By("Define PV")
-		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV)
+		persistentVolume := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(persistentVolume, corev1.PersistentVolumeReclaimDelete)
 
 		err := tshelper.CreatePersistentVolume(persistentVolume, tsparams.WaitingTime)
@@ -71,8 +73,6 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 
 		pvNames = append(pvNames, persistentVolume.Name)
 
-		By("Define PVC")
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, persistentVolume.Name)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -94,8 +94,12 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 	})
 
 	It("One pod with local storage, PVC with storageclass defined", func() {
+		By("Define PVC")
+		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
+		persistentvolumeclaim.RedefineWithStorageClass(pvc, randomStorageClassName)
+
 		By("Define PV")
-		testPv := persistentvolume.DefinePersistentVolume(randomPV)
+		testPv := persistentvolume.DefinePersistentVolume(randomPV, pvc.Name, pvc.Namespace)
 		persistentvolume.RedefineWithPVReclaimPolicy(testPv, corev1.PersistentVolumeReclaimDelete)
 		persistentvolume.RedefineWithStorageClass(testPv, randomStorageClassName)
 
@@ -103,10 +107,6 @@ var _ = Describe("lifecycle-storage-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		pvNames = append(pvNames, testPv.Name)
-
-		By("Define PVC")
-		pvc := persistentvolumeclaim.DefinePersistentVolumeClaim(tsparams.TestPVCName, randomNamespace)
-		persistentvolumeclaim.RedefineWithStorageClass(pvc, randomStorageClassName)
 
 		err = tshelper.CreateAndWaitUntilPVCIsBound(pvc, randomNamespace, tsparams.WaitingTime, testPv.Name)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/performance/parameters/parameters.go
+++ b/tests/performance/parameters/parameters.go
@@ -18,9 +18,6 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
-
-	// Each tc will save the RTC that was created in order to delete them.
-	RtcNames = []string{}
 )
 
 const (

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"runtime"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
@@ -31,6 +33,10 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 		// Create service account and roles and roles binding
 		err = tshelper.ConfigurePrivilegedServiceAccount(randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
+
+		if globalhelper.IsKindCluster() && runtime.NumCPU() <= 2 {
+			Skip("This test requires more than 2 CPU cores")
+		}
 	})
 
 	AfterEach(func() {

--- a/tests/utils/persistentvolume/persistentvolume.go
+++ b/tests/utils/persistentvolume/persistentvolume.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DefinePersistentVolume defines a persistent volume manifest based on given params.
-func DefinePersistentVolume(pvName string) *corev1.PersistentVolume {
+func DefinePersistentVolume(pvName, pvcName, pvcNamespace string) *corev1.PersistentVolume {
 	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvName,
@@ -15,6 +15,10 @@ func DefinePersistentVolume(pvName string) *corev1.PersistentVolume {
 		Spec: corev1.PersistentVolumeSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteMany,
+			},
+			ClaimRef: &corev1.ObjectReference{
+				Namespace: pvcNamespace,
+				Name:      pvcName,
 			},
 
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,


### PR DESCRIPTION
Switch `lifecycle-cpu-isolation` tests to use the `Serial` ginkgo decorator as I have seen differences during parallel runs on systems with a lot of CPUs (QE runners have 16 cores) and the free tier Github Ubuntu runners which have 2 cores.  

Bonus changes:
- Utilize `DeferCleanup` instead of appending to a slice for the names of the RTC's created during tests.
- Set a `ClaimRef` in the `PersistentVolume` objects we are creating so they are explicitly bound to certain PVCs.
- Put some NumCPU safeguards in the CPU isolation tests to make sure we have at least > 2 CPUs available on the Kind machines.