### PR TITLE
Remove cr-scale-operator-system from delete-namespaces script

### DIFF
--- a/scripts/delete-namespaces.sh
+++ b/scripts/delete-namespaces.sh
@@ -9,7 +9,7 @@ if ! command -v oc &>/dev/null; then
 	exit 0
 fi
 
-NAMESPACE_STRINGS_TO_GREP=(accesscontrol ac-test ac-rq-test cr-scale-operator-system my-ns affiliated lifecycle-tests manageability networking net-tests observability operator-ns performance platform-alteration cnf-suite)
+NAMESPACE_STRINGS_TO_GREP=(accesscontrol ac-test ac-rq-test my-ns affiliated lifecycle-tests manageability networking net-tests observability operator-ns performance platform-alteration cnf-suite)
 
 for NS in "${NAMESPACE_STRINGS_TO_GREP[@]}"; do
 	for NAMESPACE in $(oc get namespaces | grep "$NS" | awk '{print $1}'); do


### PR DESCRIPTION
We shouldn't need to delete this prior to running the tests because we purposefully Skip() tests in the lifecycle and accesscontrol suite because the operator doesn't exist.