### PR TITLE
Add retries for 'make build-image-local'

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -116,9 +116,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
-        working-directory: cnf-certification-test
+      - name: Build the `cnf-certification-test` image
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd cnf-certification-test; make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Run the tests
         uses: nick-fields/retry@v2


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1812

Adds retries to the `make build-image-local` command to smooth out failures.