### PR TITLE
Add container engine variable

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,3 +12,4 @@ general:
   tnf_image: quay.io/testnetworkfunction/cnf-certification-test
   tnf_image_tag: latest
   disable_intrusive_tests: false
+  container_engine: docker

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -9,7 +9,6 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/globalparameters"
 
 	"github.com/golang/glog"
-	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/container"
 )
 
 // OverrideReportDir overrides the report directory.
@@ -34,12 +33,10 @@ func OverrideTnfConfigDir(configDir string) {
 
 // LaunchTests stats tests based on given parameters.
 func LaunchTests(testCaseName string, tcNameForReport string) error {
-	containerEngine, err := container.SelectEngine()
-	if err != nil {
-		return fmt.Errorf("failed to select engine: %w", err)
-	}
+	containerEngine := GetConfiguration().General.ContainerEngine
+	glog.V(5).Info(fmt.Sprintf("Selected Container engine:%s", containerEngine))
 
-	err = os.Setenv("TNF_CONTAINER_CLIENT", containerEngine)
+	err := os.Setenv("TNF_CONTAINER_CLIENT", containerEngine)
 	if err != nil {
 		return fmt.Errorf("failed to set TNF_CONTAINER_CLIENT: %w", err)
 	}

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 		TnfImage              string `yaml:"tnf_image" envconfig:"TNF_IMAGE"`
 		TnfImageTag           string `yaml:"tnf_image_tag" envconfig:"TNF_IMAGE_TAG"`
 		DisableIntrusiveTests string `yaml:"disable_intrusive_tests" envconfig:"DISABLE_INTRUSIVE_TESTS"`
+		ContainerEngine       string `default:"docker" yaml:"container_engine" envconfig:"CONTAINER_ENGINE"`
 	} `yaml:"general"`
 }
 

--- a/tests/utils/container/container.go
+++ b/tests/utils/container/container.go
@@ -2,49 +2,9 @@ package container
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
-
-// SelectEngine check what container engine is present on the machine.
-func SelectEngine() (string, error) {
-	for _, containerEngine := range []string{"docker", "podman"} {
-		containerEngineCMD := exec.Command(containerEngine)
-		directoryName, _ := path.Split(containerEngineCMD.Path)
-
-		if directoryName != "" {
-			if strings.Contains(containerEngineCMD.String(), "docker") {
-				err := validateDockerDaemonRunning()
-				if err != nil {
-					return "", err
-				}
-			}
-
-			return containerEngine, nil
-		}
-	}
-
-	return "nil", fmt.Errorf("no container Engine present on host machine")
-}
-
-func validateDockerDaemonRunning() error {
-	// To make it run on MacOs or Windows
-	if _, isNonLinuxEnv := os.LookupEnv("NON_LINUX_ENV"); isNonLinuxEnv {
-		return nil
-	}
-
-	isDaemonRunning := exec.Command("systemctl", "is-active", "--quiet", "docker")
-
-	if isDaemonRunning.Run() != nil {
-		return fmt.Errorf("docker daemon is not active on host")
-	}
-
-	return nil
-}
 
 func CreateContainerSpecsFromContainerPorts(ports []corev1.ContainerPort, image, name string) []corev1.Container {
 	numContainers := len(ports)


### PR DESCRIPTION
Removed previous docker engine check as it is not valid when using docker-podman on linux. Replace previous mechanism with a simple environent variable