### PR TITLE
Switch httpd image to custom repo

### DIFF
--- a/tests/manageability/parameters/parameters.go
+++ b/tests/manageability/parameters/parameters.go
@@ -18,7 +18,7 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
-	TestImageWithValidTag = "httpd:2.4.58"
+	TestImageWithValidTag = "quay.io/bapalm/httpd:2.4.58"
 	InvalidPortName       = "sftp"
 )
 

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -34,11 +34,11 @@ var _ = Describe("manageability-containers-image-tag", func() {
 	})
 
 	It("One pod with valid image tag", func() {
-
 		By("Define pod")
 		testPod := pod.DefinePod(tsparams.TestPodName, randomNamespace,
 			tsparams.TestImageWithValidTag, tsparams.TnfTargetPodLabels)
 
+		By("Create pod")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(testPod, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
To avoid `ImagePullBackoff` failures in the manageability suite, I pushed my own version of the httpd image to my own quay repo.  The billerica lab is hitting the rate limit from Docker Hub.