### PR TITLE
Add assertions for daemonset resources

### DIFF
--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -135,6 +135,12 @@ var _ = Describe("lifecycle-container-startup", func() {
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert DaemonSet is without postStart spec")
+		runningDaemonset, err := globalhelper.GetRunningDaemonset(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDaemonset.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(runningDaemonset.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
+
 		By("Start lifecycle-container-startup test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -198,6 +198,14 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert DaemonSet is with runTimeClass and CPU resources")
+		runningDaemonset, err := globalhelper.GetRunningDaemonset(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDaemonset.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(runningDaemonset.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1"))
+		Expect(runningDaemonset.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("1"))
+		Expect(*runningDaemonset.Spec.Template.Spec.RuntimeClassName).To(Equal(rtc.Name))
+
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -103,8 +103,14 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
+		By("Create DaemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that DaemonSet has ifNotPresent as ImagePullPolicy")
+		pullPolicy, err := globalhelper.GetDaemonSetPullPolicy(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullIfNotPresent))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -126,17 +132,32 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSeta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that DaemonSetA has ifNotPresent as ImagePullPolicy")
+		pullPolicy, err := globalhelper.GetDaemonSetPullPolicy(daemonSeta)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullIfNotPresent))
+
 		daemonSetb := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsb",
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that DaemonSetB has ifNotPresent as ImagePullPolicy")
+		pullPolicy, err = globalhelper.GetDaemonSetPullPolicy(daemonSetb)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullIfNotPresent))
+
 		daemonSetc := tshelper.DefineDaemonSetWithImagePullPolicy("lifecycle-dsc",
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullIfNotPresent)
 
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSetc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that DaemonSetC has ifNotPresent as ImagePullPolicy")
+		pullPolicy, err = globalhelper.GetDaemonSetPullPolicy(daemonSetc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullIfNotPresent))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -159,6 +180,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that DaemonSet has Always as ImagePullPolicy")
+		pullPolicy, err := globalhelper.GetDaemonSetPullPolicy(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullAlways))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -254,6 +280,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that DaemonSet has Never as ImagePullPolicy")
+		pullPolicy, err := globalhelper.GetDaemonSetPullPolicy(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pullPolicy).To(Equal(corev1.PullNever))
 
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -137,6 +137,11 @@ var _ = Describe("lifecycle-liveness", func() {
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert DaemonSet is without a liveness probe")
+		runningDaemonset, err := globalhelper.GetRunningDaemonset(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDaemonset.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
+
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))


### PR DESCRIPTION
Adds some assertions after resource creation to verify that things are set that way they should be prior to running the TNF suite tests.

Bonus!  Adds some additional logic to the `isDaemonsetReady` function to help determine readiness.