### PR TITLE
Create unit tests for cluster role bindings and others

### DIFF
--- a/tests/accesscontrol/tests/access_control_crd_roles.go
+++ b/tests/accesscontrol/tests/access_control_crd_roles.go
@@ -63,12 +63,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		testRole := globalhelper.DefineRole("memcached-role", randomNamespace)
 		globalhelper.RedefineRoleWithAPIGroups(testRole, []string{tsparams.TnfCustomResourceAPIGroupName})
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName})
-		err = globalhelper.CreateRole(testRole)
+		err = globalhelper.CreateRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole)
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
 			By("Delete role")
-			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			err = globalhelper.DeleteRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole.Name, testRole.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -92,12 +92,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		testRole := globalhelper.DefineRole("memcached-role", randomNamespace)
 		globalhelper.RedefineRoleWithAPIGroups(testRole, []string{tsparams.TnfCustomResourceAPIGroupName, "rbac.authorization.k8s.io"})
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName})
-		err = globalhelper.CreateRole(testRole)
+		err = globalhelper.CreateRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole)
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
 			By("Delete role")
-			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			err = globalhelper.DeleteRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole.Name, testRole.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -121,12 +121,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		testRole := globalhelper.DefineRole("memcached-role", randomNamespace)
 		globalhelper.RedefineRoleWithAPIGroups(testRole, []string{tsparams.TnfCustomResourceAPIGroupName})
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName, "pods"})
-		err = globalhelper.CreateRole(testRole)
+		err = globalhelper.CreateRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole)
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
 			By("Delete role")
-			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			err = globalhelper.DeleteRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole.Name, testRole.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -150,12 +150,12 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		testRole := globalhelper.DefineRole("memcached-role", randomNamespace)
 		globalhelper.RedefineRoleWithAPIGroups(testRole, []string{"bad.example.com"})
 		globalhelper.RedefineRoleWithResources(testRole, []string{tsparams.TnfCustomResourceResourceName})
-		err = globalhelper.CreateRole(testRole)
+		err = globalhelper.CreateRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole)
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
 			By("Delete role")
