### PR TITLE
Add lifecycle suite flexibility for single node clusters

### DIFF
--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -129,12 +129,17 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Start lifecycle-affinity-required-pods test")
-		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
-			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		err = globalhelper.LaunchTests(
+			tsparams.TnfAffinityRequiredPodsTcName,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			randomReportDir,
+			randomTnfConfigDir)
 		Expect(err).To(HaveOccurred())
 
 		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed,
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.TnfAffinityRequiredPodsTcName,
+			globalparameters.TestCaseFailed,
 			randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -226,10 +226,21 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodHighAvailabilityTcName, globalparameters.TestCaseFailed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			Expect(err).ToNot(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(
+				tsparams.TnfPodHighAvailabilityTcName,
+				globalparameters.TestCaseSkipped,
+				randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodHighAvailabilityTcName,
+				globalparameters.TestCaseFailed, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 })

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -45,7 +45,6 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 
 	// 48120
 	It("One deployment, no nodeSelector nor nodeAffinity", func() {
-
 		By("Define Deployment")
 		deployment, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -59,14 +58,19 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCasePassed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCasePassed, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	// 48458
 	It("One deployment with nodeSelector [negative]", func() {
-
 		By("Define Deployment with nodeSelector")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -81,16 +85,22 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			Expect(err).ToNot(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	// 48470
 	It("One deployment with nodeAffinity [negative]", func() {
-
 		By("Define Deployment with nodeAffinity")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -104,11 +114,18 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			Expect(err).ToNot(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	// 48471
@@ -135,11 +152,18 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			Expect(err).ToNot(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 
 	// 48472
@@ -165,10 +189,23 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
 
-		By("Verify test case status in Claim report")
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
+			Expect(err).ToNot(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(
+				tsparams.TnfPodSchedulingTcName,
+				globalparameters.TestCaseSkipped,
+				randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			By("Verify test case status in Claim report")
+			err = globalhelper.ValidateIfReportsAreValid(
+				tsparams.TnfPodSchedulingTcName,
+				globalparameters.TestCaseFailed,
+				randomReportDir)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 })


### PR DESCRIPTION
Changes:
- Add `nodes.IsClusterOverCommitted()` funcs to check if cluster is even able to spawn CPU isolation cluster.
- Adjust various tests that do not act correctly when there is only a single node to test against (think scaling tests).