### PR TITLE
Update httpd to v2.4.58

### DIFF
--- a/tests/manageability/parameters/parameters.go
+++ b/tests/manageability/parameters/parameters.go
@@ -18,7 +18,7 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
-	TestImageWithValidTag = "httpd:2.4.57"
+	TestImageWithValidTag = "httpd:2.4.58"
 	InvalidPortName       = "sftp"
 )
 


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test-partner/pull/385 

https://hub.docker.com/layers/library/httpd/2.4.58/images/sha256-448ce9c60d2ac0e8f779ce871b06df6452c30dae74f725d5694502da9c902036?context=explore 