### PR TITLE
Various changes needed for OCP to run smoothly

### DIFF
--- a/scripts/delete-namespaces.sh
+++ b/scripts/delete-namespaces.sh
@@ -3,7 +3,7 @@
 # A script that will pre-emptively delete namespaces that are used in QE testing to make
 # sure that the namespaces are not left behind after the test run.
 
-NAMESPACE_STRINGS_TO_GREP=(accesscontrol ac-test ac-rq-test cr-scale-operator-system my-ns affiliated lifecycle manageability networking net-tests observability operator-ns performance platform-alteration)
+NAMESPACE_STRINGS_TO_GREP=(accesscontrol ac-test ac-rq-test cr-scale-operator-system my-ns affiliated lifecycle-tests manageability networking net-tests observability operator-ns performance platform-alteration)
 
 for NS in "${NAMESPACE_STRINGS_TO_GREP[@]}"; do
 	for NAMESPACE in $(oc get namespaces | grep "$NS" | awk '{print $1}'); do

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -13,7 +13,7 @@ else
 	else
 		DEPLOY_PATH=${GOPATH}/bin
 	fi
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.54.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${DEPLOY_PATH}" v1.55.0
 fi
 
 PATH=${PATH}:${DEPLOY_PATH} golangci-lint run -v

--- a/tests/accesscontrol/access_control_suite_test.go
+++ b/tests/accesscontrol/access_control_suite_test.go
@@ -26,7 +26,7 @@ func TestAccessControl(t *testing.T) {
 	RunSpecs(t, "CNFCert access-control tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 	err := globalhelper.AllowAuthenticatedUsersRunPrivilegedContainers()
 	Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
-})
+}, func() {})

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -11,6 +11,10 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/subscription"
 )
 
+const (
+	CreateInstallPlanInNamespaceStr = "Create Install Plan in Namespace: "
+)
+
 var _ = Describe("Access-control namespace, ", Serial, func() {
 	var randomNamespace string
 	var origReportDir string
@@ -41,6 +45,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		//nolint:goconst
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
@@ -180,7 +185,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
@@ -222,7 +227,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", invalidNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
@@ -264,14 +269,14 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Define Install Plan")
 		plan2 := installplan.DefineInstallPlan("test-plan-2", additionalValidNamespace)
 
-		By("Create Install Plan in Namespace: " + plan2.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan2.Namespace)
 		err = globalhelper.CreateInstallPlan(plan2)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
@@ -313,14 +318,14 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
 		By("Define Install Plan")
 		plan2 := installplan.DefineInstallPlan("test-plan-2", invalidNamespace)
 
-		By("Create Install Plan in Namespace: " + plan2.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan2.Namespace)
 		err = globalhelper.CreateInstallPlan(plan2)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
@@ -352,7 +357,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 
@@ -404,7 +409,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		By("Define Install Plan")
 		plan := installplan.DefineInstallPlan("test-plan", randomNamespace)
 
-		By("Create Install Plan in Namespace: " + plan.Namespace)
+		By(CreateInstallPlanInNamespaceStr + plan.Namespace)
 		err = globalhelper.CreateInstallPlan(plan)
 		Expect(err).ToNot(HaveOccurred(), "Error creating installplan")
 

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -110,21 +110,11 @@ var _ = Describe("Access-control security-context,", func() {
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Assert deployment does not have security context set")
-		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(runningDeployment.Spec.Template.Spec.SecurityContext).To(BeNil())
-
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Assert deployment does not have security context set")
-		runningDeployment, err = globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(runningDeployment.Spec.Template.Spec.SecurityContext).To(BeNil())
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -11,7 +11,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification container-is-certified-digest,", func() {
+var _ = Describe("Affiliated-certification container-is-certified-digest,", Serial, func() {
 	var randomNamespace string
 	var origReportDir string
 	var origTnfConfigDir string

--- a/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
@@ -52,6 +52,7 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestHelmVersion,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
+		//nolint:goconst
 		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestHelmVersion+" test")
 
@@ -69,7 +70,7 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 		}
 
 		By("Remove helm")
-		cmd := exec.Command("rm", "-rf", "/usr/local/bin/helm")
+		cmd := exec.Command("sudo", "rm", "-rf", "/usr/local/bin/helm")
 		err := cmd.Run()
 		Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm")
 
@@ -83,6 +84,10 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred(), "Error installing helm v2")
 
 		DeferCleanup(func() {
+			By("Delete tiller from kube-system namespace")
+			err := globalhelper.DeleteDeployment("tiller-deploy", "kube-system")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting tiller deployment")
+
 			By("Re-install helm v3")
 			cmd = exec.Command("/bin/bash", "-c",
 				"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -15,6 +15,11 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
+const (
+	ErrorDeployOperatorStr   = "Error deploying operator "
+	ErrorLabelingOperatorStr = "Error labeling operator "
+)
+
 var _ = Describe("Affiliated-certification invalid operator certification,", Serial, func() {
 
 	var (
@@ -36,7 +41,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 			tsparams.CertifiedOperatorFullInstana,
 			v1alpha1.ApprovalManual,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.CertifiedOperatorPrefixInstana)
 
 		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullInstana,
@@ -44,6 +49,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 
 		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixInstana,
 			tsparams.TestCertificationNameSpace)
+		//nolint:goconst
 		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixInstana+
 			" is not ready")
 
@@ -84,7 +90,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 			tsparams.UncertifiedOperatorFullSriov,
 			v1alpha1.ApprovalManual,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.UncertifiedOperatorPrefixSriov)
 
 		approveInstallPlanWhenReady(tsparams.UncertifiedOperatorFullSriov,
@@ -142,7 +148,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 				tsparams.TestCertificationNameSpace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixSriov)
+			ErrorLabelingOperatorStr+tsparams.UncertifiedOperatorPrefixSriov)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -171,7 +177,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 				tsparams.TestCertificationNameSpace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixSriov)
+			ErrorLabelingOperatorStr+tsparams.UncertifiedOperatorPrefixSriov)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -179,7 +185,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 				tsparams.TestCertificationNameSpace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInstana)
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixInstana)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -12,7 +12,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/affiliatedcertification/parameters"
 )
 
