### PR TITLE
Split CI into different jobs

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -1,5 +1,5 @@
 ---
-name: Makefile CI
+name: Test Incoming Changes
 
 'on':
   push:
@@ -8,21 +8,22 @@ name: Makefile CI
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
-
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.3
 
-      - uses: actions/checkout@v4
       - uses: nosborn/github-action-markdown-cli@v3.3.0
         with:
           files: README.md
+
       - uses: ludeeus/action-shellcheck@master
         with:
           ignore_paths: vendor
@@ -47,6 +48,36 @@ jobs:
       - name: Run lint
         run: make lint
 
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.3
+
+      - name: Install ginkgo
+        run: make install-ginkgo
+
+      - name: Compile test suites
+        run: ginkgo build -r ./tests
+
+  unittest:
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.3
+
       - name: Checkout the cnf-certification-test repo
         uses: actions/checkout@v4
         with:
@@ -56,8 +87,3 @@ jobs:
       - name: Run Unit Tests
         run: TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test make unit-tests
 
-      - name: Install ginkgo
-        run: make install-ginkgo
-
-      - name: Compile test suites
-        run: ginkgo build -r ./tests


### PR DESCRIPTION
Splits up the multiple items that the original CI YAML performed into actual separate jobs.