### PR TITLE
Add checks for node count prior to icmp tests using daemonset

### DIFF
--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -167,6 +167,12 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		err = globalhelper.CreateAndWaitUntilDaemonSetIsReady(daemonSet, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
+		// Note: We cannot perform the icmpv4 connectivity test on a single node cluster when defining a daemonset.
+		expectedState := globalparameters.TestCasePassed
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			expectedState = globalparameters.TestCaseSkipped
+		}
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfDefaultNetworkTcName,
@@ -176,7 +182,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfDefaultNetworkTcName,
-			globalparameters.TestCasePassed, randomReportDir)
+			expectedState, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -391,16 +391,28 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds5")
 		Expect(err).ToNot(HaveOccurred())
 
+		// Note: We cannot perform the icmpv4 connectivity test on a single node cluster when defining a daemonset.
+		// Since this is a [negative] test case, we expect it to fail.
+		expectedState := globalparameters.TestCaseFailed
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			expectedState = globalparameters.TestCasePassed
+		}
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+
+		if expectedState == globalparameters.TestCasePassed {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfMultusIpv4TcName,
-			globalparameters.TestCaseFailed, randomReportDir)
+			expectedState, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
The `networking` suite ICMP tests that utilize daemonsets are banking on their being more than one node in the cluster.  I added checks for the number of nodes and changed the expected state of the test based on that.

For testing, I was using OpenShift Local (CRC) on a Mac.