-var _ = Describe("Affiliated-certification operator certification,", func() {
+var _ = Describe("Affiliated-certification operator certification,", Serial, func() {
 
 	var (
 		installedLabeledOperators []tsparams.OperatorLabelInfo
@@ -45,7 +45,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.UncertifiedOperatorPrefixFalcon)
 
 		err = waitUntilOperatorIsReady(tsparams.UncertifiedOperatorPrefixFalcon,
@@ -71,7 +71,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 			tsparams.CertifiedOperatorFullFederatorai,
 			v1alpha1.ApprovalManual,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.CertifiedOperatorPrefixFederatorai)
 
 		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullFederatorai,
@@ -100,7 +100,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 			tsparams.CertifiedOperatorFullInstana,
 			v1alpha1.ApprovalManual,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.CertifiedOperatorPrefixInstana)
 
 		approveInstallPlanWhenReady(tsparams.CertifiedOperatorFullInstana,
@@ -133,7 +133,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 					randomNamespace,
 					tsparams.OperatorLabel)
 			}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-				"Error labeling operator "+tsparams.UncertifiedOperatorPrefixFalcon)
+				ErrorLabelingOperatorStr+tsparams.UncertifiedOperatorPrefixFalcon)
 
 			By("Start test")
 			err := globalhelper.LaunchTests(
@@ -160,7 +160,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixFederatorai)
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixFederatorai)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -168,7 +168,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.UncertifiedOperatorPrefixFalcon)
+			ErrorLabelingOperatorStr+tsparams.UncertifiedOperatorPrefixFalcon)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -195,7 +195,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInstana)
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixInstana)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -221,7 +221,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixInstana)
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixInstana)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -229,7 +229,7 @@ var _ = Describe("Affiliated-certification operator certification,", func() {
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.CertifiedOperatorPrefixFederatorai)
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixFederatorai)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 )
 
