### PR TITLE
Github CI: Step to use /mnt for docker storage

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -77,6 +77,20 @@ jobs:
         run: make bootstrap-cluster
         working-directory: cnf-certification-test-partner
 
+      # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
+      # This step needs to be done right after the partner repo's bootstrap scripts, as they
+      # overwrite the docker's daemon.json.
+      - name: Make docker to use /mnt (sdb) for storage
+        run: |
+          df -h
+          lsblk
+          sudo mkdir /mnt/docker-storage
+          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+          cat /etc/docker/daemon.json
+          sudo systemctl restart docker
+          sudo ls -la /mnt/docker-storage
+
       - name: Create `local-test-infra` OpenShift resources
         run: make rebuild-cluster
         working-directory: cnf-certification-test-partner


### PR DESCRIPTION
Use /mnt (sdb) for docker storage. Same as
https://github.com/test-network-function/cnf-certification-test/pull/1857