### PR TITLE
Shorten minReadySeconds

### DIFF
--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -16,7 +16,7 @@ func DefineDaemonSet(namespace string, image string, label map[string]string, na
 			Name:      name,
 			Namespace: namespace},
 		Spec: appsv1.DaemonSetSpec{
-			MinReadySeconds: 15,
+			MinReadySeconds: 5,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},
@@ -43,7 +43,7 @@ func DefineDaemonSetWithContainerSpecs(name, namespace string, labels map[string
 			Name:      name,
 			Namespace: namespace},
 		Spec: appsv1.DaemonSetSpec{
-			MinReadySeconds: 15,
+			MinReadySeconds: 5,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/tests/utils/daemonset/daemonset_test.go
+++ b/tests/utils/daemonset/daemonset_test.go
@@ -12,7 +12,7 @@ func TestDefineDaemonSet(t *testing.T) {
 	assert.NotNil(t, ds)
 	assert.Equal(t, "nginx", ds.Name)
 	assert.Equal(t, "default", ds.Namespace)
-	assert.Equal(t, int32(15), ds.Spec.MinReadySeconds)
+	assert.Equal(t, int32(5), ds.Spec.MinReadySeconds)
 	assert.Equal(t, "testpod-", ds.Spec.Template.ObjectMeta.Name)
 }
 
@@ -25,7 +25,7 @@ func TestDefineDaemonSetWithContainerSpecs(t *testing.T) {
 	assert.NotNil(t, testDS)
 	assert.Equal(t, "nginx", testDS.Name)
 	assert.Equal(t, "default", testDS.Namespace)
-	assert.Equal(t, int32(15), testDS.Spec.MinReadySeconds)
+	assert.Equal(t, int32(5), testDS.Spec.MinReadySeconds)
 }
 
 func TestRedefineDaemonSetWithNodeSelector(t *testing.T) {

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -24,7 +24,7 @@ func DefineDeployment(deploymentName string, namespace string, image string, lab
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas:        ptr.To[int32](1),
-			MinReadySeconds: 15,
+			MinReadySeconds: 5,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},

--- a/tests/utils/deployment/deployment_test.go
+++ b/tests/utils/deployment/deployment_test.go
@@ -38,7 +38,7 @@ func TestDefineDeployment(t *testing.T) {
 
 			// Assert hardcoded default values are in the deployment.
 			assert.Equal(t, int32(1), *deployment.Spec.Replicas)
-			assert.Equal(t, int32(15), deployment.Spec.MinReadySeconds)
+			assert.Equal(t, int32(5), deployment.Spec.MinReadySeconds)
 		})
 	}
 }

--- a/tests/utils/replicaset/replicaset.go
+++ b/tests/utils/replicaset/replicaset.go
@@ -15,7 +15,7 @@ func DefineReplicaSet(replicaSetName string, namespace string, image string, lab
 			Namespace: namespace},
 		Spec: appsv1.ReplicaSetSpec{
 			Replicas:        ptr.To[int32](1),
-			MinReadySeconds: 15,
+			MinReadySeconds: 5,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,
 			},

--- a/tests/utils/statefulset/statefulset.go
+++ b/tests/utils/statefulset/statefulset.go
@@ -15,7 +15,7 @@ func DefineStatefulSet(statefulSetName string, namespace string,
 			Name:      statefulSetName,
 			Namespace: namespace},
 		Spec: appsv1.StatefulSetSpec{
-			MinReadySeconds: 15,
+			MinReadySeconds: 5,
 			Replicas:        ptr.To[int32](1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: label,

--- a/tests/utils/statefulset/statefulset_test.go
+++ b/tests/utils/statefulset/statefulset_test.go
@@ -17,7 +17,7 @@ func TestDefineStatefulSet(t *testing.T) {
 	assert.Equal(t, "test", testStatefulSet.Spec.Template.ObjectMeta.Labels["app"])
 	assert.Equal(t, "testImage", testStatefulSet.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, int64(0), *testStatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds)
-	assert.Equal(t, int32(15), testStatefulSet.Spec.MinReadySeconds)
+	assert.Equal(t, int32(5), testStatefulSet.Spec.MinReadySeconds)
 }
 
 func TestRedefineWithReadinessProbe(t *testing.T) {


### PR DESCRIPTION
Changing the `minReadySeconds` from 15 seconds to 5 seconds across the repo.  Wondering if all of the stability changes will allow for this work happily.