### PR TITLE
Safeguard against missing catalog sources

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -88,6 +88,11 @@ var _ = SynchronizedBeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
+	if !globalhelper.IsKindCluster() {
+		By("Check if catalog sources are available")
+		err = globalhelper.ValidateCatalogSources()
+		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
+	}
 }, func() {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {

--- a/tests/globalhelper/catalogsources.go
+++ b/tests/globalhelper/catalogsources.go
@@ -1,0 +1,53 @@
+package globalhelper
+
+import (
+	"context"
+	"fmt"
+
+	v1alpha1typed "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	CatalogSourceNamespace = "openshift-marketplace"
+)
+
+func ValidateCatalogSources() error {
+	return validateCatalogSources(GetAPIClient().OperatorsV1alpha1Interface)
+}
+
+func validateCatalogSources(opclient v1alpha1typed.OperatorsV1alpha1Interface) error {
+	validCatalogSources := []string{"certified-operators", "community-operators", "redhat-operators", "redhat-marketplace"}
+
+	catalogSources, err := opclient.CatalogSources(CatalogSourceNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(catalogSources.Items) == 0 {
+		return fmt.Errorf("no catalog sources found")
+	}
+
+	var foundCatalogSources []string
+	for _, catalogSource := range catalogSources.Items {
+		foundCatalogSources = append(foundCatalogSources, catalogSource.Name)
+	}
+
+	for _, validCatalogSource := range validCatalogSources {
+		if !contains(foundCatalogSources, validCatalogSource) {
+			return fmt.Errorf("catalog source %s not found", validCatalogSource)
+		}
+	}
+
+	return nil
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/globalhelper/catalogsources_test.go
+++ b/tests/globalhelper/catalogsources_test.go
@@ -1,0 +1,1 @@
+package globalhelper

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -46,6 +46,13 @@ var _ = SynchronizedBeforeSuite(func() {
 		[]string{},
 		[]string{}, globalhelper.GetConfiguration().General.TnfConfigDir)
 	Expect(err).ToNot(HaveOccurred())
+
+	// Safeguard against running the operator tests on a cluster without catalog sources
+	if !globalhelper.IsKindCluster() {
+		By("Check if catalog sources are available")
+		err = globalhelper.ValidateCatalogSources()
+		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
+	}
 }, func() {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {


### PR DESCRIPTION
If the OCP cluster we are running QE against doesn't have the following, throw an error before they can run the test suite as a prerequisite:

```
NAMESPACE               NAME                  DISPLAY               TYPE   PUBLISHER   AGE
openshift-marketplace   certified-operators   Certified Operators   grpc   Red Hat     88d
openshift-marketplace   community-operators   Community Operators   grpc   Red Hat     88d
openshift-marketplace   redhat-marketplace    Red Hat Marketplace   grpc   Red Hat     88d
openshift-marketplace   redhat-operators      Red Hat Operators     grpc   Red Hat     88d
```