-var _ = Describe("Affiliated-certification helm chart certification,", func() {
+var _ = Describe("Affiliated-certification helm chart certification,", Serial, func() {
 	var randomNamespace string
 	var origReportDir string
 	var origTnfConfigDir string
@@ -47,13 +47,39 @@ var _ = Describe("Affiliated-certification helm chart certification,", func() {
 			Skip("helm does not exist please install it to run the test.")
 		}
 
-		By("Install a helm chart")
+		By("Add openshift-helm-charts repo")
 		cmd = exec.Command("/bin/bash", "-c",
-			"helm repo add openshift-helm-charts https://charts.openshift.io/ "+
-				"&& helm repo update && "+
-				"helm install example-vault1 openshift-helm-charts/hashicorp-vault -n "+randomNamespace)
+			"helm repo add openshift-helm-charts https://charts.openshift.io/ --force-update "+
+				"&& helm repo update")
 		err = cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm chart")
+		Expect(err).ToNot(HaveOccurred(), "Error adding openshift-helm-carts repo")
+
+		By("Install helm chart")
+		cmd = exec.Command("/bin/bash", "-c",
+			"helm install example-vault1 openshift-helm-charts/hashicorp-vault -n "+randomNamespace)
+		err = cmd.Run()
+		Expect(err).ToNot(HaveOccurred(), "Error installing hashicorp-vault helm chart")
+
+		DeferCleanup(func() {
+			By("Remove the example-vault1 helm chart")
+			cmd = exec.Command("/bin/bash", "-c", // uninstall the chart
+				"helm uninstall example-vault1 --ignore-not-found -n "+randomNamespace)
+			err = cmd.Run()
+			Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm chart")
+
+			By("Delete clusterrole and clusterrolebinding")
+			err = globalhelper.DeleteClusterRoleBindingByName("example-vault1-agent-injector-binding")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting clusterrolebinding")
+			err = globalhelper.DeleteClusterRoleBindingByName("example-vault1-server-binding")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting clusterrolebinding")
+
+			err = globalhelper.DeleteClusterRole("example-vault1-agent-injector-clusterrole")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting clusterrole")
+
+			By("Delete mutatingwebhookconfiguration")
+			err = globalhelper.DeleteMutatingWebhookConfiguration("example-vault1-agent-injector-cfg")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting mutatingwebhookconfiguration")
+		})
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -82,17 +108,38 @@ var _ = Describe("Affiliated-certification helm chart certification,", func() {
 			Skip("helm does not exist please install it to run the test.")
 		}
 
-		By("Create ns istio-system")
+		By("Create istio-system namespace")
 		err = globalhelper.CreateNamespace("istio-system")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "Error creating istio-system namespace")
 
-		By("Install a helm chart")
+		By("Add istio helm chart repo")
 		cmd = exec.Command("/bin/bash", "-c",
-			"helm repo add istio https://istio-release.storage.googleapis.com/charts "+
-				"&& helm repo update &&"+
-				"helm install istio-base istio/base --set defaultRevision=default -n "+randomNamespace)
+			"helm repo add istio https://istio-release.storage.googleapis.com/charts --force-update "+
+				"&& helm repo update")
 		err = cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm chart")
+		Expect(err).ToNot(HaveOccurred(), "Error adding istio charts repo")
+
+		By("Install istio-base helm chart")
+		cmd = exec.Command("/bin/bash", "-c",
+			"helm install istio-base istio/base --set defaultRevision=default -n "+randomNamespace)
+		err = cmd.Run()
+		Expect(err).ToNot(HaveOccurred(), "Error installing istio-base helm chart")
+
+		DeferCleanup(func() {
+			By("Remove istio-base helm chart")
+			cmd = exec.Command("/bin/bash", "-c", // uninstall the chart
+				"helm uninstall istio-base --ignore-not-found -n "+randomNamespace)
+			err = cmd.Run()
+			Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm chart")
+
+			By("Delete istio-system namespace")
+			err = globalhelper.DeleteNamespaceAndWait("istio-system", tsparams.Timeout)
+			Expect(err).ToNot(HaveOccurred(), "Error deleting istio-system namespace")
+
+			By("Remove validating webhook configuration")
+			err = globalhelper.DeleteValidatingWebhookConfiguration("istiod-default-validator")
+			Expect(err).ToNot(HaveOccurred(), "Error deleting validating webhook configuration")
+		})
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -106,13 +153,5 @@ var _ = Describe("Affiliated-certification helm chart certification,", func() {
 			tsparams.TestHelmChartCertified,
 			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Remove the istio-system ns and istio chart")
-		cmd = exec.Command("/bin/bash", "-c", // uinstall the chart
-			"helm uninstall istio-base -n "+randomNamespace)
-		err = cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm chart")
-		err = globalhelper.CleanNamespace("istio-system")
-		Expect(err).ToNot(HaveOccurred(), "Error delete ns istio-system")
 	})
 })

--- a/tests/globalhelper/clusterrolebindings.go
+++ b/tests/globalhelper/clusterrolebindings.go
@@ -45,3 +45,21 @@ func deleteClusterRoleBinding(client typedrbacv1.RbacV1Interface, clusterRoleBin
 
 	return nil
 }
+
+func DeleteClusterRoleBindingByName(name string) error {
+	return deleteClusterRoleBindingByName(GetAPIClient().K8sClient.RbacV1(), name)
+}
+
+func deleteClusterRoleBindingByName(client typedrbacv1.RbacV1Interface, name string) error {
+	// Exit if the cluster role binding does not exist
+	_, err := client.ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+
+	if err := client.ClusterRoleBindings().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete cluster role binding: %w", err)
+	}
+
+	return nil
+}

