### PR TITLE
Add assertions for deployments

### DIFF
--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -44,6 +44,11 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has no securityContext RunAsUser 0")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNonRootUser,
@@ -68,6 +73,12 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has securityContext RunAsUser 0")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(0)))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNonRootUser,
@@ -90,13 +101,22 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has no securityContext RunAsUser 0")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
+
+		By("Define deployment with securityContext RunAsUser set as 0")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1338)
-
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has no securityContext RunAsUser 0")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -122,11 +142,22 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has securityContext RunAsUser 0")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(0)))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has no securityContext")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -140,5 +171,4 @@ var _ = Describe("Access-control non-root user,", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/deployment"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Access-control ipc-lock-capability-check,", func() {
@@ -44,6 +45,11 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have IPC_LOCK capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlIpcLockCapability,
@@ -68,6 +74,12 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does have IPC_LOCK capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
+			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("IPC_LOCK")))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlIpcLockCapability,
@@ -90,11 +102,21 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have IPC_LOCK capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have IPC_LOCK capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -120,11 +142,22 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does have IPC_LOCK capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
+			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("IPC_LOCK")))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have IPC_LOCK capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -138,5 +171,4 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -3,6 +3,7 @@ package accesscontrol
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
@@ -44,6 +45,11 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have NET_ADMIN capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetAdminCapability,
@@ -68,6 +74,12 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has NET_ADMIN capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
+			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("NET_ADMIN")))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetAdminCapability,
@@ -90,11 +102,21 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 does not have NET_ADMIN capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 does not have NET_ADMIN capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -120,11 +142,22 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has NET_ADMIN capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
+			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("NET_ADMIN")))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have NET_ADMIN capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -3,6 +3,7 @@ package accesscontrol
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
@@ -44,6 +45,11 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have NET_RAW capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetRawCapability,
@@ -68,6 +74,12 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has NET_RAW capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
+			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("NET_RAW")))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetRawCapability,
@@ -90,11 +102,21 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have NET_RAW capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have NET_RAW capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -120,11 +142,22 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has NET_RAW capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("NET_RAW")))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have NET_RAW capability")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -44,6 +44,11 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has no securityContext RunAsUser 1337")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNo1337Uid,
@@ -68,6 +73,12 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has securityContext RunAsUser 1337")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(1337)))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNo1337Uid,
@@ -90,13 +101,23 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has no securityContext RunAsUser")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1338)
+		deployment.RedefineWithPodSecurityContextRunAsUser(dep2, 1338)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has securityContext RunAsUser 1338")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -122,11 +143,22 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has securityContext RunAsUser 1337")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(1337)))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has no securityContext")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -49,6 +49,13 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert all services in namespace are not nodeport")
+		services, err := globalhelper.GetServicesFromNamespace(randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, service := range services {
+			Expect(service.Spec.Type).ToNot(Equal(corev1.ServiceTypeNodePort))
+		}
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNodePortTcName,
@@ -76,6 +83,13 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert all services in namespace are not nodeport")
+		services, err := globalhelper.GetServicesFromNamespace(randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, service := range services {
+			Expect(service.Spec.Type).ToNot(Equal(corev1.ServiceTypeNodePort))
+		}
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -110,6 +124,13 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert all services in namespace are not nodeport")
+		services, err := globalhelper.GetServicesFromNamespace(randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, service := range services {
+			Expect(service.Spec.Type).ToNot(Equal(corev1.ServiceTypeNodePort))
+		}
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNodePortTcName,
@@ -138,6 +159,15 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert testservice in namespace is type nodePort")
+		services, err := globalhelper.GetServicesFromNamespace(randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, service := range services {
+			if service.Name == "testservice" {
+				Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}
+		}
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNodePortTcName,
@@ -149,7 +179,6 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 			tsparams.TnfNodePortTcName,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	// 45484
@@ -170,6 +199,17 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert the services in namespace have corresponding nodeport statuses")
+		services, err := globalhelper.GetServicesFromNamespace(randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, service := range services {
+			if service.Name == "testservicefirst" {
+				Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			} else if service.Name == "testservicesecond" {
+				Expect(service.Spec.Type).ToNot(Equal(corev1.ServiceTypeNodePort))
+			}
+		}
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -52,6 +52,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment automountServiceAccountToken is false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
@@ -78,6 +85,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment automountServiceAccountToken is true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
@@ -101,6 +115,12 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment automountServiceAccountToken is nil")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeNil())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
 
 		By("Set namespace's default serviceaccount's automountServiceAccountToken to false")
 		err = tshelper.SetServiceAccountAutomountServiceAccountToken(randomNamespace,
@@ -136,6 +156,15 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 			tsparams.ServiceAccountName, "true")
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment serviceaccount name is set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
+		// Deployment is running so this is already nil
+		By("Assert deployment automountServiceAccountToken nil")
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
@@ -164,6 +193,14 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = tshelper.SetServiceAccountAutomountServiceAccountToken(randomNamespace,
 			tsparams.ServiceAccountName, "nil")
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment serviceaccount name is set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
+		By("Assert deployment automountServiceAccountToken is nil")
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -196,6 +233,15 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 			tsparams.ServiceAccountName, "true")
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment serviceaccount name is set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
+		By("Assert deployment automountServiceAccountToken is false")
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
@@ -222,6 +268,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment automountServiceAccountToken is false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -231,6 +284,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment automountServiceAccountToken is false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment2.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+		Expect(runningDeployment2.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -258,6 +318,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment automountServiceAccountToken is true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -267,6 +334,13 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment automountServiceAccountToken is false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+		Expect(*runningDeployment2.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+		Expect(runningDeployment2.Spec.Template.Spec.ServiceAccountName).To(Equal(tsparams.ServiceAccountName))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -279,7 +353,5 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -37,7 +37,7 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 
 	// 56427
 	It("one deployment, one pod, does not have cluster role binding", func() {
-		By("Define deployment that do not have rolebinding")
+		By("Define deployment that do not have cluster role binding")
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -86,6 +86,11 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has service account")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal("my-service-account"))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -46,6 +46,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has hostIPC set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostIPC).To(BeFalse())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostIpc,
@@ -69,6 +74,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has hostIPC set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostIPC).To(BeTrue())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -94,6 +104,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has hostIPC set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostIPC).To(BeFalse())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +116,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostIPC set to false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.HostIPC).To(BeFalse())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -126,6 +146,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has hostIPC set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostIPC).To(BeTrue())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -133,6 +158,11 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostIPC set to false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.HostIPC).To(BeFalse())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -146,5 +176,4 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -46,6 +46,11 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has hostNetwork set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostNetwork).To(BeFalse())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostNetwork,
@@ -70,6 +75,11 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has hostNetwork set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostNetwork).To(BeTrue())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostNetwork,
@@ -93,6 +103,11 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has hostNetwork set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostNetwork).To(BeFalse())
 
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -126,6 +141,11 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has hostNetwork set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostNetwork).To(BeTrue())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -133,6 +153,11 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostNetwork set to false")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostNetwork).To(BeFalse())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -146,5 +171,4 @@ var _ = Describe("Access-control pod-host-network ", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -44,6 +44,13 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have hostPath set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment.Spec.Template.Spec.Volumes {
+			Expect(volume.HostPath).To(BeNil())
+		}
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPath,
@@ -68,6 +75,15 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has hostPath set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment.Spec.Template.Spec.Volumes {
+			if volume.Name == "volume" {
+				Expect(volume.HostPath).ToNot(BeNil())
+			}
+		}
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPath,
@@ -90,11 +106,25 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 does not have hostPath set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment.Spec.Template.Spec.Volumes {
+			Expect(volume.HostPath).To(BeNil())
+		}
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 does not have hostPath set")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment2.Spec.Template.Spec.Volumes {
+			Expect(volume.HostPath).To(BeNil())
+		}
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -118,6 +148,13 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 does not have hostPath set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment.Spec.Template.Spec.Volumes {
+			Expect(volume.HostPath).To(BeNil())
+		}
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -125,6 +162,15 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostPath set")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, volume := range runningDeployment2.Spec.Template.Spec.Volumes {
+			if volume.Name == "volume" {
+				Expect(volume.HostPath).ToNot(BeNil())
+			}
+		}
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -138,5 +184,4 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -46,6 +46,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has hostPid set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostPID).To(BeFalse())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPid,
@@ -69,6 +74,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has hostPid set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostPID).To(BeTrue())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -94,6 +104,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has hostPid set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostPID).To(BeFalse())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +116,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostPid set to false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.HostPID).To(BeFalse())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -126,6 +146,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has hostPid set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.HostPID).To(BeTrue())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -133,6 +158,11 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has hostPid set to false")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.HostPID).To(BeFalse())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -146,5 +176,4 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -47,6 +47,14 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment has requests and limits set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal(tsparams.CPULimit))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(tsparams.MemoryLimit))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(tsparams.CPURequest))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
@@ -71,6 +79,12 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment has no limits set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("0"))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
@@ -92,6 +106,14 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has no limits or requests set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("0"))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -118,6 +140,12 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment has CPU limits not set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(tsparams.CPURequest))
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
@@ -142,6 +170,12 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment has memory limits not set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("0"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -168,6 +202,14 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment1 has requests and limits set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal(tsparams.CPULimit))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(tsparams.MemoryLimit))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(tsparams.CPURequest))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -176,6 +218,14 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment2 has requests and limits set")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal(tsparams.CPULimit))
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(tsparams.MemoryLimit))
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(tsparams.CPURequest))
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -202,6 +252,12 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment1 has memory limits set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(tsparams.MemoryLimit))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -210,6 +266,12 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment2 has memory limits not set")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("0"))
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(tsparams.MemoryRequest))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -44,6 +44,11 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment does not allow privilege escalation")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPrivilegeEscalation,
@@ -67,6 +72,13 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment does allow privilege escalation")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(0)))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -92,11 +104,22 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment1 does not allow privilege escalation")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment2 does not allow privilege escalation")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -122,11 +145,22 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment1 does allow privilege escalation")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment2 does not allow privilege escalation")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -140,5 +174,4 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -3,6 +3,7 @@ package accesscontrol
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
@@ -44,6 +45,11 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have security context set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysAdminCapability,
@@ -68,6 +74,14 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has security context SYS_ADMIN set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_ADMIN")))
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(0)))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).ToNot(BeNil())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysAdminCapability,
@@ -90,11 +104,21 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 does not have security context set")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 does not have security context set")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -120,11 +144,22 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has SYS_ADMIN capability")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_ADMIN")))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 does not have security context set")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -138,5 +173,4 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -3,6 +3,7 @@ package accesscontrol
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/helper"
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/accesscontrol/parameters"
@@ -46,6 +47,11 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has shareProcessNamespace set to false")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeFalse())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysPtraceCapability,
@@ -66,11 +72,17 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
-
 		deployment.RedefineWithSysPtrace(dep)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has shareProcessNamespace set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_PTRACE")))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -96,6 +108,11 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has shareProcessNamespace set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