-			err = globalhelper.DeleteRole(testRole.Name, testRole.Namespace)
+			err = globalhelper.DeleteRole(globalhelper.GetAPIClient().K8sClient.RbacV1(), testRole.Name, testRole.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -30,7 +30,8 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 			[]string{})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		err = globalhelper.CreateServiceAccount(tsparams.ServiceAccountName, randomNamespace)
+		err = globalhelper.CreateServiceAccount(globalhelper.GetAPIClient().K8sClient.CoreV1(),
+			tsparams.ServiceAccountName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/accesscontrol/tests/access_control_pod_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_role_bindings.go
@@ -160,6 +160,11 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		err = namespaces.Create(anotherNamespace, globalhelper.GetAPIClient())
 		Expect(err).ToNot(HaveOccurred())
 
+		DeferCleanup(func() {
+			err = namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, anotherNamespace, tsparams.Timeout)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		// Create role binding in a new namespace
 		err = globalhelper.CreateRoleBindingWithServiceAccountSubject(globalhelper.GetAPIClient().K8sClient.RbacV1(),
 			tsparams.TestRoleBindingName,
@@ -176,9 +181,6 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfPodRoleBindings,
 			globalparameters.TestCaseFailed)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = namespaces.DeleteAndWait(globalhelper.GetAPIClient().CoreV1Interface, anotherNamespace, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/accesscontrol/tests/access_control_pod_service_account.go
+++ b/tests/accesscontrol/tests/access_control_pod_service_account.go
@@ -36,7 +36,8 @@ var _ = Describe("Access-control pod-service-account,", func() {
 	It("one pod with valid service account", func() {
 
 		By("Create service account")
-		err := globalhelper.CreateServiceAccount(tsparams.TestServiceAccount, randomNamespace)
+		err := globalhelper.CreateServiceAccount(globalhelper.GetAPIClient().K8sClient.CoreV1(),
+			tsparams.TestServiceAccount, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Define pod with service account")

--- a/tests/globalhelper/clusterrolebindings.go
+++ b/tests/globalhelper/clusterrolebindings.go
@@ -1,0 +1,37 @@
+package globalhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedrbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+func CreateClusterRoleBinding(client typedrbacv1.RbacV1Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
+	_, err := client.ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		glog.V(5).Info(fmt.Sprintf("cluster role binding %s already exists", clusterRoleBinding.Name))
+	} else if err != nil {
+		return fmt.Errorf("failed to create cluster role binding: %w", err)
+	}
+
+	return nil
+}
+
+func DeleteClusterRoleBinding(client typedrbacv1.RbacV1Interface, name string) error {
+	// Exit if the cluster role binding does not exist
+	_, err := client.ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+
+	if err := client.ClusterRoleBindings().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete cluster role binding: %w", err)
+	}
+
+	return nil
+}

--- a/tests/globalhelper/clusterrolebindings_test.go
+++ b/tests/globalhelper/clusterrolebindings_test.go
@@ -1,0 +1,67 @@
+package globalhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateClusterRoleBinding(t *testing.T) {
+	testCases := []struct {
+		crbAlreadyExists bool
+	}{
+		{crbAlreadyExists: false},
+		{crbAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.crbAlreadyExists {
+			// Create a fake cluster role binding object
+			runtimeObjects = append(runtimeObjects, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testCRB",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, CreateClusterRoleBinding(client.RbacV1(), &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testCRB",
+			},
+		}))
+	}
+}
+
+func TestDeleteClusterRoleBinding(t *testing.T) {
+	testCases := []struct {
+		crbAlreadyExists bool
+	}{
+		{crbAlreadyExists: false},
+		{crbAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.crbAlreadyExists {
+			// Create a fake cluster role binding object
+			runtimeObjects = append(runtimeObjects, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testCRB",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, DeleteClusterRoleBinding(client.RbacV1(), "testCRB"))
+	}
+}

--- a/tests/globalhelper/rbac_test.go
+++ b/tests/globalhelper/rbac_test.go
@@ -1,0 +1,218 @@
+package globalhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateServiceAccount(t *testing.T) {
+	testCases := []struct {
+		saAlreadyExists bool
+	}{
+		{saAlreadyExists: false},
+		{saAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.saAlreadyExists {
+			// Create a fake service account object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSA",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, CreateServiceAccount(client.CoreV1(), "testSA", "default"))
+	}
+}
+
+func TestDeleteServiceAccount(t *testing.T) {
+	testCases := []struct {
+		saAlreadyExists bool
+	}{
+		{saAlreadyExists: false},
+		{saAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.saAlreadyExists {
+			// Create a fake service account object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSA",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, DeleteServiceAccount(client.CoreV1(), "testSA", "default"))
+	}
+}
+
+func TestDefineRole(t *testing.T) {
+	testCases := []struct {
+		roleName  string
+		namespace string
+	}{
+		{roleName: "testRole", namespace: "default"},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.roleName, DefineRole(tc.roleName, tc.namespace).Name)
+		assert.Equal(t, tc.namespace, DefineRole(tc.roleName, tc.namespace).Namespace)
+	}
+}
+
+func TestRedefineRoleWithAPIGroups(t *testing.T) {
+	testCases := []struct {
+		roleName  string
+		namespace string
+	}{
+		{roleName: "testRole", namespace: "default"},
+	}
+
+	for _, tc := range testCases {
+		role := DefineRole(tc.roleName, tc.namespace)
+		role.Rules[0].APIGroups = []string{"testAPIGroup"}
+		assert.Equal(t, []string{"testAPIGroup"}, role.Rules[0].APIGroups)
+	}
+}
+
+func TestRedefineRoleWithResources(t *testing.T) {
+	testCases := []struct {
+		roleName  string
+		namespace string
+	}{
+		{roleName: "testRole", namespace: "default"},
+	}
+
+	for _, tc := range testCases {
+		role := DefineRole(tc.roleName, tc.namespace)
+		role.Rules[0].Resources = []string{"testResource"}
+		assert.Equal(t, []string{"testResource"}, role.Rules[0].Resources)
+	}
+}
+
+func TestCreateRole(t *testing.T) {
+	testCases := []struct {
+		roleAlreadyExists bool
+	}{
+		{roleAlreadyExists: false},
+		{roleAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.roleAlreadyExists {
+			// Create a fake role object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testRole",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, CreateRole(client.RbacV1(), DefineRole("testRole", "default")))
+	}
+}
+
+func TestDeleteRole(t *testing.T) {
+	testCases := []struct {
+		roleAlreadyExists bool
+	}{
+		{roleAlreadyExists: false},
+		{roleAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.roleAlreadyExists {
+			// Create a fake role object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testRole",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, DeleteRole(client.RbacV1(), "testRole", "default"))
+	}
+}
+
+func TestDeleteRoleBinding(t *testing.T) {
+	testCases := []struct {
+		roleBindingAlreadyExists bool
+	}{
+		{roleBindingAlreadyExists: false},
+		{roleBindingAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.roleBindingAlreadyExists {
+			// Create a fake role binding object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testRoleBinding",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, DeleteRoleBinding(client.RbacV1(), "testRoleBinding", "default"))
+	}
+}
+
+func TestCreateRoleBindingWithServiceAccountSubject(t *testing.T) {
+	testCases := []struct {
+		roleBindingAlreadyExists bool
+	}{
+		{roleBindingAlreadyExists: false},
+		{roleBindingAlreadyExists: true},
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if tc.roleBindingAlreadyExists {
+			// Create a fake role binding object
+			runtimeObjects = append(runtimeObjects, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testRoleBinding",
+					Namespace: "default",
+				},
+			})
+		}
+
+		// Create a fake clientset
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		assert.Nil(t, CreateRoleBindingWithServiceAccountSubject(client.RbacV1(), "testRoleBinding",
+			"my-role", "testSA", "default", "default"))
+	}
+}

--- a/tests/utils/rbac/rbac.go
+++ b/tests/utils/rbac/rbac.go
@@ -39,18 +39,18 @@ func DefineRbacAuthorizationClusterGroupSubjects(subjectNames []string) *[]rbacv
 	return &Subjects
 }
 
-func DefineRbacAuthorizationClusterServiceAccountSubjects(namespace, name string) *rbacv1.ClusterRoleBinding {
+func DefineRbacAuthorizationClusterServiceAccountSubjects(clusterRoleBindingName, serviceAccountNamespace,
+	serviceAccountName string) *rbacv1.ClusterRoleBinding {
 	// Define the RoleBinding
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-cluster-role-binding",
-			Namespace: namespace,
+			Name: clusterRoleBindingName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      name,
-				Namespace: namespace,
+				Name:      serviceAccountName,
+				Namespace: serviceAccountNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
Notable changes: 
- Moved `Create` and `Delete` Cluster Role Binding funcs from helper.go to their own file.
- Cherry picked the changes from #513 into this branch.
- Removed references to `Namespace` fields in cluster role binding objects.