### PR TITLE
Fixed pod's cpu & mem resource setters helpers.

### DIFF
--- a/tests/utils/pod/pod.go
+++ b/tests/utils/pod/pod.go
@@ -102,27 +102,35 @@ func RedefineWithPVC(pod *corev1.Pod, volumeName string, claimName string) {
 
 func RedefineWithCPUResources(pod *corev1.Pod, limit string, req string) {
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Resources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse(limit),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse(req),
-			},
+		containerResources := &pod.Spec.Containers[i].Resources
+
+		if containerResources.Requests == nil {
+			containerResources.Requests = corev1.ResourceList{}
 		}
+
+		if containerResources.Limits == nil {
+			containerResources.Limits = corev1.ResourceList{}
+		}
+
+		containerResources.Requests[corev1.ResourceCPU] = resource.MustParse(req)
+		containerResources.Limits[corev1.ResourceCPU] = resource.MustParse(limit)
 	}
 }
 
 func RedefineWithMemoryResources(pod *corev1.Pod, limit string, req string) {
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Resources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse(limit),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse(req),
-			},
+		containerResources := &pod.Spec.Containers[i].Resources
+
+		if containerResources.Requests == nil {
+			containerResources.Requests = corev1.ResourceList{}
 		}
+
+		if containerResources.Limits == nil {
+			containerResources.Limits = corev1.ResourceList{}
+		}
+
+		containerResources.Requests[corev1.ResourceMemory] = resource.MustParse(req)
+		containerResources.Limits[corev1.ResourceMemory] = resource.MustParse(limit)
 	}
 }
 


### PR DESCRIPTION
The original implementation was overwriting any req/limit that was previosly set for the other resources. For instance, test cases doing this didn't work properly:
```
  pod.RedefineWithCPUResources(testPod, "1", "1")
  pod.RedefineWithMemoryResources(testPod, "512Mi", "512Mi")
```
The call to pod.RedefineWithMemoryResources() was zero-ing the cpu req/limits that was just set before ("1", "1") as it was creating a new empty container.Resources field (corev1.ResourceRequirements{}).

The new implementations don't overwrite other reqs/limits values, they just set/overwrite the corresponding ones (cpu/mem).

The affected test cases were passing until now because a bug in the cert suite code in the function AreCPUResourcesWholeUnits() that was wrongly returning "true" when the cpu reqs/limit were not set. It was fixed here:
https://github.com/test-network-function/cnf-certification-test/pull/1631