### PR TITLE
Add ENABLE_FLAKY_RETRY flag

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -18,6 +18,13 @@ if [[ ${ENABLE_PARALLEL} == "true" ]]; then
 	PFLAG="-p"
 fi
 
+# Allow for flake retries
+FFLAG=""
+if [[ ${ENABLE_FLAKY_RETRY} == "true" ]]; then
+	echo "Retrying flaky tests"
+	FFLAG="--flake-attempts=2"
+fi
+
 function run_tests {
 	case $1 in
 	all)
@@ -34,7 +41,7 @@ function run_tests {
 			fi
 		done
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v ${PFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
+		ginkgo -timeout=24h -v ${PFLAG} ${FFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
 		;;
 	features)
 		if [ -z "$FEATURES" ]; then
@@ -51,7 +58,7 @@ function run_tests {
 		done
 
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v ${PFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
+		ginkgo -timeout=24h -v ${PFLAG} ${FFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite $command
 		;;
 	*)
 		echo "Unknown case"


### PR DESCRIPTION
Ginkgo [allows](https://onsi.github.io/ginkgo/) for a flag `ginkgo --flake-attempts=N` that you can turn on and it will retry a spec with `N` retries.  I'm adding the ability to call this for our nightly runs and it is turned off by default.