--- a/tests/globalhelper/clusterroles.go
+++ b/tests/globalhelper/clusterroles.go
@@ -1,0 +1,32 @@
+package globalhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedrbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+func DeleteClusterRole(name string) error {
+	return deleteClusterRole(GetAPIClient().K8sClient.RbacV1(), name)
+}
+
+func deleteClusterRole(client typedrbacv1.RbacV1Interface, name string) error {
+	err := client.ClusterRoles().Delete(
+		context.TODO(),
+		name,
+		metav1.DeleteOptions{},
+	)
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("cluster-role %s is not found", name))
+
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to delete cluster role %q: %w", name, err)
+	}
+
+	return nil
+}

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -88,3 +88,19 @@ func getRunningDeployment(client typedappsv1.AppsV1Interface, namespace, deploym
 
 	return runningDeployment, nil
 }
+
+func DeleteDeployment(name, namespace string) error {
+	return deleteDeployment(GetAPIClient().K8sClient.AppsV1(), name, namespace)
+}
+
+func deleteDeployment(client typedappsv1.AppsV1Interface, name, namespace string) error {
+	err := client.Deployments(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("deployment %s is not found", name))
+
+		return nil
+	}
+
+	return err
+}

--- a/tests/globalhelper/mutatingwebhook.go
+++ b/tests/globalhelper/mutatingwebhook.go
@@ -1,0 +1,32 @@
+package globalhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregistrationtypedv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+)
+
+func DeleteMutatingWebhookConfiguration(name string) error {
+	return deleteMutatingWebhookConfiguration(GetAPIClient().K8sClient.AdmissionregistrationV1(), name)
+}
+
+func deleteMutatingWebhookConfiguration(client admissionregistrationtypedv1.AdmissionregistrationV1Interface, name string) error {
+	err := client.MutatingWebhookConfigurations().Delete(
+		context.TODO(),
+		name,
+		metav1.DeleteOptions{},
+	)
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("mutating webhook configuration %s is not found", name))
+
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to delete mutating webhook configuration %q: %w", name, err)
+	}
+
+	return nil
+}