+
 		By("Start test")
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysPtraceCapability,
@@ -116,21 +133,33 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
-
 		deployment.RedefineWithSysPtrace(dep)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment1 has shareProcessNamespace set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_PTRACE")))
+
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep2, true)
-
 		deployment.RedefineWithSysPtrace(dep2)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has shareProcessNamespace set to true")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_PTRACE")))
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -152,11 +181,17 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
-
 		deployment.RedefineWithSysPtrace(dep)
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment1 has shareProcessNamespace set to true")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add).
+			To(ContainElement(corev1.Capability("SYS_PTRACE")))
 
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -165,6 +200,11 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment2 has shareProcessNamespace set to true")
+		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -70,3 +70,21 @@ func createAndWaitUntilDeploymentIsReady(client typedappsv1.AppsV1Interface, dep
 
 	return nil
 }
+
+// GetRunningDeployment returns a running deployment.
+func GetRunningDeployment(namespace, deploymentName string) (*appsv1.Deployment, error) {
+	return getRunningDeployment(GetAPIClient().K8sClient.AppsV1(), namespace, deploymentName)
+}
+
+func getRunningDeployment(client typedappsv1.AppsV1Interface, namespace, deploymentName string) (*appsv1.Deployment, error) {
+	runningDeployment, err := client.Deployments(namespace).Get(
+		context.TODO(),
+		deploymentName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment %q (ns %s): %w", deploymentName, namespace, err)
+	}
+
+	return runningDeployment, nil
+}

