### PR TITLE
Remove Patch() from IsClusterStable() func path

### DIFF
--- a/tests/utils/cluster/cluster.go
+++ b/tests/utils/cluster/cluster.go
@@ -27,6 +27,17 @@ func IsClusterStable(client corev1Typed.NodeInterface) (bool, error) {
 			if err != nil {
 				return false, err
 			}
+
+			updatedNode, err := client.Get(context.TODO(), node.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if updatedNode.Spec.Unschedulable {
+				return false, nil
+			}
+
+			glog.V(5).Info(fmt.Sprintf("node %s is in schedulable state", node.Name))
 		}
 	}
 

--- a/tests/utils/cluster/cluster_test.go
+++ b/tests/utils/cluster/cluster_test.go
@@ -1,1 +1,42 @@
 package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestIsClusterStable(t *testing.T) {
+	generateNode := func(unschedulable bool) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+			},
+			Spec: corev1.NodeSpec{
+				Unschedulable: unschedulable,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testUnschedulable bool
+	}{
+		{testUnschedulable: true}, // attempts an uncordon
+		{testUnschedulable: false},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, generateNode(testCase.testUnschedulable))
+
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		result, err := IsClusterStable(client.CoreV1().Nodes())
+		assert.Nil(t, err)
+		assert.True(t, result)
+	}
+}


### PR DESCRIPTION
- Adjust `IsClusterStable()` to check the value after performing the Update().
- Remove the `Patch()` func from the `setUnSchedulableValue` function.  Use `Update()` instead which is more user friendly.
- Add unit tests for `IsClusterStable()`.