### PR TITLE
Fix operator suite

### DIFF
--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -143,7 +143,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallSource,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -169,12 +169,12 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallSource,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -208,7 +208,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallSource,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -242,13 +242,12 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallSource,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -86,7 +86,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatus,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -111,13 +111,13 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixOpenvino+
 			" is not ready")
 
-		defer func() {
+		DeferCleanup(func() {
 			err := tshelper.DeleteLabelFromInstalledCSV(
 				tsparams.OperatorPrefixOpenvino,
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+tsparams.OperatorPrefixOpenvino)
-		}()
+		})
 
 		By("Label operators")
 		Eventually(func() error {
@@ -142,12 +142,12 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatus,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -172,13 +172,13 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 		// Do not wait until the operator is ready. This time the CNF Certification suite must handle the situation.
 
-		defer func() {
+		DeferCleanup(func() {
 			err := tshelper.DeleteLabelFromInstalledCSV(
 				tsparams.OperatorPrefixAnchore,
 				tsparams.OperatorNamespace,
 				tsparams.OperatorLabel)
 			Expect(err).ToNot(HaveOccurred(), ErrorRemovingLabelStr+tsparams.OperatorPrefixAnchore)
-		}()
+		})
 
 		By("Label operators")
 		Eventually(func() error {
@@ -203,12 +203,12 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatus,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -140,7 +140,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatusNoPrivileges,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -166,7 +166,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatusNoPrivileges,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -187,12 +187,12 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatusNoPrivileges,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -226,7 +226,7 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatusNoPrivileges,
-			globalparameters.TestCasePassed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -255,12 +255,12 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfOperatorInstallStatusNoPrivileges,
-			globalparameters.TestCaseFailed, globalhelper.GetConfiguration().General.TnfReportDir)
+			globalparameters.TestCaseSkipped, globalhelper.GetConfiguration().General.TnfReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Follow up to the `ginkgo_removal` branch work.  These changes are needed for the OCP scenario tests to pass for the operator suite.

![image](https://github.com/test-network-function/cnfcert-tests-verification/assets/4563082/de9d642b-4e0a-44c9-965b-09c04d7106a2)
