### PR TITLE
Reduce the number of procs for parallel

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,7 @@ fi
 PFLAG=""
 if [[ ${ENABLE_PARALLEL} == "true" ]]; then
 	echo "Running tests in parallel"
-	PFLAG="-p"
+	PFLAG="-procs=4"
 fi
 
 # Allow for flake retries


### PR DESCRIPTION
https://onsi.github.io/ginkgo/#spec-parallelization

Explicitly set the number of procs spawned during parallel execution to 4 instead of allowing ginkgo to determine based on CPU.  Trying to figure out why we are seeing errors like:

https://github.com/test-network-function/cnf-certification-test/actions/runs/6844412413/job/18626977288