### PR TITLE
Add 'ginkgo_removal' branch for unit testing

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -3,9 +3,9 @@ name: Test Incoming Changes
 
 'on':
   push:
-    branches: [main]
+    branches: [main, ginkgo_removal]
   pull_request:
-    branches: [main]
+    branches: [main, ginkgo_removal]
 
 jobs:
   lint:


### PR DESCRIPTION
#622 introduced the ginkgo_removal branch QE PR testing but didn't enable the unit testing which is allowing failures to sneak past.