--- a/tests/globalhelper/services.go
+++ b/tests/globalhelper/services.go
@@ -1,0 +1,22 @@
+package globalhelper
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetServicesFromNamespace(namespace string) (services []corev1.Service, err error) {
+	return getServicesFromNamespace(namespace, GetAPIClient().K8sClient)
+}
+
+func getServicesFromNamespace(namespace string, client kubernetes.Interface) ([]corev1.Service, error) {
+	services, err := client.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return services.Items, nil
+}

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -47,6 +47,11 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has prestop configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).ToNot(BeNil())
+
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfShutdownTcName,
@@ -67,6 +72,11 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have prestop configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
@@ -91,6 +101,11 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has prestop configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).ToNot(BeNil())
+
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfShutdownTcName,
@@ -114,6 +129,11 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has prestop configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).ToNot(BeNil())
+
 		By("Define second deployment with preStop field configured")
 		deploymentb, err := tshelper.DefineDeployment(3, 2, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -122,6 +142,11 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has prestop configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).ToNot(BeNil())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(
@@ -168,12 +193,22 @@ var _ = Describe("lifecycle-container-shutdown", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have prestop configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
+
 		By("Define and create second deployment")
 		deploymentb, err := tshelper.DefineDeployment(3, 2, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have prestop configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
 
 		By("Start lifecycle-container-shutdown test")
 		err = globalhelper.LaunchTests(

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -47,6 +47,11 @@ var _ = Describe("lifecycle-container-startup", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has postStart configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PostStart).ToNot(BeNil())
+
 		By("Start lifecycle-container-startup test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -68,6 +73,11 @@ var _ = Describe("lifecycle-container-startup", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has postStart configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PostStart).ToNot(BeNil())
+
 		By("Define second deployment with postStart spec")
 		deploymentb, err := tshelper.DefineDeployment(1, 2, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -76,6 +86,11 @@ var _ = Describe("lifecycle-container-startup", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has postStart configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PostStart).ToNot(BeNil())
 
 		By("Start lifecycle-container-startup test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,
@@ -162,12 +177,22 @@ var _ = Describe("lifecycle-container-startup", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has postStart configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Lifecycle.PostStart).ToNot(BeNil())
+
 		By("Define second deployment without postStart spec")
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have postStart configured")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
 
 		By("Start lifecycle-container-startup test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -156,6 +156,13 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has runTimeClass configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Template.Spec.RuntimeClassName).To(Equal(rtc.Name))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1"))
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("1"))
+
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -254,7 +261,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 
 		annotationsMap := make(map[string]string)
 
-		By("Define deployment with resources and runTimeClass")
+		By("Define deployment with resources and no runTimeClass")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels)
 
@@ -267,6 +274,11 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has runTimeClass configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.RuntimeClassName).To(BeNil())
 
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -48,6 +48,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has ifNotPresent configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -70,6 +75,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has ifNotPresent configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -78,6 +88,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has ifNotPresent configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+
 		deploymentc, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpc", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -85,6 +100,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has ifNotPresent configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentc.Namespace, deploymentc.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -208,6 +228,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has Always pull policy configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
+
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -229,6 +254,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has Always pull policy configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -252,6 +282,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has Never pull policy configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullNever))
+
 		By("Define deployment with ifNotPresent as ImagePullPolicy")
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -260,6 +295,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has ifNotPresent pull policy configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
@@ -294,6 +334,11 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has ifNotPresent pull policy configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -49,6 +49,11 @@ var _ = Describe("lifecycle-liveness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has liveness probe configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
+
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -70,6 +75,13 @@ var _ = Describe("lifecycle-liveness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert all containers have liveness probe configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, container := range runningDeployment.Spec.Template.Spec.Containers {
+			Expect(container.LivenessProbe).ToNot(BeNil())
+		}
+
 		By("Define second deployment with a liveness probe")
 		deploymentb, err := tshelper.DefineDeployment(3, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -78,6 +90,13 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert all containers have liveness probe configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		for _, container := range runningDeployment.Spec.Template.Spec.Containers {
+			Expect(container.LivenessProbe).ToNot(BeNil())
+		}
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,
@@ -163,12 +182,22 @@ var _ = Describe("lifecycle-liveness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has liveness probe configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
+
 		By("Define second deployment without a liveness probe")
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have liveness probe configured")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -73,6 +73,11 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has persistent volume claim configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(pvc.Name))
+
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -81,7 +86,6 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPersistentVolumeReclaimPolicyTcName, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	// 54202
@@ -197,6 +201,11 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has persistent volume claim configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(pvc.Name))
+
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -306,8 +315,18 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(depa, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has persistent volume claim configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(depa.Namespace, depa.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(pvca.Name))
+
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(depb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has persistent volume claim configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(depb.Namespace, depb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(pvcb.Name))
 
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -60,6 +60,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has podAntiAffinity configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -88,6 +93,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has podAntiAffinity configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+
 		By("Define and create second deployment")
 		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -96,6 +106,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has podAntiAffinity configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
@@ -123,6 +138,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has podAntiAffinity configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity).To(BeNil())
+
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -149,12 +169,22 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have podAntiAffinity configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity).To(BeNil())
+
 		By("Define and create second deployment")
 		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment does not have podAntiAffinity configured")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity).To(BeNil())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
@@ -183,6 +213,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has podAntiAffinity configured")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
 
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -77,6 +77,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has pod anti-affinity")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -107,6 +112,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has pod anti-affinity")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+
 		By("Define and create second deployment")
 		deploymentb, err := tshelper.DefineDeployment(maxPodsPerDeployment, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -115,6 +125,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has pod anti-affinity")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,
@@ -143,6 +158,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has pod anti-affinity")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,
@@ -176,6 +196,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has pod anti-affinity")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+
 		By("Define and create second deployment")
 		deploymentb, err := tshelper.DefineDeployment(maxPodsPerDeploymentPerSecondDeployment, 1,
 			"lifecycle-dpb", randomNamespace)
@@ -185,6 +210,11 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has pod anti-affinity")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
 
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -49,6 +49,11 @@ var _ = Describe("lifecycle-readiness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has readiness probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -70,6 +75,11 @@ var _ = Describe("lifecycle-readiness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has readiness probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+
 		By("Define second deployment with a readiness probe")
 		deploymentb, err := tshelper.DefineDeployment(3, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -78,6 +88,11 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has readiness probe")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(tsparams.TnfReadinessTcName,
@@ -156,12 +171,22 @@ var _ = Describe("lifecycle-readiness", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has readiness probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+
 		By("Define second deployment without a readiness probe")
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has no readiness probe")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(tsparams.TnfReadinessTcName,

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -49,6 +49,11 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has startup probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
+
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -70,6 +75,11 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has startup probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
+
 		By("Define second deployment with a startup probe")
 		deploymentb, err := tshelper.DefineDeployment(3, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -78,6 +88,11 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has startup probe")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
 
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
@@ -139,6 +154,11 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has startup probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
+
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -180,12 +200,22 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deploymenta has startup probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
+
 		By("Define second deployment without a startup probe")
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymentb has no startup probe")
+		runningDeployment, err = globalhelper.GetRunningDeployment(deploymentb.Namespace, deploymentb.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).To(BeNil())
 
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
@@ -208,6 +238,11 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deploymenta has startup probe")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deploymenta.Namespace, deploymenta.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].StartupProbe).ToNot(BeNil())
 
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -62,6 +62,11 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		err := tshelper.DefineAndCreateDeploymentWithContainerPorts(1, []corev1.ContainerPort{{ContainerPort: 15443}}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert that deployment has declared reserved port")
+		runningDeployment, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(15443)))
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfReservedPartnerPortsTcName,

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -47,6 +47,11 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has container port 8080")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(8080)))
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
@@ -70,6 +75,11 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has container port 8081")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(8081)))
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -97,6 +107,11 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has container port 8081")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(8081)))
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
@@ -121,6 +136,11 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment does not have container port 8080")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].Ports).To(BeEmpty())
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
@@ -137,7 +157,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	It("one deployment, one pod, two containers, both containers declare used ports (8080, 8081)", func() {
 
 		By("Define deployment and create it on cluster")
-		ports := []corev1.ContainerPort{{ContainerPort: 8080}, {ContainerPort: 8081}}
+		ports := []corev1.ContainerPort{{ContainerPort: 8080, Protocol: "TCP"}, {ContainerPort: 8081, Protocol: "TCP"}}
 		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 1, ports)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
@@ -167,7 +187,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 	It("one deployment, one pod, two containers, the first one uses and declares port 8080, the second one uses port 8081 but declares 8082 [negative]", func() {
 
 		By("Define deployment and create it on cluster")
-		ports := []corev1.ContainerPort{{ContainerPort: 8080}, {ContainerPort: 8082}}
+		ports := []corev1.ContainerPort{{ContainerPort: 8080, Protocol: "TCP"}, {ContainerPort: 8082, Protocol: "TCP"}}
 		dep, err := tshelper.DefineDeploymentWithContainerPorts("networking-deployment", randomNamespace, 2, ports)
 		Expect(err).ToNot(HaveOccurred())
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -48,6 +48,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has one replica")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(1)))
+
 		By("Create pod disruption budget")
 		pdb := poddisruptionbudget.DefinePodDisruptionBudgetMinAvailable(tsparams.TestPdbBaseName, randomNamespace,
 			intstr.FromInt(1), tsparams.TnfTargetPodLabels)
@@ -75,6 +80,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has two replicas")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(2)))
 
 		By("Create pod disruption budget")
 		pdb := poddisruptionbudget.DefinePodDisruptionBudgetMaxUnAvailable(tsparams.TestPdbBaseName, randomNamespace,
@@ -132,6 +142,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has two replicas")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(2)))
+
 		By("Create pod disruption budget")
 		pdb := poddisruptionbudget.DefinePodDisruptionBudgetMaxUnAvailable(tsparams.TestPdbBaseName, randomNamespace,
 			intstr.FromInt(2), tsparams.TnfTargetPodLabels)
@@ -160,6 +175,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has two replicas")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(2)))
+
 		By("Create pod disruption budget")
 		pdb := poddisruptionbudget.DefinePodDisruptionBudgetMaxUnAvailable(tsparams.TestPdbBaseName, randomNamespace,
 			intstr.FromInt(3), tsparams.TnfTargetPodLabels)
@@ -187,6 +207,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has one replica")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(1)))
+
 		By("Create pod disruption budget")
 		pdb := poddisruptionbudget.DefinePodDisruptionBudgetMinAvailable(tsparams.TestPdbBaseName, randomNamespace,
 			intstr.FromInt(1), tsparams.TnfUnknownPodLabels)
@@ -213,6 +238,11 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has one replica")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*runningDeployment.Spec.Replicas).To(Equal(int32(1)))
 
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -41,8 +41,15 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{corev1.TerminationMessageFallbackToLogsOnError})
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has terminationMessagePolicy set to FallbackToLogsOnError")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).
+			To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
@@ -66,6 +73,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert deployment has terminationMessagePolicy set to FallbackToLogsOnError")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).
+			To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
+
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -80,7 +93,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	It("One daemonset with two containers, both with terminationMessagePolicy "+
 		"set to FallbackToLogsOnError", func() {
 
-		By("Create deployment in the cluster")
+		By("Create daemonset in the cluster")
 		daemonSet := tshelper.DefineDaemonSetWithTerminationMsgPolicies(tsparams.TestDaemonSetBaseName,
 			randomNamespace,
 			[]corev1.TerminationMessagePolicy{
@@ -110,8 +123,15 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{corev1.TerminationMessageFallbackToLogsOnError})
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has terminationMessagePolicy set to FallbackToLogsOnError")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).
+			To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 
 		By("Create statefulset in the cluster")
 		statefulSet := tshelper.DefineStatefulSetWithTerminationMsgPolicies(tsparams.TestStatefulSetBaseName,
@@ -167,6 +187,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert the two containers have different terminationMessagePolicy")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[1].TerminationMessagePolicy).
+			To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
+
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
@@ -211,6 +237,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert deployment has terminationMessagePolicy set to FallbackToLogsOnError")
+		runningDeployment, err := globalhelper.GetRunningDeployment(deployment.Namespace, deployment.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).
+			To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 
 		By("Create statefulset in the cluster")
 		statefulSet := tshelper.DefineStatefulSetWithTerminationMsgPolicies(tsparams.TestStatefulSetBaseName,
@@ -266,7 +298,8 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Create deployment without TNF target labels in the cluster")
 		deployment := tshelper.DefineDeploymentWithoutTargetLabels(tsparams.TestDeploymentBaseName, randomNamespace)
 
-		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
+		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
+			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,9 +54,6 @@ var _ = Describe("platform-alteration-base-image", func() {
 
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Sleep for 5 minutes")
-		time.Sleep(5 * time.Minute)
 
 		By("Start platform-alteration-base-image test")
 		err = globalhelper.LaunchTests(

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -58,7 +58,6 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages1gOnlyName, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("One pod with 1Gi hugepages", func() {
@@ -130,7 +129,6 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages1gOnlyName, globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("One pod, two containers, one with 1Gi hugepages, other with 2Mi [negative]", func() {
@@ -158,6 +156,5 @@ var _ = Describe("platform-alteration-hugepages-1g-only", func() {
 		By("Verify test case status in Junit and Claim reports")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages1gOnlyName, globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 })


### PR DESCRIPTION
Similar to #534 

This PR adds assertions before running the tests for It() blocks that are using Deployment resources.

MinReadySeconds has also been changed to 15 seconds.

I also added a `NumberReady` check in the IsDeploymentReady func.