### PR TITLE
Specify interface for Nodes()

### DIFF
--- a/tests/accesscontrol/tests/access_control_crd_roles.go
+++ b/tests/accesscontrol/tests/access_control_crd_roles.go
@@ -34,7 +34,7 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 	BeforeEach(func() {
 		if globalhelper.IsKindCluster() {
 			By("Make masters schedulable")
-			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().CoreV1Interface, true)
+			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().K8sClient.CoreV1().Nodes(), true)
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/tests/lifecycle/helper/helper.go
+++ b/tests/lifecycle/helper/helper.go
@@ -75,13 +75,13 @@ func DefineDaemonSetWithImagePullPolicy(name, namespace string, image string, pu
 // WaitUntilClusterIsStable validates that all nodes are schedulable, and in ready state.
 func WaitUntilClusterIsStable() error {
 	Eventually(func() bool {
-		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient())
+		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
 	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
-	err := nodes.WaitForNodesReady(globalhelper.GetAPIClient(),
+	err := nodes.WaitForNodesReady(globalhelper.GetAPIClient().Nodes(),
 		tsparams.WaitingTime, tsparams.RetryInterval*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to wait for node to become ready: %w", err)

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -42,7 +42,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
-	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/tests/lifecycle/tests/lifecycle_crd_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_crd_scaling.go
@@ -25,7 +25,7 @@ var _ = Describe("lifecycle-crd-scaling", Serial, func() {
 	BeforeEach(func() {
 		if globalhelper.IsKindCluster() {
 			By("Make masters schedulable")
-			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().CoreV1Interface, true)
+			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().Nodes(), true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Enable intrusive tests")

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -21,7 +21,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 	BeforeEach(func() {
 		if globalhelper.IsKindCluster() {
 			By("Make masters schedulable")
-			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().CoreV1Interface, true)
+			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().Nodes(), true)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
@@ -44,7 +44,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48492
 	It("One deployment, replicas are more than 1, podAntiAffinity is set", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 2 {
@@ -72,7 +72,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48495
 	It("Two deployments, replicas are more than 1, podAntiAffinity is set", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -109,7 +109,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48499
 	It("One deployment, replicas are more than 1, podAntiAffinity is not set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 2 {
@@ -135,7 +135,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48500
 	It("Two deployments, replicas are more than 1, podAntiAffinity is not set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -168,7 +168,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 	// 48869
 	It("One deployment, replicas equal to 1, podAntiAffinity is set [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -28,7 +28,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		if globalhelper.IsKindCluster() {
 			By("Make masters schedulable")
-			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().CoreV1Interface, true)
+			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().Nodes(), true)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
@@ -59,7 +59,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47405
 	It("One deployment with PodAntiAffinity, replicas are less than schedulable nodes", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {
@@ -89,7 +89,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47406
 	It("Two deployments with PodAntiAffinity, replicas are less than schedulable nodes", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes < 4 {
@@ -128,7 +128,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47407
 	It("One deployment with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		if schedulableNodes == 0 {
@@ -156,7 +156,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47408
 	It("Two deployments with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
-		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient())
+		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		// all nodes will be scheduled with a pod.

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -27,7 +27,7 @@ var _ = Describe("lifecycle-statefulset-scaling", Serial, func() {
 
 		if globalhelper.IsKindCluster() {
 			By("Make masters schedulable")
-			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().CoreV1Interface, true)
+			err := nodes.EnableMasterScheduling(globalhelper.GetAPIClient().Nodes(), true)
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -214,7 +214,7 @@ func GetClusterMultusInterfaces(namespace string) ([]string, error) {
 	var nodesInterfacesList [][]string
 
 	for _, runningPod := range podsList.Items {
-		isMasterNode, err := nodes.IsNodeMaster(runningPod.Spec.NodeName, globalhelper.GetAPIClient())
+		isMasterNode, err := nodes.IsNodeMaster(runningPod.Spec.NodeName, globalhelper.GetAPIClient().Nodes())
 		if err != nil {
 			return nil, err
 		}

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -42,14 +42,14 @@ var _ = BeforeSuite(func() {
 
 	By("Validate that cluster is Schedulable")
 	Eventually(func() bool {
-		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient())
+		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
 	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
 	By("Validate that all nodes are Ready")
-	err = nodes.WaitForNodesReady(globalhelper.GetAPIClient(), tsparams.WaitingTime, tsparams.RetryInterval)
+	err = nodes.WaitForNodesReady(globalhelper.GetAPIClient().Nodes(), tsparams.WaitingTime, tsparams.RetryInterval)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Set rbac policy which allows authenticated users to run privileged containers")
@@ -57,6 +57,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
-	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -41,17 +41,17 @@ var _ = BeforeSuite(func() {
 
 	By("Validate that cluster is Schedulable")
 	Eventually(func() bool {
-		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient())
+		isClusterReady, err := cluster.IsClusterStable(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
 		return isClusterReady
 	}, tsparams.WaitingTime, tsparams.RetryInterval*time.Second).Should(BeTrue())
 
 	By("Validate that all nodes are Ready")
-	err = nodes.WaitForNodesReady(globalhelper.GetAPIClient(), tsparams.WaitingTime, tsparams.RetryInterval)
+	err = nodes.WaitForNodesReady(globalhelper.GetAPIClient().Nodes(), tsparams.WaitingTime, tsparams.RetryInterval)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
-	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().CoreV1Interface, configSuite.General.CnfNodeLabel)
+	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/tests/utils/cluster/cluster.go
+++ b/tests/utils/cluster/cluster.go
@@ -8,13 +8,13 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	testclient "github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
 	nodesutils "github.com/test-network-function/cnfcert-tests-verification/tests/utils/nodes"
+	corev1Typed "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // IsClusterStable tests if cluster is stable.
-func IsClusterStable(clients *testclient.ClientSet) (bool, error) {
-	nodes, err := clients.Nodes().List(context.TODO(), metav1.ListOptions{})
+func IsClusterStable(client corev1Typed.NodeInterface) (bool, error) {
+	nodes, err := client.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -22,7 +22,7 @@ func IsClusterStable(clients *testclient.ClientSet) (bool, error) {
 	for _, node := range nodes.Items {
 		if node.Spec.Unschedulable {
 			glog.V(5).Info(fmt.Sprintf("node %s is in unschedulable state, trying to uncordon it", node.Name))
-			err := nodesutils.UnCordon(clients, node.Name)
+			err := nodesutils.UnCordon(client, node.Name)
 
 			if err != nil {
 				return false, err

--- a/tests/utils/nodes/nodes_test.go
+++ b/tests/utils/nodes/nodes_test.go
@@ -46,14 +46,14 @@ func TestEnsureAllNodesAreLabeled(t *testing.T) {
 		client := k8sfake.NewSimpleClientset(runtimeObjects...)
 
 		// Label all the nodes accordingly
-		err := EnsureAllNodesAreLabeled(client.CoreV1(), "testValue")
+		err := EnsureAllNodesAreLabeled(client.CoreV1().Nodes(), "testValue")
 		assert.Nil(t, err)
 
 		// Without generating a runtimeObject
-		err = EnsureAllNodesAreLabeled(client.CoreV1(), "worker-cnf")
+		err = EnsureAllNodesAreLabeled(client.CoreV1().Nodes(), "worker-cnf")
 		assert.Nil(t, err)
 
-		err = EnsureAllNodesAreLabeled(client.CoreV1(), "node-role.kubernetes.io/worker-cnf")
+		err = EnsureAllNodesAreLabeled(client.CoreV1().Nodes(), "node-role.kubernetes.io/worker-cnf")
 		assert.Nil(t, err)
 
 		// Get all of the nodes from the fake client and test their labels


### PR DESCRIPTION
Utilize the `NodeInterface`.

Instead of passing around the entire `testclient.ClientSet`, just ask for what we need.  In this case we are only utilizing NodeInterface functionality.