### PR TITLE
Change expected state for MCO test

### DIFF
--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -99,7 +99,7 @@ var _ = Describe("platform-alteration-boot-params", func() {
 
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfBootParamsName,
-			globalparameters.TestCasePassed, randomReportDir)
+			globalparameters.TestCaseSkipped, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
In our OCP environments, we do not have any `machineConfig` objects to test.  So the test expects there to be some but there aren't any deployed in the cluster.  The test suite code marks this as skipped now due to changes in the `ginkgo_removal` effort.