### PR TITLE
Enable PR checks against test suite

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -1,8 +1,8 @@
 name: QE Testing (Ubuntu-hosted)
 
 on:
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:
@@ -26,6 +26,7 @@ jobs:
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
       TEST_TNF_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/runner/.docker/'
+      SKIP_PRELOAD_IMAGES: true # Not needed for github-hosted runs
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -97,6 +98,9 @@ jobs:
           repository: ${{ env.TEST_REPO }}
           path: cnf-certification-test
 
-      # Setup is complete.  Time to run the QE tests.
       - name: Run the tests
-        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features

--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -14,6 +14,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
@@ -144,4 +145,17 @@ func AppendLabelsToPod(pod *corev1.Pod, labels map[string]string) {
 	}
 
 	pod.Labels = newMap
+}
+
+func GetRunningPod(namespace, name string) (*corev1.Pod, error) {
+	return getRunningPod(GetAPIClient().K8sClient.CoreV1(), namespace, name)
+}
+
+func getRunningPod(client typedcorev1.CoreV1Interface, namespace, name string) (*corev1.Pod, error) {
+	pod, err := client.Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod %q (ns %s): %w", name, namespace, err)
+	}
+
+	return pod, nil
 }

--- a/tests/performance/tests/rt_app_no_exec_probes.go
+++ b/tests/performance/tests/rt_app_no_exec_probes.go
@@ -95,8 +95,15 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 		pod.RedefineWithCPUResources(testPod, "1", "1")
 		pod.RedefineWithMemoryResources(testPod, "512Mi", "512Mi")
 
+		By("Create and wait until pod is ready")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert pod has modified resources")
+		runningPod, err := globalhelper.GetRunningPod(testPod.Namespace, testPod.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningPod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("512Mi"))
+		Expect(runningPod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1"))
 
 		By("Start rt-apps-no-exec-probes test")
 		err = globalhelper.LaunchTests(tsparams.TnfRtAppsNoExecProbes,

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -52,6 +52,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels)
 
+		By("Create and wait until deployment is ready")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -75,6 +76,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -105,6 +107,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		podsList, err := globalhelper.GetListOfPodsInNamespace(randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Assert there is at least one pod")
 		Expect(len(podsList.Items)).NotTo(BeZero())
 
 		By("Change container base image")

--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -82,6 +82,12 @@ var _ = Describe("platform-alteration-boot-params", func() {
 					By("Update the current machineConfig")
 					_, err := globalhelper.GetAPIClient().MachineConfigs().Update(context.TODO(), &machineConfig, metav1.UpdateOptions{})
 					Expect(err).ToNot(HaveOccurred())
+
+					By("Assert machineConfig has been updated")
+					updatedMachineConfig, err := globalhelper.GetAPIClient().MachineConfigs().Get(context.TODO(),
+						machineConfig.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedMachineConfig.Spec.KernelArguments).To(Equal([]string{"skew_tick=1", "nohz=off"}))
 				}
 			}
 		}

--- a/tests/platformalteration/tests/platform_alteration_sysctl_config.go
+++ b/tests/platformalteration/tests/platform_alteration_sysctl_config.go
@@ -54,8 +54,16 @@ var _ = Describe("platform-alteration-sysctl-config", func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert sysctl config is unchanged")
+		runningDaemonSet, err := globalhelper.GetRunningDaemonset(daemonSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDaemonSet.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeTrue())
+		Expect(runningDaemonSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/host"))
+		Expect(runningDaemonSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("host"))
 
 		By("Start platform-alteration-sysctl-config test")
 		err = globalhelper.LaunchTests(tsparams.TnfSysctlConfigName,


### PR DESCRIPTION
The QE repo has reached a point where I believe it is stable enough to turn on the PR checks again starting with the QE repo itself and soon the TNF suite repo.