### PR TITLE
Enable collector for QE runs

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 3
-          command: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+          command: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE}/cnf-certification-test TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
 
   check-all-dependencies-are-merged:
     runs-on: ubuntu-latest

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -22,7 +22,12 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-const retryInterval = 5
+const (
+	retryInterval = 5
+	ExecutedBy    = "QE"
+	AppPwd        = "qepwd"
+	PartnerName   = "qeuser"
+)
 
 // ValidateIfReportsAreValid test if report is valid for given test case.
 func ValidateIfReportsAreValid(tcName string, tcExpectedStatus string, reportDir string) error {
@@ -73,6 +78,18 @@ func DefineTnfConfig(namespaces []string, targetPodLabels []string, targetOperat
 	defer configFile.Close()
 	configFileEncoder := yaml.NewEncoder(configFile)
 	tnfConfig := globalparameters.TnfConfig{}
+
+	// Configure the collector submission details
+	tnfConfig.ExecutedBy = ExecutedBy
+	tnfConfig.CollectorAppPassword = AppPwd
+	tnfConfig.PartnerName = PartnerName
+
+	// Check if job ID environment variable is set and append to partner name
+	// Example, this should look like "qeuser_1234"
+	jobID := os.Getenv("JOB_ID")
+	if jobID != "" {
+		tnfConfig.PartnerName = fmt.Sprintf("%s_%s", PartnerName, jobID)
+	}
 
 	err = defineTnfNamespaces(&tnfConfig, namespaces)
 	if err != nil {

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -27,6 +27,12 @@ func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, 
 		return fmt.Errorf("failed to set TNF_OMIT_ARTIFACTS_ZIP_FILE: %w", err)
 	}
 
+	// enable the collector
+	err = os.Setenv("TNF_ENABLE_DATA_COLLECTION", "true")
+	if err != nil {
+		return fmt.Errorf("failed to set TNF_ENABLE_DATA_COLLECTION: %w", err)
+	}
+
 	glog.V(5).Info(fmt.Sprintf("container engine set to %s", containerEngine))
 	testArgs := []string{
 		"-k", os.Getenv("KUBECONFIG"),

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -9,6 +9,9 @@ type (
 		OperatorsUnderTestLabels []string                     `yaml:"operatorsUnderTestLabels" json:"operatorsUnderTestLabels"`
 		Certifiedcontainerinfo   []CertifiedContainerRepoInfo `yaml:"certifiedcontainerinfo" json:"certifiedcontainerinfo"`
 		TargetCrdFilters         []TargetCrdFilter            `yaml:"targetCrdFilters" json:"targetCrdFilters"`
+		ExecutedBy               string                       `yaml:"executedBy" json:"executedBy"`
+		CollectorAppPassword     string                       `yaml:"CollectorAppPassword" json:"CollectorAppPassword"`
+		PartnerName              string                       `yaml:"partnerName" json:"partnerName"`
 	}
 
 	TargetCrdFilter struct {


### PR DESCRIPTION
- Modify the `tnf_config` that we build to pass in variables for the collector.
- Add `JOB_ID` environment variable to pass the github job ID in as part of the `partnerName`.