--- a/tests/globalhelper/validatingwebhook.go
+++ b/tests/globalhelper/validatingwebhook.go
@@ -1,0 +1,32 @@
+package globalhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregistrationtypedv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+)
+
+func DeleteValidatingWebhookConfiguration(name string) error {
+	return deleteValidatingWebhookConfiguration(GetAPIClient().K8sClient.AdmissionregistrationV1(), name)
+}
+
+func deleteValidatingWebhookConfiguration(client admissionregistrationtypedv1.AdmissionregistrationV1Interface, name string) error {
+	err := client.ValidatingWebhookConfigurations().Delete(
+		context.TODO(),
+		name,
+		metav1.DeleteOptions{},
+	)
+	if k8serrors.IsNotFound(err) {
+		glog.V(5).Info(fmt.Sprintf("validating webhook configuration %s is not found", name))
+
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to delete validating webhook configuration %q: %w", name, err)
+	}
+
+	return nil
+}

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -32,7 +32,7 @@ func TestLifecycle(t *testing.T) {
 	RunSpecs(t, "CNFCert lifecycle tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
 		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
@@ -44,9 +44,9 @@ var _ = BeforeSuite(func() {
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
 	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
 	err := os.Unsetenv("TNF_NON_INTRUSIVE_ONLY")
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -14,6 +14,10 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/runtimeclass"
 )
 
+const (
+	DeletingRTC = "Deleting RTC: "
+)
+
 var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 	var randomNamespace string
 	var origReportDir string
@@ -62,7 +66,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -103,7 +107,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -145,7 +149,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -194,7 +198,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -235,7 +239,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -314,7 +318,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {
-			By("Deleting rtc " + rtc.Name)
+			By(DeletingRTC + rtc.Name)
 			err := globalhelper.DeleteRunTimeClass(rtc)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -33,7 +33,7 @@ func TestNetworking(t *testing.T) {
 	RunSpecs(t, "CNFCert networking tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {
@@ -59,4 +59,4 @@ var _ = BeforeSuite(func() {
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
 	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})

--- a/tests/observability/observability_suite_test.go
+++ b/tests/observability/observability_suite_test.go
@@ -28,7 +28,7 @@ func TestObservability(t *testing.T) {
 	RunSpecs(t, "CNFCert observability tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 
 	By(fmt.Sprintf("Create %s namespace", tsparams.TestNamespace))
 	err := globalhelper.CreateNamespace(tsparams.TestNamespace)
@@ -42,10 +42,10 @@ var _ = BeforeSuite(func() {
 		[]string{},
 		[]string{tsparams.CrdSuffix1, tsparams.CrdSuffix2})
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
 	By(fmt.Sprintf("Remove %s namespace", tsparams.TestNamespace))
 	err := globalhelper.DeleteNamespaceAndWait(tsparams.TestNamespace, tsparams.NsResourcesDeleteTimeoutMins)
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -45,6 +45,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
+		//nolint:goconst
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))

--- a/tests/observability/tests/crd_status.go
+++ b/tests/observability/tests/crd_status.go
@@ -18,6 +18,10 @@ var (
 	crdNames = []string{}
 )
 
+const (
+	CreateCRDInClusterStr = "Create CRD in the cluster with suffix "
+)
+
 var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 	AfterEach(func() {
 		By("Removing all CRDs created by previous test case.")
@@ -31,7 +35,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52444
 	It("One CRD created with status subresource", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrd", tsparams.CrdSuffix1)
 
 		err := tshelper.CreateAndWaitUntilCrdIsReady(crd1, tsparams.CrdDeployTimeoutMins)
@@ -51,13 +55,13 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52445
 	It("Two CRDs created, both with status subresource", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
 		err := tshelper.CreateAndWaitUntilCrdIsReady(crd1, tsparams.CrdDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix2)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix2)
 		crd2 := tshelper.DefineCrdWithStatusSubresource("TestCrdTwo", tsparams.CrdSuffix2)
 
 		err = tshelper.CreateAndWaitUntilCrdIsReady(crd2, tsparams.CrdDeployTimeoutMins)
@@ -78,7 +82,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52446
 	It("One CRD created without status subresource [negative]", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrd", tsparams.CrdSuffix1)
 
 		err := tshelper.CreateAndWaitUntilCrdIsReady(crd1, tsparams.CrdDeployTimeoutMins)
@@ -98,13 +102,13 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52447
 	It("Two CRDs created, one with and the other without status subresource [negative]", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
 		err := tshelper.CreateAndWaitUntilCrdIsReady(crd1, tsparams.CrdDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix2)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix2)
 		crd2 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdTwo", tsparams.CrdSuffix2)
 
 		err = tshelper.CreateAndWaitUntilCrdIsReady(crd2, tsparams.CrdDeployTimeoutMins)
@@ -125,13 +129,13 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52448
 	It("Two CRDs created, both without status subresource [negative]", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix1)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix1)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdOne", tsparams.CrdSuffix1)
 
 		err := tshelper.CreateAndWaitUntilCrdIsReady(crd1, tsparams.CrdDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Create CRD in the cluster with suffix " + tsparams.CrdSuffix2)
+		By(CreateCRDInClusterStr + tsparams.CrdSuffix2)
 		crd2 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdTwo", tsparams.CrdSuffix2)
 
 		err = tshelper.CreateAndWaitUntilCrdIsReady(crd2, tsparams.CrdDeployTimeoutMins)
@@ -152,7 +156,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 
 	// 52449
 	It("One CRD deployed not having any of the configured suffixes [skip]", func() {
-		By("Create CRD in the cluster with suffix " + tsparams.NotConfiguredCrdSuffix)
+		By(CreateCRDInClusterStr + tsparams.NotConfiguredCrdSuffix)
 		crd1 := tshelper.DefineCrdWithoutStatusSubresource("TestCrdOne",
 			tsparams.NotConfiguredCrdSuffix)
 

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -28,7 +28,7 @@ func TestOperator(t *testing.T) {
 	RunSpecs(t, "CNFCert operator tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 
 	if globalhelper.IsKindCluster() {
 		Skip("Skipping operator tests on kind cluster")
@@ -46,9 +46,9 @@ var _ = BeforeSuite(func() {
 		[]string{},
 		[]string{})
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
 	if globalhelper.IsKindCluster() {
 		Skip("Skipping operator tests cleanup on kind cluster")
 	}
@@ -63,4 +63,4 @@ var _ = AfterSuite(func() {
 	By("Remove reports from reports directory")
 	err = globalhelper.RemoveContentsFromReportDir()
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -12,6 +12,12 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/execute"
 )
 
+const (
+	ErrorDeployOperatorStr   = "Error deploying operator "
+	ErrorLabelingOperatorStr = "Error labeling operator "
+	ErrorRemovingLabelStr    = "Error removing label from operator "
+)
+
 var _ = Describe("Operator install-source,", Serial, func() {
 
 	var (
@@ -37,11 +43,12 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixCloudbees)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixCloudbees,
 			tsparams.OperatorNamespace)
+		//nolint:goconst
 		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixCloudbees+
 			" is not ready")
 
@@ -62,7 +69,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixAnchore)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixAnchore,
@@ -87,7 +94,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixOpenvino)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixOpenvino,
@@ -111,7 +118,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				info.OperatorPrefix,
 				info.Namespace,
 				info.Label)
-			Expect(err).ToNot(HaveOccurred(), "Error removing label from operator "+info.OperatorPrefix)
+			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+info.OperatorPrefix)
 		}
 	})
 
@@ -124,7 +131,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -148,7 +155,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixOpenvino)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixOpenvino)
 
 		By("Delete operator's subscription")
 		err := globalhelper.DeleteSubscription(tsparams.OperatorNamespace,
@@ -177,7 +184,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -185,7 +192,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixAnchore)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixAnchore)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -209,7 +216,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixAnchore)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixAnchore)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -217,7 +224,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixOpenvino)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixOpenvino)
 
 		By("Delete operator's subscription")
 		err := globalhelper.DeleteSubscription(tsparams.OperatorNamespace,

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -37,7 +37,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixCloudbees)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixCloudbees,
@@ -61,7 +61,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				info.OperatorPrefix,
 				info.Namespace,
 				info.Label)
-			Expect(err).ToNot(HaveOccurred(), "Error removing label from operator "+info.OperatorPrefix)
+			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+info.OperatorPrefix)
 		}
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -101,7 +101,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixOpenvino)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixOpenvino,
@@ -114,7 +114,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorPrefixOpenvino,
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
-			Expect(err).ToNot(HaveOccurred(), "Error removing label from operator "+tsparams.OperatorPrefixOpenvino)
+			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+tsparams.OperatorPrefixOpenvino)
 		}()
 
 		By("Label operators")
