### PR TITLE
Switch glog.Fatal to glog.Error

### DIFF
--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -34,8 +34,8 @@ func createAndWaitUntilDaemonSetIsReady(client appsv1Typed.AppsV1Interface, daem
 	Eventually(func() bool {
 		status, err := isDaemonSetReady(client, runningDaemonSet.Namespace, runningDaemonSet.Name)
 		if err != nil {
-			glog.Fatal(fmt.Sprintf(
-				"daemonset %s is not ready, retry in 5 seconds", runningDaemonSet.Name))
+			glog.Errorf(
+				"daemonset %s is not ready, retry in 5 seconds", runningDaemonSet.Name)
 
 			return false
 		}
@@ -76,7 +76,7 @@ func getDaemonSetPullPolicy(daemonset *appsv1.DaemonSet, client appsv1Typed.Apps
 		metav1.GetOptions{},
 	)
 	if err != nil {
-		glog.Fatal(fmt.Sprintf("failed to get daemonset %s: %v", daemonset.Name, err))
+		glog.Errorf("failed to get daemonset %s: %v", daemonset.Name, err)
 
 		return "", err
 	}
@@ -95,7 +95,7 @@ func getRunningDaemonset(daemonset *appsv1.DaemonSet, client appsv1Typed.AppsV1I
 		metav1.GetOptions{},
 	)
 	if err != nil {
-		glog.Fatal(fmt.Sprintf("failed to get daemonset %s: %v", daemonset.Name, err))
+		glog.Errorf("failed to get daemonset %s: %v", daemonset.Name, err)
 
 		return nil, err
 	}

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -44,7 +44,7 @@ func GetAPIClient() *testclient.ClientSet {
 	apiclient, err = config.DefineClients()
 
 	if err != nil {
-		glog.Fatal(fmt.Sprintf("can not load api client. Please check KUBECONFIG env var - %s", err))
+		glog.Fatalf("can not load api client. Please check KUBECONFIG env var - %s", err)
 	}
 
 	return apiclient
@@ -59,7 +59,7 @@ func GetConfiguration() *config.Config {
 	conf, err = config.NewConfig()
 
 	if err != nil {
-		glog.Fatal(fmt.Sprintf("can not load configuration - %s", err))
+		glog.Fatalf("can not load configuration - %s", err)
 	}
 
 	return conf

--- a/tests/globalhelper/networkpolicy.go
+++ b/tests/globalhelper/networkpolicy.go
@@ -26,8 +26,8 @@ func CreateAndWaitUntilNetworkPolicyIsReady(networkPolicy *networkingv1.NetworkP
 	Eventually(func() bool {
 		status, err := doesNetworkPolicyExist(policy.Namespace, policy.Name)
 		if err != nil {
-			glog.Fatal(fmt.Sprintf(
-				"Network Policy %s is not ready.", policy.Name))
+			glog.Errorf(
+				"Network Policy %s is not ready.", policy.Name)
 
 			return false
 		}

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -292,6 +292,6 @@ func CopyClaimFileToTcFolder(tcName, formattedTcName string) {
 
 	err = CopyFiles(srcClaim, dstClaim)
 	if err != nil {
-		glog.Error(fmt.Sprintf("failed to copy %s to %s", srcClaim, dstClaim))
+		glog.Fatalf("failed to copy %s to %s", srcClaim, dstClaim)
 	}
 }

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -4,7 +4,6 @@ package lifecycle
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -35,7 +34,7 @@ func TestLifecycle(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	err = tshelper.WaitUntilClusterIsStable()

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,7 +21,7 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	BeforeEach(func() {

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,7 +22,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	BeforeEach(func() {

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -4,7 +4,6 @@ package networking
 
 import (
 	"flag"
-	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	By("Validate that cluster is Schedulable")

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,7 +16,7 @@ import (
 var _ = Describe("Networking custom namespace, custom deployment,", func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	var randomNamespace string

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -4,7 +4,6 @@ package platformalteration
 
 import (
 	"flag"
-	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestPlatformAlteration(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() {
 	configSuite, err := config.NewConfig()
 	if err != nil {
-		glog.Fatal(fmt.Errorf("can not load config file: %w", err))
+		glog.Fatalf("can not load config file: %w", err)
 	}
 
 	By("Validate that cluster is Schedulable")


### PR DESCRIPTION
Also removed unnecessary usage of `fmt.Sprintf` when we can just use `glog.Errorf`.