### PR TITLE
Adjust tainted node test to be ran in 'Serial'

### DIFF
--- a/tests/platformalteration/tests/platform_alteration_boot_params.go
+++ b/tests/platformalteration/tests/platform_alteration_boot_params.go
@@ -51,6 +51,7 @@ var _ = Describe("platform-alteration-boot-params", func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -52,6 +52,7 @@ var _ = Describe("platform-alteration-hugepages-1g-only", Serial, func() {
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith1GiHugepages(dep, 1)
 
+		By("Create and wait until deployment is ready")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -53,6 +53,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		deployment.RedefineWithCPUResources(dep, "500m", "250m")
 		deployment.RedefineWith2MiHugepages(dep, 4)
 
+		By("Create and wait until deployment is ready")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -76,6 +77,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		pod.RedefineWithCPUResources(puta, "500m", "250m")
 		pod.RedefineWith2MiHugepages(puta, 4)
 
+		By("Create and wait until pod is ready")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(puta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,6 +101,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		deployment.RedefineWith2MiHugepages(dep, 4)
 		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
+		By("Create and wait until deployment is ready")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -128,6 +131,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		err = pod.RedefineSecondContainerWith1GHugepages(put, 1)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create and wait until pod is ready")
 		err = globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -139,6 +143,5 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 })

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -68,6 +68,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 			globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -93,6 +94,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 		// Append UBI-based container.
 		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
+		By("Create and wait until deployment is ready")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -47,6 +47,7 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -89,6 +90,7 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 		daemonset.RedefineWithPrivilegedContainer(daemonSet)
 		daemonset.RedefineWithVolumeMount(daemonSet)
 
+		By("Create and wait until daemonSet is ready")
 		err := globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/test-network-function/cnfcert-tests-verification/tests/utils/daemonset"
 )
 
-var _ = Describe("platform-alteration-tainted-node-kernel", func() {
+var _ = Describe("platform-alteration-tainted-node-kernel", Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomTnfConfigDir string


### PR DESCRIPTION
We shouldn't be cordoning nodes while other tests are running.