@@ -124,7 +124,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -132,7 +132,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixOpenvino)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixOpenvino)
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -163,7 +163,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			v1alpha1.ApprovalAutomatic,
 			nodeSelector,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixAnchore)
 
 		// Do not wait until the operator is ready. This time the CNF Certification suite must handle the situation.
@@ -173,7 +173,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorPrefixAnchore,
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
-			Expect(err).ToNot(HaveOccurred(), "Error removing label from operator "+tsparams.OperatorPrefixAnchore)
+			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+tsparams.OperatorPrefixAnchore)
 		}()
 
 		By("Label operators")
@@ -183,7 +183,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -191,7 +191,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixAnchore)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixAnchore)
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -38,7 +38,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixCloudbees)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixCloudbees,
@@ -64,7 +64,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixQuay)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixQuay,
@@ -90,7 +90,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 			"",
 			v1alpha1.ApprovalAutomatic,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Error deploying operator "+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.OperatorPrefixKiali)
 
 		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixKiali,
@@ -127,7 +127,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixQuay)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixQuay)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -151,7 +151,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -175,7 +175,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixKiali)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixKiali)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -199,7 +199,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixQuay)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixQuay)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -207,7 +207,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixCloudbees)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(
@@ -231,7 +231,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixKiali)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixKiali)
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -239,7 +239,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			"Error labeling operator "+tsparams.OperatorPrefixQuay)
+			ErrorLabelingOperatorStr+tsparams.OperatorPrefixQuay)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -33,7 +33,7 @@ func TestPlatformAlteration(t *testing.T) {
 	RunSpecs(t, "CNFCert platform-alteration tests", reporterConfig)
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
 		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
@@ -54,4 +54,4 @@ var _ = BeforeSuite(func() {
 	By("Ensure all nodes are labeled with 'worker-cnf' label")
 	err = nodes.EnsureAllNodesAreLabeled(globalhelper.GetAPIClient().Nodes(), configSuite.General.CnfNodeLabel)
 	Expect(err).ToNot(HaveOccurred())
-})
+}, func() {})

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -31,6 +31,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", Ordered, fu
 	BeforeAll(func() {
 		if _, exists := os.LookupEnv("NON_LINUX_ENV"); !exists {
 			By("Install istio")
+			//nolint:goconst
 			cmd := exec.Command("/bin/bash", "-c", "curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.18.1 sh - "+
 				"&& istio-1.18.1/bin/istioctl install --set profile=demo -y")
 			err := cmd.Run()

--- a/tests/utils/pod/pod.go
+++ b/tests/utils/pod/pod.go
@@ -10,6 +10,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	HugePages2Mi = "2Mi"
+	HugePages1Gi = "1Gi"
+)
+
 // DefinePod defines pod manifest based on given params.
 func DefinePod(podName string, namespace string, image string, label map[string]string) *corev1.Pod {
 	return &corev1.Pod{
@@ -178,8 +183,8 @@ func RedefineWith2MiHugepages(pod *corev1.Pod, hugepages int) {
 	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Mi"))
 
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
-		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+HugePages2Mi] = hugepagesVal
+		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+HugePages2Mi] = hugepagesVal
 	}
 }
 
@@ -187,8 +192,8 @@ func RedefineWith1GiHugepages(pod *corev1.Pod, hugepages int) {
 	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Gi"))
 
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
-		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
+		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
+		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
 	}
 }
 
