### PR TITLE
Remove global variable TC name from observability suite

### DIFF
--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -36,8 +36,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51747
 	It("One deployment one pod one container that prints two log lines", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -48,7 +46,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -58,8 +57,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51753
 	It("One deployment one pod one container that prints one log line", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -70,7 +67,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -80,8 +78,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51754
 	It("One deployment one pod with two containers, both containers print two log lines to stdout", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -92,7 +88,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -102,8 +99,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51755
 	It("One daemonset with two containers, first prints two lines, the second one line", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		if globalhelper.IsKindCluster() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
@@ -117,7 +112,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -127,8 +123,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51756
 	It("Two deployments, two pods with two containers each, all printing 1 log line", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		if globalhelper.IsKindCluster() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
@@ -152,7 +146,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -163,8 +158,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 	// 51757
 	It("One deployment and one statefulset, both having one pod with one container that prints one log "+
 		"line each", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -184,7 +177,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -194,8 +188,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51758
 	It("One pod with one container that prints one log line to stdout", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create pod in the cluster")
 		pod := tshelper.DefinePodWithStdoutBuffer(
 			tsparams.TestPodBaseName, randomNamespace, tsparams.OneLogLine)
@@ -204,7 +196,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -214,8 +207,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51759
 	It("One pod with one container that prints to stdout one log line starting with a tab char", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create pod in the cluster")
 		pod := tshelper.DefinePodWithStdoutBuffer(tsparams.TestPodBaseName, randomNamespace,
 			"\t"+tsparams.OneLogLine)
@@ -224,7 +215,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -234,8 +226,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51760
 	It("One deployment one pod one container without any log line to stdout [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -246,7 +236,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -256,8 +247,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51761
 	It("One deployment one pod two containers but only one printing one log line [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -268,7 +257,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -278,8 +268,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51762
 	It("Two deployments one pod two containers each, first deployment passing but second fails [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment1 in the cluster whose containers print one line to stdout each")
 		deployment1 := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName+"1", randomNamespace, 1,
@@ -299,7 +287,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -309,8 +298,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51763
 	It("One pod one container without any log line to stdout [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create pod in the cluster")
 		pod := tshelper.DefinePodWithStdoutBuffer(tsparams.TestPodBaseName, randomNamespace,
 			tsparams.NoLogLines)
@@ -319,7 +306,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -330,8 +318,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 	// 51764
 	It("One deployment and one statefulset both one container each, but only deployment prints "+
 		"one log line [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
@@ -351,7 +337,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -361,8 +348,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51765
 	It("One deployment one pod one container printing one log line without newline char", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		if globalhelper.IsKindCluster() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
@@ -377,7 +362,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -388,8 +374,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 	// 51767
 	It("One deployment one pod two containers, first prints one line, second prints "+
 		"one line without newline", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		if globalhelper.IsKindCluster() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
@@ -404,7 +388,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -414,8 +399,6 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51768
 	It("One deployment with one pod and one container without TNF target labels [skip]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment without TNF target labels in the cluster")
 		deployment := tshelper.DefineDeploymentWithoutTargetLabels(
 			tsparams.TestDeploymentBaseName, randomNamespace)
@@ -425,7 +408,8 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/observability/tests/crd_status.go
+++ b/tests/observability/tests/crd_status.go
@@ -31,8 +31,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52444
 	It("One CRD created with status subresource", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrd", tsparams.CrdSuffix1)
 
@@ -43,7 +41,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd1.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -53,8 +51,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52445
 	It("Two CRDs created, both with status subresource", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
@@ -72,7 +68,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd2.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -82,8 +78,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52446
 	It("One CRD created without status subresource [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrd", tsparams.CrdSuffix1)
 
@@ -94,7 +88,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd1.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -104,8 +98,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52447
 	It("Two CRDs created, one with and the other without status subresource [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
@@ -123,7 +115,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd2.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -133,8 +125,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52448
 	It("Two CRDs created, both without status subresource [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
@@ -152,7 +142,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd2.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -162,8 +152,6 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52449
 	It("One CRD deployed not having any of the configured suffixes [skip]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create CRD in the cluster with suffix " + tsparams.NotConfiguredCrdSuffix)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdOne",
 			tsparams.NotConfiguredCrdSuffix)
@@ -175,7 +163,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 		crdNames = append(crdNames, crd1.Name)
 
 		By("Start TNF " + tsparams.TnfCrdStatusTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfCrdStatusTcName, globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -39,8 +39,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56635
 	It("One deployment, pod disruption budget minAvailable value meet requirements", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -58,7 +56,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -68,8 +67,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56636
 	It("One deployment, pod disruption budget maxUnavailable value meet requirements", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -87,7 +84,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -97,8 +95,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56637
 	It("One statefulSet, pod disruption budget minAvailable value is zero [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create statefulSet")
 		sf := statefulset.DefineStatefulSet(tsparams.TestStatefulSetBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -116,7 +112,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -126,8 +123,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56638
 	It("One deployment, pod disruption budget maxUnavailable equals to replica number [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -145,7 +140,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -155,8 +151,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56746
 	It("One deployment, pod disruption budget maxUnavailable is bigger than the replica number [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -174,7 +168,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -183,8 +178,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 	})
 
 	It("One deployment, pod disruption budget matchLabels does not match deployment label [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -202,7 +195,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -211,8 +205,6 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 	})
 
 	It("One deployment, no pod disruption budget [negative]", func() {
-		qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 		By("Create deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
@@ -223,7 +215,8 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -12,8 +12,6 @@ import (
 )
 
 var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
-	qeTcFileName := globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText())
-
 	var randomNamespace string
 	var origReportDir string
 	var origTnfConfigDir string
@@ -38,7 +36,6 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 	// Positive #1.
 	It("One deployment one pod one container with terminationMessagePolicy set to FallbackToLogsOnError", func() {
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
@@ -48,7 +45,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -58,7 +56,6 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 	// // Positive #2.
 	It("One deployment one pod two containers both with terminationMessagePolicy set to FallbackToLogsOnError", func() {
-
 		By("Create deployment in the cluster")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{
@@ -70,7 +67,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -94,7 +92,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -123,7 +122,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -143,7 +143,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -167,7 +168,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -189,7 +191,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -218,7 +221,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -247,7 +251,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")
@@ -265,7 +270,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
-		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName, qeTcFileName)
+		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Junit and Claim reports")


### PR DESCRIPTION
Remove the `qeTcFileName` global variable and align the observability suite test cases with the other suites about how `LaunchTests` is called.

We were seeing instances in parallel runs where `qeTcFileName` was empty strings and I'm thinking it has to do with the global variable.