### PR TITLE
Add unit tests for init.go

### DIFF
--- a/tests/globalhelper/init_test.go
+++ b/tests/globalhelper/init_test.go
@@ -1,1 +1,33 @@
 package globalhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOriginalTNFPaths(t *testing.T) {
+	t.Setenv("TNF_CONFIG_DIR", "/tmp/tnf-config")
+	t.Setenv("TNF_REPORT_DIR", "/tmp/tnf-report")
+
+	reportDir, tnfConfigDir := GetOriginalTNFPaths()
+	assert.Equal(t, "/tmp/tnf-report", reportDir)
+	assert.Equal(t, "/tmp/tnf-config", tnfConfigDir)
+}
+
+func TestOverrideDirectories(t *testing.T) {
+	t.Setenv("TNF_CONFIG_DIR", "/tmp/tnf-config")
+	t.Setenv("TNF_REPORT_DIR", "/tmp/tnf-report")
+
+	OverrideDirectories("abc123")
+
+	reportDir, tnfConfigDir := GetOriginalTNFPaths()
+	assert.Equal(t, "/tmp/tnf-report/abc123", reportDir)
+	assert.Equal(t, "/tmp/tnf-config/abc123", tnfConfigDir)
+}
+
+func TestRestoreOriginalTNFPaths(t *testing.T) {
+	RestoreOriginalTNFPaths("/tmp/tnf-report", "/tmp/tnf-config")
+	assert.Equal(t, "/tmp/tnf-report", GetConfiguration().General.TnfReportDir)
+	assert.Equal(t, "/tmp/tnf-config", GetConfiguration().General.TnfConfigDir)
+}


### PR DESCRIPTION
Add unit tests for functions in init.go.  There are a few functions in this file that use Ginkgo/Gomega commands and/or try to access that can be addressed later in another PR for testing.