### PR TITLE
Reorg installPlan funcs

### DIFF
--- a/tests/accesscontrol/helper/helper.go
+++ b/tests/accesscontrol/helper/helper.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/client"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/container"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/installplan"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/service"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -106,18 +104,6 @@ func SetServiceAccountAutomountServiceAccountToken(namespace, saname, value stri
 
 	_, err = globalhelper.GetAPIClient().ServiceAccounts(namespace).
 		Update(context.TODO(), serviceacct, metav1.UpdateOptions{})
-
-	return err
-}
-
-func DefineAndCreateInstallPlan(name, namespace string, clientSet *client.ClientSet) error {
-	plan := installplan.DefineInstallPlan(name, namespace)
-
-	err := globalhelper.GetAPIClient().Create(context.TODO(), plan)
-
-	if k8serrors.IsAlreadyExists(err) {
-		return nil
-	}
 
 	return err
 }

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -4,10 +4,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/installplan"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/subscription"
 )
 
@@ -177,9 +177,11 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resource")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", randomNamespace,
-			globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -217,8 +219,11 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resource")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", invalidNamespace, globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", invalidNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -256,13 +261,18 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resources")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", randomNamespace,
-			globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
-		err = tshelper.DefineAndCreateInstallPlan("test-plan-2", additionalValidNamespace,
-			globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan2 := installplan.DefineInstallPlan("test-plan-2", additionalValidNamespace)
+
+		By("Create Install Plan in Namespace: " + plan2.Namespace)
+		err = globalhelper.CreateInstallPlan(plan2)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -300,11 +310,18 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resources")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", randomNamespace, globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
-		err = tshelper.DefineAndCreateInstallPlan("test-plan-2", invalidNamespace, globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan2 := installplan.DefineInstallPlan("test-plan-2", invalidNamespace)
+
+		By("Create Install Plan in Namespace: " + plan2.Namespace)
+		err = globalhelper.CreateInstallPlan(plan2)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Start test")
@@ -332,9 +349,11 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com", "subscriptions.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resources")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", randomNamespace,
-			globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Define and create subscription")
@@ -382,9 +401,11 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 			[]string{"installplans.operators.coreos.com", "subscriptions.operators.coreos.com"})
 		Expect(err).ToNot(HaveOccurred(), "error defining tnf config file")
 
-		By("Create custom resources")
-		err = tshelper.DefineAndCreateInstallPlan("test-plan", randomNamespace,
-			globalhelper.GetAPIClient())
+		By("Define Install Plan")
+		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
+
+		By("Create Install Plan in Namespace: " + plan.Namespace)
+		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Define and create subscription")

--- a/tests/globalhelper/installplans.go
+++ b/tests/globalhelper/installplans.go
@@ -1,0 +1,23 @@
+package globalhelper
+
+import (
+	"context"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1alpha1typed "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateInstallPlan(plan *v1alpha1.InstallPlan) error {
+	return createInstallPlan(plan, GetAPIClient().OperatorsV1alpha1Interface)
+}
+
+func createInstallPlan(plan *v1alpha1.InstallPlan, opclient v1alpha1typed.OperatorsV1alpha1Interface) error {
+	_, err := opclient.InstallPlans(plan.Namespace).Create(context.Background(), plan, metav1.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return err
+}


### PR DESCRIPTION
Removed the `accesscontrol` function `DefineAndCreateInstallPlan` and utilize the same style as #524.