### PR TITLE
Switch to Skipped expected state for nodeport test

### DIFF
--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -65,7 +65,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfNodePortTcName,
-			globalparameters.TestCasePassed)
+			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 
 	})


### PR DESCRIPTION
In the `ginkgo_removal` branch, we mark a test as skipped if there are no services found.