### PR TITLE
Add more logging around deployment creation

### DIFF
--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -144,6 +144,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextNetAdmin(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -153,9 +154,11 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		Expect(runningDeployment.Spec.Template.Spec.Containers[0].
 			SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("NET_ADMIN")))
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -71,6 +72,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextNetRaw(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,6 +101,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,6 +113,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -139,6 +143,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextNetRaw(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -151,6 +156,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -41,6 +41,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -70,6 +71,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1337)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -98,6 +100,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -111,6 +114,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep2, 1338)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +144,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 
 		deployment.RedefineWithPodSecurityContextRunAsUser(dep, 1337)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -152,6 +157,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -46,6 +46,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		dep, err := tshelper.DefineDeployment(3, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -81,6 +82,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		dep, err := tshelper.DefineDeployment(3, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -121,6 +123,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		dep, err := tshelper.DefineDeployment(3, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -152,10 +155,11 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Define deployment and create it on cluster")
+		By("Define deployment")
 		dep, err := tshelper.DefineDeployment(3, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -193,10 +197,11 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 			[]corev1.IPFamily{"IPv4"}, "SingleStack")
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Define deployment and create it on cluster")
+		By("Define deployment")
 		dep, err := tshelper.DefineDeployment(3, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_one_process_per_container.go
+++ b/tests/accesscontrol/tests/access_control_one_process_per_container.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -65,6 +66,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		err = deployment.RedefineContainerCommand(dep, 0, commandToLaunchTwoProcesses)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -88,6 +90,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 
 		globalhelper.AppendContainersToDeployment(dep, 1, globalhelper.GetConfiguration().General.TestImage)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,6 +117,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		err = deployment.RedefineContainerCommand(dep, 1, commandToLaunchTwoProcesses)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -49,6 +49,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -82,6 +83,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -113,6 +115,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithServiceAccount(dep, tsparams.ServiceAccountName)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,6 +151,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithServiceAccount(dep, tsparams.ServiceAccountName)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -186,6 +190,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithServiceAccount(dep, tsparams.ServiceAccountName)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -225,6 +230,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -265,6 +271,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep, false)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -282,6 +289,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -315,6 +323,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep, true)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -332,6 +341,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 
 		deployment.RedefineWithAutomountServiceAccountToken(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -41,6 +41,7 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -84,6 +85,7 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 			randomNamespace, "my-service-account")
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -43,6 +43,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		deployment.RedefineWithHostIpc(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		deployment.RedefineWithHostIpc(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +103,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		deployment.RedefineWithHostIpc(dep, false)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -109,11 +112,13 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runningDeployment.Spec.Template.Spec.HostIPC).To(BeFalse())
 
+		By("Define deployment 2")
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithHostIpc(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -143,6 +148,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		deployment.RedefineWithHostIpc(dep, true)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -156,6 +162,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 
 		deployment.RedefineWithHostIpc(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -43,6 +43,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +103,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep, false)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,6 +117,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -138,6 +142,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep, true)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -151,6 +156,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 
 		deployment.RedefineWithHostNetwork(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -41,6 +41,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 
 		deployment.RedefineWithHostPath(dep, "volume", "mnt/data")
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -103,6 +105,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -116,6 +119,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -145,6 +149,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -160,6 +165,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 
 		deployment.RedefineWithHostPath(dep2, "volume", "mnt/data")
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -43,6 +43,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +103,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep, false)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,6 +117,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -143,6 +147,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep, true)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -156,6 +161,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 
 		deployment.RedefineWithHostPid(dep2, false)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -44,6 +44,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -76,6 +77,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 
 		deployment.RedefineWithResourceRequests(dep, tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -104,6 +106,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -137,6 +140,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithMemoryRequestsAndLimitsAndCPURequest(dep, tsparams.MemoryLimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -168,6 +172,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithMemoryRequestAndCPURequestsAndLimits(dep, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -199,6 +204,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -216,6 +222,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithAllRequestsAndLimits(dep2, tsparams.MemoryLimit, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -249,6 +256,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithAllRequestsAndLimits(dep, tsparams.MemoryLimit, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -264,6 +272,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		deployment.RedefineWithMemoryRequestAndCPURequestsAndLimits(dep2, tsparams.CPULimit,
 			tsparams.MemoryRequest, tsparams.CPURequest)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -76,6 +76,7 @@ var _ = Describe("Access-control security-context,", func() {
 
 		deployment.RedefineWithHostPid(dep, true)
 
+		By("Create and wait until deployment is ready")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -107,12 +108,14 @@ var _ = Describe("Access-control security-context,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -137,6 +140,7 @@ var _ = Describe("Access-control security-context,", func() {
 
 		deployment.RedefineWithContainersSecurityContextIpcLock(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -149,6 +153,7 @@ var _ = Describe("Access-control security-context,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -41,6 +41,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -70,6 +71,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +103,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, false)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -113,6 +116,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -142,6 +146,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 
 		deployment.RedefineWithContainersSecurityContextAllowPrivilegeEscalation(dep, true)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -154,6 +159,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -42,6 +42,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -71,6 +72,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextSysAdmin(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,6 +103,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "acdeployment1", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -112,6 +115,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -141,6 +145,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 
 		deployment.RedefineWithContainersSecurityContextSysAdmin(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -153,6 +158,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		dep2, err := tshelper.DefineDeployment(1, 1, "acdeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -44,6 +44,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 
 		deployment.RedefineWithShareProcessNamespace(dep, false)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -74,6 +75,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		deployment.RedefineWithShareProcessNamespace(dep, true)
 		deployment.RedefineWithSysPtrace(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -105,6 +107,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 
 		deployment.RedefineWithShareProcessNamespace(dep, true)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -135,6 +138,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		deployment.RedefineWithShareProcessNamespace(dep, true)
 		deployment.RedefineWithSysPtrace(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -151,6 +155,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		deployment.RedefineWithShareProcessNamespace(dep2, true)
 		deployment.RedefineWithSysPtrace(dep2)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -183,6 +188,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		deployment.RedefineWithShareProcessNamespace(dep, true)
 		deployment.RedefineWithSysPtrace(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -198,6 +204,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 
 		deployment.RedefineWithShareProcessNamespace(dep2, true)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -45,6 +45,7 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -68,6 +69,7 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.UncertifiedContainerURLCnfTest, tsparams.TestDeploymentLabels)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -94,12 +96,14 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
 
+		By("Create deployment 1")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", randomNamespace,
 			tsparams.CertifiedContainerURLCockroachDB, tsparams.TestDeploymentLabels)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -126,12 +130,14 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.UncertifiedContainerURLCnfTest, tsparams.TestDeploymentLabels)
 
+		By("Create deployment 1")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2 := deployment.DefineDeployment("affiliated-cert-deployment-2", randomNamespace,
 			tsparams.CertifiedContainerURLCockroachDB, tsparams.TestDeploymentLabels)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -44,6 +44,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 
 		deployment.RedefineAllContainersWithPreStopSpec(deploymenta, tsparams.PreStopCommand)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -70,6 +71,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		deployment, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -98,6 +100,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 
 		deployment.RedefineAllContainersWithPreStopSpec(deploymenta, tsparams.PreStopCommand)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -126,6 +129,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 
 		deployment.RedefineAllContainersWithPreStopSpec(deploymenta, tsparams.PreStopCommand)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +144,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 
 		deployment.RedefineAllContainersWithPreStopSpec(deploymentb, tsparams.PreStopCommand)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -169,6 +174,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		err = deployment.RedefineFirstContainerWithPreStopSpec(deploymenta, tsparams.PreStopCommand)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -190,6 +196,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		deploymenta, err := tshelper.DefineDeployment(3, 2, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -202,6 +209,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		deploymentb, err := tshelper.DefineDeployment(3, 2, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -44,6 +44,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 
 		deployment.RedefineWithPostStart(deploymenta)
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -70,6 +71,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 
 		deployment.RedefineWithPostStart(deploymenta)
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -84,6 +86,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 
 		deployment.RedefineWithPostStart(deploymentb)
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -180,6 +183,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 
 		deployment.RedefineWithPostStart(deploymenta)
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -192,6 +196,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -157,6 +157,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		deployment.RedefineWithRunTimeClass(dep, rtc.Name)
 		deployment.RedefineWithCPUResources(dep, "1", "1")
 
+		By("Deploy deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -278,6 +279,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		dep.Spec.Template.SetAnnotations(annotationsMap)
 		deployment.RedefineWithCPUResources(dep, "1", "1")
 
+		By("Deploy deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -56,6 +56,7 @@ var _ = Describe("lifecycle-deployment-scaling", Serial, func() {
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -45,6 +45,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymenta, corev1.PullIfNotPresent)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymenta, corev1.PullIfNotPresent)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -85,6 +87,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymentb, corev1.PullIfNotPresent)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -98,6 +101,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymentc, corev1.PullIfNotPresent)
 
+		By("Create deployment 3")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentc, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -226,6 +230,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		deployment := deployment.DefineDeployment(tsparams.TestDeploymentName, randomNamespace,
 			"registry.access.redhat.com/ubi8/ubi:latest", tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -253,6 +258,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymenta, corev1.PullAlways)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -280,6 +286,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymenta, corev1.PullNever)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -294,6 +301,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymentb, corev1.PullIfNotPresent)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -334,6 +342,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 
 		deployment.RedefineWithImagePullPolicy(deploymenta, corev1.PullIfNotPresent)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -46,6 +46,7 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		deployment.RedefineWithLivenessProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		deployment.RedefineWithLivenessProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -88,6 +90,7 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		deployment.RedefineWithLivenessProbe(deploymentb)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -185,6 +188,7 @@ var _ = Describe("lifecycle-liveness", func() {
 
 		deployment.RedefineWithLivenessProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -197,6 +201,7 @@ var _ = Describe("lifecycle-liveness", func() {
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -70,6 +70,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 		deployment.RedefineWithPVC(dep, persistentVolume.Name, pvc.Name)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -201,6 +202,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 		deployment.RedefineWithPVC(dep, persistentVolume.Name, pvc.Name)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -317,6 +319,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 
 		deployment.RedefineWithPVC(depb, persistentVolumeb.Name, pvcb.Name)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(depa, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -325,6 +328,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runningDeployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(pvca.Name))
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(depb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -51,12 +51,13 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 			Skip("The cluster does not have enough schedulable nodes.")
 		}
 
-		By("Define and create deployment")
+		By("Define deployment")
 		deploymenta, err := tshelper.DefineDeployment(2, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -90,6 +91,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -104,6 +106,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -131,10 +134,11 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 			Skip("The cluster does not have enough schedulable nodes.")
 		}
 
-		By("Define and create deployment")
+		By("Define deployment")
 		deployment, err := tshelper.DefineDeployment(2, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -205,7 +209,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 			Skip("The cluster does not have enough schedulable nodes.")
 		}
 
-		By("Define and create deployment")
+		By("Define deployment")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -62,12 +62,14 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		deploymenta, err := tshelper.DefineDeployment(2, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -124,12 +126,14 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		deploymenta, err := tshelper.DefineDeployment(2, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		deploymentb, err := tshelper.DefineDeployment(2, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -68,12 +68,13 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		// at least one "clean of any resource" worker is needed.
 		maxPodsPerDeployment := schedulableNodes - 1
 
-		By("Define and create deployment")
+		By("Define deployment")
 		deploymenta, err := tshelper.DefineDeployment(maxPodsPerDeployment, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -109,6 +110,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -123,6 +125,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestTargetLabels)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -150,12 +153,13 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 			Skip("The cluster does not have enough schedulable nodes.")
 		}
 
-		By("Define and create deployment")
+		By("Define deployment")
 		deploymenta, err := tshelper.DefineDeployment(schedulableNodes, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -193,6 +197,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymenta, tsparams.TestTargetLabels)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -208,6 +213,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 		deployment.RedefineWithPodAntiAffinity(deploymentb, tsparams.TestTargetLabels)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -50,6 +50,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		deployment, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,6 +74,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		deployment.RedefineWithNodeSelector(deploymenta, map[string]string{configSuite.General.CnfNodeLabel: ""})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -95,6 +97,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		deployment.RedefineWithNodeAffinity(deploymenta, configSuite.General.CnfNodeLabel)
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -115,6 +118,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -124,6 +128,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 		deployment.RedefineWithNodeAffinity(deploymentb, configSuite.General.CnfNodeLabel)
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -144,6 +149,7 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		deployment, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create Deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -40,6 +40,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -64,6 +65,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 
 		deployment.RedefineWithNoExecuteToleration(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -88,6 +90,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 
 		deployment.RedefineWithPreferNoScheduleToleration(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -112,6 +115,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 
 		deployment.RedefineWithNoScheduleToleration(dep)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -134,12 +138,14 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		dep, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -165,12 +171,14 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		deployment.RedefineWithNoScheduleToleration(dep)
 		deployment.RedefineWithNoExecuteToleration(dep)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
 		dep2, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -46,6 +46,7 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		deployment.RedefineWithReadinessProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		deployment.RedefineWithReadinessProbe(deploymenta)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -86,6 +88,7 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		deployment.RedefineWithReadinessProbe(deploymentb)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -179,6 +182,7 @@ var _ = Describe("lifecycle-readiness", func() {
 
 		deployment.RedefineWithReadinessProbe(deploymenta)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -191,6 +195,7 @@ var _ = Describe("lifecycle-readiness", func() {
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -46,6 +46,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		deployment.RedefineWithStartUpProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,6 +73,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		deployment.RedefineWithStartUpProbe(deploymenta)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -86,6 +88,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		deployment.RedefineWithStartUpProbe(deploymentb)
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -156,6 +159,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		globalhelper.AppendContainersToDeployment(deploymenta, 1, globalhelper.GetConfiguration().General.TestImage)
 		deployment.RedefineWithStartUpProbe(deploymenta)
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -203,6 +207,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 
 		deployment.RedefineWithStartUpProbe(deploymenta)
 
+		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -215,6 +220,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		deploymentb, err := tshelper.DefineDeployment(1, 1, "lifecycle-dpb", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment 2")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymentb, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -45,6 +45,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -74,6 +75,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 			[]corev1.ContainerPort{{ContainerPort: 8081}})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -105,6 +107,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -134,6 +137,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerCommand(dep, 0, []string{})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -168,6 +172,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerEnvVarList(dep, 1, []corev1.EnvVar{{Name: "LIVENESS_PROBE_DEFAULT_PORT", Value: "8081"}})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -198,6 +203,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerEnvVarList(dep, 1, []corev1.EnvVar{{Name: "LIVENESS_PROBE_DEFAULT_PORT", Value: "8081"}})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -222,6 +228,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = deployment.RedefineContainerCommand(dep, 1, []string{})
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create deployment")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -36,11 +36,12 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51747
 	It("One deployment one pod one container that prints two log lines", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.TwoLogLines})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
 			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
@@ -57,7 +58,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51753
 	It("One deployment one pod one container that prints one log line", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLine})
@@ -78,7 +79,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51754
 	It("One deployment one pod with two containers, both containers print two log lines to stdout", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.TwoLogLines, tsparams.TwoLogLines})
@@ -158,7 +159,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 	// 51757
 	It("One deployment and one statefulset, both having one pod with one container that prints one log "+
 		"line each", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLine})
@@ -226,7 +227,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51760
 	It("One deployment one pod one container without any log line to stdout [negative]", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.NoLogLines})
@@ -247,7 +248,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 
 	// 51761
 	It("One deployment one pod two containers but only one printing one log line [negative]", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLine, tsparams.NoLogLines})
@@ -318,7 +319,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 	// 51764
 	It("One deployment and one statefulset both one container each, but only deployment prints "+
 		"one log line [negative]", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLine})
@@ -352,7 +353,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLineWithoutNewLine})
@@ -378,7 +379,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 			Skip("Test skipped on KIND cluster due to newline char issue")
 		}
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithStdoutBuffers(
 			tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]string{tsparams.OneLogLine, tsparams.OneLogLineWithoutNewLine})

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -39,12 +39,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56635
 	It("One deployment, pod disruption budget minAvailable value meet requirements", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 1)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -72,12 +73,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56636
 	It("One deployment, pod disruption budget maxUnavailable value meet requirements", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -111,6 +113,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 		statefulset.RedefineWithReplicaNumber(myStatefulSet, 1)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilStatefulSetIsReady(myStatefulSet, tsparams.StatefulSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -138,12 +141,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56638
 	It("One deployment, pod disruption budget maxUnavailable equals to replica number [negative]", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -171,12 +175,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 
 	// 56746
 	It("One deployment, pod disruption budget maxUnavailable is bigger than the replica number [negative]", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 2)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -203,12 +208,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 	})
 
 	It("One deployment, pod disruption budget matchLabels does not match deployment label [negative]", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 1)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -235,12 +241,13 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 	})
 
 	It("One deployment, no pod disruption budget [negative]", func() {
-		By("Create deployment")
+		By("Define deployment")
 		dep := deployment.DefineDeployment(tsparams.TestDeploymentBaseName, randomNamespace,
 			globalhelper.GetConfiguration().General.TestImage, tsparams.TnfTargetPodLabels)
 
 		deployment.RedefineWithReplicaNumber(dep, 1)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -36,11 +36,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 	// Positive #1.
 	It("One deployment one pod one container with terminationMessagePolicy set to FallbackToLogsOnError", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{corev1.TerminationMessageFallbackToLogsOnError})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
 			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
@@ -64,13 +65,14 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 
 	// // Positive #2.
 	It("One deployment one pod two containers both with terminationMessagePolicy set to FallbackToLogsOnError", func() {
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName, randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{
 				corev1.TerminationMessageFallbackToLogsOnError,
 				corev1.TerminationMessageFallbackToLogsOnError,
 			})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -129,11 +131,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	It("One deployment and one statefulset, both with one pod with one container, "+
 		"all with terminationMessagePolicy set to FallbackToLogsOnError", func() {
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{corev1.TerminationMessageFallbackToLogsOnError})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
 			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
@@ -172,11 +175,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	// Negative #1.
 	It("One deployment one pod one container without terminationMessagePolicy [negative]", func() {
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{tsparams.UseDefaultTerminationMsgPolicy})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -195,7 +199,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	It("One deployment one pod two containers, only one container with terminationMessagePolicy "+
 		"set to FallbackToLogsOnError [negative]", func() {
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{
@@ -203,6 +207,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 				corev1.TerminationMessageFallbackToLogsOnError,
 			})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -226,13 +231,14 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	// Negative #3.
 	It("One deployment with two pods with one container each without terminationMessagePolicy set [negative]", func() {
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 2,
 			[]corev1.TerminationMessagePolicy{
 				tsparams.UseDefaultTerminationMsgPolicy,
 			})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -251,11 +257,12 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	It("One deployment and one statefulset, both with one pod with one container, "+
 		"only the deployment has terminationMessagePolicy set to FallbackToLogsOnError [negative]", func() {
 
-		By("Create deployment in the cluster")
+		By("Define deployment")
 		deployment := tshelper.DefineDeploymentWithTerminationMsgPolicies(tsparams.TestDeploymentBaseName,
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{corev1.TerminationMessageFallbackToLogsOnError})
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment, tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -270,6 +277,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 			randomNamespace, 1,
 			[]corev1.TerminationMessagePolicy{tsparams.UseDefaultTerminationMsgPolicy})
 
+		By("Create statefulset in the cluster")
 		err = globalhelper.CreateAndWaitUntilStatefulSetIsReady(statefulSet, tsparams.StatefulSetDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -320,9 +328,10 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 	// Skip #1.
 	It("One deployment with one pod and one container without TNF target labels [skip]", func() {
 
-		By("Create deployment without TNF target labels in the cluster")
+		By("Define deployment without TNF target labels in the cluster")
 		deployment := tshelper.DefineDeploymentWithoutTargetLabels(tsparams.TestDeploymentBaseName, randomNamespace)
 
+		By("Create deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deployment,
 			tsparams.DeploymentDeployTimeoutMins)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -101,6 +101,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 
 		deployment.RedefineWithPrivilegedContainer(deploymenta)
 
+		By("Create first deployment")
 		err := globalhelper.CreateAndWaitUntilDeploymentIsReady(deploymenta, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -74,6 +74,7 @@ var _ = Describe("platform-alteration-hugepages-1g-only", Serial, func() {
 		pod.RedefineWithCPUResources(put, "500m", "250m")
 		pod.RedefineWith1GiHugepages(put, 1)
 
+		By("Create and wait until pod is ready")
 		err := globalhelper.CreateAndWaitUntilPodIsReady(put, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
I went through and added separate By("") statements for when deployments are created on the cluster for granularity. 