@@ -196,8 +201,8 @@ func RedefineFirstContainerWith2MiHugepages(pod *corev1.Pod, hugepages int) erro
 	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Mi"))
 
 	if len(pod.Spec.Containers) > 0 {
-		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
-		pod.Spec.Containers[0].Resources.Limits[corev1.ResourceHugePagesPrefix+"2Mi"] = hugepagesVal
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceHugePagesPrefix+HugePages2Mi] = hugepagesVal
+		pod.Spec.Containers[0].Resources.Limits[corev1.ResourceHugePagesPrefix+HugePages2Mi] = hugepagesVal
 
 		return nil
 	}
@@ -209,8 +214,8 @@ func RedefineFirstContainerWith1GiHugepages(pod *corev1.Pod, hugepages int) erro
 	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Gi"))
 
 	if len(pod.Spec.Containers) > 0 {
-		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
-		pod.Spec.Containers[0].Resources.Limits[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
+		pod.Spec.Containers[0].Resources.Limits[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
 
 		return nil
 	}
@@ -222,8 +227,8 @@ func RedefineSecondContainerWith1GHugepages(pod *corev1.Pod, hugepages int) erro
 	hugepagesVal := resource.MustParse(fmt.Sprintf("%d%s", hugepages, "Gi"))
 
 	if len(pod.Spec.Containers) > 1 {
-		pod.Spec.Containers[1].Resources.Requests[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
-		pod.Spec.Containers[1].Resources.Limits[corev1.ResourceHugePagesPrefix+"1Gi"] = hugepagesVal
+		pod.Spec.Containers[1].Resources.Requests[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
+		pod.Spec.Containers[1].Resources.Limits[corev1.ResourceHugePagesPrefix+HugePages1Gi] = hugepagesVal
 
 		return nil
 	}


### PR DESCRIPTION
Notable changes:
- Utilizing ginkgo's `SynchronizedBeforeSuite` and `SynchronizedAfterSuite` funcs (which I should have done in the first place) for parallel run support.
- golangci-lint v1.55.0 
- Added some string consts due to golangci-lint update.
- Removed two assertion statements in `accesscontrol` suite because in OCP the `SecurityContext` pointers get automatically populated when deployments are created versus in k8s they are left `nil`.
- Lots of work in the `affiliatedcertification` suite in the helm section.  Helm leaves a lot of leftovers that we have to deal with outside of `helm uninstall` during cleanup.  This is where most of the changes happened.
- Transitioned mostly all tests in `affiliatedcertification` to use the `Serial` label.