### PR TITLE
Adjust redefine funcs to not return their own objects

### DIFF
--- a/tests/accesscontrol/helper/helper.go
+++ b/tests/accesscontrol/helper/helper.go
@@ -138,9 +138,7 @@ func DefineAndCreateServiceOnCluster(name, namespace string, port int32, targetP
 	}
 
 	if withNodePort {
-		var err error
-
-		testService, err = service.RedefineWithNodePort(testService)
+		err := service.RedefineWithNodePort(testService)
 		if err != nil {
 			return err
 		}

--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -158,9 +158,7 @@ func DefineAndCreateServiceOnCluster(name, namespace string, port, targetPort in
 	}
 
 	if withNodePort {
-		var err error
-
-		testService, err = service.RedefineWithNodePort(testService)
+		err := service.RedefineWithNodePort(testService)
 		if err != nil {
 			return err
 		}
@@ -186,7 +184,7 @@ func DefineAndCreateNadOnCluster(name, namespace, network string) error {
 	nadOneInterface := nad.DefineNad(name, namespace)
 
 	if network != "" {
-		nadOneInterface = nad.RedefineNadWithWhereaboutsIpam(nadOneInterface, network)
+		nad.RedefineNadWithWhereaboutsIpam(nadOneInterface, network)
 	}
 
 	err := globalhelper.GetAPIClient().Create(context.TODO(), nadOneInterface)
@@ -317,7 +315,7 @@ func defineDeploymentBasedOnArgs(
 	}
 
 	if len(multus) > 0 {
-		deploymentStruct = deployment.RedefineWithMultus(deploymentStruct, multus)
+		deployment.RedefineWithMultus(deploymentStruct, multus)
 	}
 
 	return deploymentStruct

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -77,9 +77,9 @@ func RedefineWithLabels(deployment *appsv1.Deployment, label map[string]string) 
 }
 
 // RedefineWithMultus redefines deployment with additional labels.
-func RedefineWithMultus(deployment *appsv1.Deployment, nadNames []string) *appsv1.Deployment {
+func RedefineWithMultus(deployment *appsv1.Deployment, nadNames []string) {
 	if len(nadNames) < 1 {
-		return deployment
+		return
 	}
 
 	var nadAnnotations []MultusAnnotation
@@ -93,8 +93,6 @@ func RedefineWithMultus(deployment *appsv1.Deployment, nadNames []string) *appsv
 	deployment.Spec.Template.Annotations = map[string]string{
 		"k8s.v1.cni.cncf.io/networks": string(bString),
 	}
-
-	return deployment
 }
 
 // RedefineWithReplicaNumber redefines deployment with requested replica number.

--- a/tests/utils/nad/nad.go
+++ b/tests/utils/nad/nad.go
@@ -25,12 +25,10 @@ func DefineNad(name string, namespace string) *netattdefv1.NetworkAttachmentDefi
 
 // RedefineNadWithWhereaboutsIpam updates nad with whereabouts ipam config.
 func RedefineNadWithWhereaboutsIpam(
-	nad *netattdefv1.NetworkAttachmentDefinition, network string) *netattdefv1.NetworkAttachmentDefinition {
+	nad *netattdefv1.NetworkAttachmentDefinition, network string) {
 	nad.Spec.Config = strings.Trim(nad.Spec.Config, `}`)
 	nad.Spec.Config = fmt.Sprintf(
 		"%s, %s}", nad.Spec.Config,
 		fmt.Sprintf(`"ipam":{ "type": "whereabouts", "range": "%s"}`, network),
 	)
-
-	return nad
 }

--- a/tests/utils/service/service.go
+++ b/tests/utils/service/service.go
@@ -41,13 +41,13 @@ func DefineService(name string,
 }
 
 // RedefineWithNodePort redefines service struct with NodePort.
-func RedefineWithNodePort(testService *corev1.Service) (*corev1.Service, error) {
+func RedefineWithNodePort(testService *corev1.Service) error {
 	testService.Spec.Type = "NodePort"
 	if len(testService.Spec.Ports) < 1 {
-		return nil, fmt.Errorf("service does not have available ports")
+		return fmt.Errorf("service does not have available ports")
 	}
 
 	testService.Spec.Ports[0].NodePort = testService.Spec.Ports[0].Port
 
-	return testService, nil
+	return nil
 }

--- a/tests/utils/service/service_test.go
+++ b/tests/utils/service/service_test.go
@@ -25,7 +25,7 @@ func TestRedefineWithNodePort(t *testing.T) {
 	singleStack := corev1.IPFamilyPolicySingleStack
 	testService := DefineService("testService", "testNamespace", 80, 8080, "TCP",
 		map[string]string{"app": "test"}, []corev1.IPFamily{corev1.IPv4Protocol}, &singleStack)
-	testService, err := RedefineWithNodePort(testService)
+	err := RedefineWithNodePort(testService)
 	assert.Nil(t, err)
 	assert.NotNil(t, testService)
 	assert.Equal(t, corev1.ServiceTypeNodePort, testService.Spec.Type)


### PR DESCRIPTION
These funcs shouldn't return the same object they are modifying.