### PR TITLE
Various ginkgo_removal fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ make install
 
 * To debug
 
-Use `DEBUG_TNF=true` and `TNF_LOG_LEVEL=trace` while running the above commands.
+Use `DEBUG_TNF=true` and `TNF_LOG_LEVEL=debug` while running the above commands.
 This would create a `Debug` folder containing suites folders with TNF logs for each of the tests.
 
 ```sh
@@ -153,7 +153,7 @@ This would create a `Debug` folder containing suites folders with TNF logs for e
   FEATURES=platformalteration \
   KUBECONFIG=$HOME/.kube/config \
   NON_LINUX_ENV= \
-  TNF_LOG_LEVEL=trace \
+  TNF_LOG_LEVEL=debug \
   TNF_REPO_PATH=$HOME/path/to/cnf-certification-test \
   make test-features
 ```
@@ -163,7 +163,7 @@ This would create a `Debug` folder containing suites folders with TNF logs for e
   DEBUG_TNF=true \
   FEATURES=platformalteration \
   KUBECONFIG=$HOME/.kube/config \
-  TNF_LOG_LEVEL=trace \
+  TNF_LOG_LEVEL=debug \
   TNF_REPO_PATH=$HOME/path/to/cnf-certification-test \
   make test-features
 ```

--- a/tests/accesscontrol/tests/access_control_bpf_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_bpf_capability_check.go
@@ -40,6 +40,7 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -63,6 +64,7 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextBpf(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -84,12 +86,15 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment without BPF")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Define deployment 2 without BPF")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2 without BPF")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -113,12 +118,15 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextBpf(dep)
 
+		By("Create deployment with BPF")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Define deployment 2 without BPF")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2 without BPF")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_container_host_port.go
+++ b/tests/accesscontrol/tests/access_control_container_host_port.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -71,6 +72,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		dep, err := tshelper.DefineDeploymentWithContainerPorts("acdeployment", randomNamespace, 1, ports)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -102,6 +104,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		dep, err := tshelper.DefineDeploymentWithContainerPorts("acdeployment", randomNamespace, 1, ports)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -136,6 +139,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		dep, err := tshelper.DefineDeploymentWithContainerPorts("acdeployment", randomNamespace, 1, ports)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -41,6 +41,7 @@ var _ = Describe("Access-control non-root user,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -70,6 +71,7 @@ var _ = Describe("Access-control non-root user,", func() {
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 0)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -98,6 +100,7 @@ var _ = Describe("Access-control non-root user,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,6 +113,7 @@ var _ = Describe("Access-control non-root user,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -139,6 +143,7 @@ var _ = Describe("Access-control non-root user,", func() {
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 0)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,9 +153,11 @@ var _ = Describe("Access-control non-root user,", func() {
 		Expect(runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).ToNot(BeNil())
 		Expect(*runningDeployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(0)))
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -71,6 +71,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextIpcLock(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,6 +100,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,6 +112,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -139,6 +142,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextIpcLock(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,9 +152,11 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
 			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("IPC_LOCK")))
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
+++ b/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
@@ -51,6 +51,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -81,6 +82,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,10 +101,11 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 
 	// 56471
 	It("two deployments, one pod each, both in a namespace with resource quota", func() {
-		By("Define deployments")
+		By("Define deployment 1")
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,10 +117,12 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		err = globalhelper.CreateResourceQuota(resourceQuota)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeploymentWithNamespace(1, 1, "accesscontroldeployment2",
 			randomNamespace2)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -144,17 +149,20 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 
 	// 56472
 	It("two deployments, one pod each, one in a namespace without resource quota [negative]", func() {
-		By("Define deployments")
+		By("Define deployment 1")
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeploymentWithNamespace(1, 1, "accesscontroldeployment2",
 			randomNamespace2)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -71,6 +72,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextNetAdmin(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,6 +101,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -107,9 +110,11 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/globalhelper/daemonset_test.go
+++ b/tests/globalhelper/daemonset_test.go
@@ -62,7 +62,7 @@ func TestCreateAndWaitUntilDaemonSetIsReady(t *testing.T) {
 		client := k8sfake.NewSimpleClientset(runtimeObjects...)
 
 		t.Run(testCase.name, func(t *testing.T) {
-			err := createAndWaitUntilDaemonSetIsReady(client.AppsV1(),
+			err := createAndWaitUntilDaemonSetIsReady(client.AppsV1(), client.CoreV1(),
 				generateDaemonset(testCase.numAvailable, testCase.numScheduled, testCase.numUnavailable, testCase.numReady), 5)
 			if (err != nil) != testCase.wantErr {
 				t.Errorf("CreateAndWaitUntilDaemonSetIsReady() error = %v, wantErr %v", err, testCase.wantErr)

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -98,6 +98,13 @@ func BeforeEachSetupWithRandomNamespace(incomingNamespace string) (randomNamespa
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, origReportDir, origConfigDir string, waitingTime time.Duration) {
+	// logfile := "cnf-certsuite.log"
+	// By("Print logs")
+	// myFile, err := os.ReadFile(GetConfiguration().General.TnfReportDir + "/" + logfile)
+	// if err != nil {
+	// 	glog.Errorf("can not read file %s - %s", logfile, err)
+	// }
+	// fmt.Println(string(myFile))
 	By(fmt.Sprintf("Remove reports from report directory: %s", GetConfiguration().General.TnfReportDir))
 
 	err := RemoveContentsFromReportDir()

--- a/tests/globalhelper/nodes.go
+++ b/tests/globalhelper/nodes.go
@@ -91,3 +91,19 @@ func NodeHasHugePagesEnabled(node *corev1.Node, resourceName string) bool {
 
 	return hugepagesEnabled
 }
+
+func GetNumberOfNodes() int {
+	return getNumberOfNodes(GetAPIClient().K8sClient.CoreV1())
+}
+
+func getNumberOfNodes(client corev1Typed.CoreV1Interface) int {
+	nodes, err := client.Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/worker-cnf",
+	})
+
+	if err != nil {
+		return 0
+	}
+
+	return len(nodes.Items)
+}

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -152,6 +152,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Deploy daemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -206,6 +206,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
 
+		By("Deploy daemonSet")
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -247,6 +248,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		daemonset.RedefineWithRunTimeClass(daemonSet, rtc.Name)
 		daemonset.RedefineWithCPUResources(daemonSet, "1", "1")
 
+		By("Deploy daemonSet")
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -198,6 +198,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace, "registry.access.redhat.com/ubi8/ubi",
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Create DaemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -318,6 +319,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		daemonSet := tshelper.DefineDaemonSetWithImagePullPolicy(tsparams.TestDaemonSetName,
 			randomNamespace, globalhelper.GetConfiguration().General.TestImage, corev1.PullNever)
 
+		By("Create DaemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -158,6 +158,7 @@ var _ = Describe("lifecycle-liveness", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Create daemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -152,6 +152,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Create daemonSet")
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -152,6 +152,7 @@ var _ = Describe("lifecycle-readiness", func() {
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Create daemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -181,6 +181,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TestTargetLabels, tsparams.TestDaemonSetName)
 
+		By("Create daemonSet")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -87,12 +87,12 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
 		Expect(err).ToNot(HaveOccurred())
 
+		// Skipped because no listening ports are detected
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
-			globalparameters.TestCasePassed)
+			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 
 	It("one deployment, one pod, container declares port 8081 but uses port 8080 instead [negative]", func() {

--- a/tests/performance/tests/rt_app_no_exec_probes.go
+++ b/tests/performance/tests/rt_app_no_exec_probes.go
@@ -57,7 +57,7 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfRtAppsNoExecProbes,
-			globalparameters.TestCasePassed)
+			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -78,11 +78,11 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 		By("Start rt-apps-no-exec-probes test")
 		err = globalhelper.LaunchTests(tsparams.TnfRtAppsNoExecProbes,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfRtAppsNoExecProbes,
-			globalparameters.TestCaseFailed)
+			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -112,7 +112,7 @@ var _ = Describe("performance-rt-apps-no-exec-probes", func() {
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfRtAppsNoExecProbes,
-			globalparameters.TestCasePassed)
+			globalparameters.TestCaseSkipped)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/performance/tests/rt_isolated_cpu_pool.go
+++ b/tests/performance/tests/rt_isolated_cpu_pool.go
@@ -70,12 +70,12 @@ var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", Serial, f
 		err = globalhelper.LaunchTests(
 			tsparams.TnfRtIsolatedCPUPoolSchedulingPolicy,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfRtIsolatedCPUPoolSchedulingPolicy,
-			globalparameters.TestCasePassed)
+			globalparameters.TestCaseFailed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -105,12 +105,12 @@ var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", Serial, f
 		err = globalhelper.LaunchTests(
 			tsparams.TnfRtIsolatedCPUPoolSchedulingPolicy,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()))
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfRtIsolatedCPUPoolSchedulingPolicy,
-			globalparameters.TestCaseFailed)
+			globalparameters.TestCasePassed)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -103,7 +103,7 @@ func NewConfig() (*Config, error) {
 // DebugTnf activates debug mode.
 func (c *Config) DebugTnf() (bool, error) {
 	if c.General.DebugTnf == "true" {
-		err := os.Setenv("TNF_LOG_LEVEL", "trace")
+		err := os.Setenv("TNF_LOG_LEVEL", "debug")
 		if err != nil {
 			return false, fmt.Errorf("failed to set env var TNF_LOG_LEVEL: %w", err)
 		}


### PR DESCRIPTION
Changes:
- Change `TNF_LOG_LEVEL` from trace to debug for the logging changes made in the suite in [PR#1663](https://github.com/test-network-function/cnf-certification-test/pull/1663)
- Added a number of `By("Create deployment")` statements that give more context to what the test is actually doing.
- Some modifications to the `isDaemonsetReady` logic.  It now mirrors what we do in the test suite repo where we compare the number of nodes (`GetNumberOfNodes()`) to the number of desired scheduled pods in the daemonset.  This makes everything much more stable/happy.

Marked WIP until I have gotten through all of the tests.