### PR TITLE
Do not expect error on negative test cases

### DIFF
--- a/tests/accesscontrol/tests/access_control_bpf_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_bpf_capability_check.go
@@ -72,7 +72,7 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlBpfCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -134,7 +134,7 @@ var _ = Describe("Access-control bpf-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlBpfCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_container_host_port.go
+++ b/tests/accesscontrol/tests/access_control_container_host_port.go
@@ -87,7 +87,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlContainerHostPort,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -160,7 +160,7 @@ var _ = Describe("Access-control container-host-port,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlContainerHostPort,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_container_non-root_user.go
+++ b/tests/accesscontrol/tests/access_control_container_non-root_user.go
@@ -85,7 +85,7 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNonRootUser,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -170,7 +170,7 @@ var _ = Describe("Access-control non-root user,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNonRootUser,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_crd_roles.go
+++ b/tests/accesscontrol/tests/access_control_crd_roles.go
@@ -103,7 +103,7 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCrdRoles, globalparameters.TestCaseFailed, randomReportDir)
@@ -132,7 +132,7 @@ var _ = Describe("access-control-crd-roles", Serial, func() {
 		By("Start lifecycle-crd-scaling test")
 		err = globalhelper.LaunchTests(tsparams.TnfCrdRoles,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCrdRoles, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_ipc_lock_capability_check.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlIpcLockCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -170,7 +170,7 @@ var _ = Describe("Access-control ipc-lock-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlIpcLockCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_namespace.go
+++ b/tests/accesscontrol/tests/access_control_namespace.go
@@ -80,7 +80,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
 		By("Verify test case status in Claim report")
@@ -160,7 +160,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
 		By("Verify test case status in Claim report")
@@ -234,7 +234,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
 		By("Verify test case status in Claim report")
@@ -332,7 +332,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
 		By("Verify test case status in Claim report")
@@ -426,7 +426,7 @@ var _ = Describe("Access-control namespace, ", Serial, func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespace,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseNameAccessControlNamespace+" test")
 
 		By("Verify test case status in Claim report")

--- a/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
+++ b/tests/accesscontrol/tests/access_control_namespace_resource_quota.go
@@ -90,7 +90,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespaceResourceQuota,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -178,7 +178,7 @@ var _ = Describe("Access-control namespace-resource-quota,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNamespaceResourceQuota,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_admin_capability_check.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetAdminCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -171,7 +171,7 @@ var _ = Describe("Access-control net-admin-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetAdminCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_net_raw_capability_check.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetRawCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -169,7 +169,7 @@ var _ = Describe("Access-control net-raw-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNetRawCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_no_1337_uid.go
+++ b/tests/accesscontrol/tests/access_control_no_1337_uid.go
@@ -85,7 +85,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNo1337Uid,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -170,7 +170,7 @@ var _ = Describe("Access-control no-1337-uid,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlNo1337Uid,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_nodeport_service.go
+++ b/tests/accesscontrol/tests/access_control_nodeport_service.go
@@ -176,7 +176,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -220,7 +220,7 @@ var _ = Describe("Access control custom namespace, custom deployment,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNodePortTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_one_process_per_container.go
+++ b/tests/accesscontrol/tests/access_control_one_process_per_container.go
@@ -74,7 +74,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlOneProcessPerContainer,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -125,7 +125,7 @@ var _ = Describe("Access-control one-process-per-container,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlOneProcessPerContainer,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
+++ b/tests/accesscontrol/tests/access_control_pod_automount_service_account_token.go
@@ -98,7 +98,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -173,7 +173,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -211,7 +211,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -356,7 +356,7 @@ var _ = Describe("Access-control pod-automount-service-account-token, ", func() 
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodAutomountToken,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_cluster_role_bindings.go
@@ -98,7 +98,7 @@ var _ = Describe("Access-control pod cluster role binding,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlClusterRoleBindings,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_host_ipc.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_ipc.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -175,7 +175,7 @@ var _ = Describe("Access-control pod-host-ipc, ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostIpc,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_host_network.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_network.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostNetwork,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -169,7 +169,7 @@ var _ = Describe("Access-control pod-host-network ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostNetwork,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_host_path.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_path.go
@@ -90,7 +90,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -182,7 +182,7 @@ var _ = Describe("Access-control pod-host-path, ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPath,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_host_pid.go
+++ b/tests/accesscontrol/tests/access_control_pod_host_pid.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPid,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -174,7 +174,7 @@ var _ = Describe("Access-control pod-host-pid ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPodHostPid,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_role_bindings.go
+++ b/tests/accesscontrol/tests/access_control_pod_role_bindings.go
@@ -89,7 +89,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodRoleBindings,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -173,7 +173,7 @@ var _ = Describe("Access-control pod-role-bindings,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodRoleBindings,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_pod_service_account.go
+++ b/tests/accesscontrol/tests/access_control_pod_service_account.go
@@ -77,7 +77,7 @@ var _ = Describe("Access-control pod-service-account,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodServiceAccount,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -101,7 +101,7 @@ var _ = Describe("Access-control pod-service-account,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodServiceAccount,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_requests_and_limits.go
+++ b/tests/accesscontrol/tests/access_control_requests_and_limits.go
@@ -91,7 +91,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -122,7 +122,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -154,7 +154,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -186,7 +186,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -286,7 +286,7 @@ var _ = Describe("Access-control requests-and-limits,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlRequestsAndLimits,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_security_context.go
+++ b/tests/accesscontrol/tests/access_control_security_context.go
@@ -89,7 +89,7 @@ var _ = Describe("Access-control security-context,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfSecurityContextTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -166,7 +166,7 @@ var _ = Describe("Access-control security-context,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfSecurityContextTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
+++ b/tests/accesscontrol/tests/access_control_security_context_privilege_escalation.go
@@ -86,7 +86,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPrivilegeEscalation,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -172,7 +172,7 @@ var _ = Describe("Access-control security-context-privilege-escalation,", func()
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlPrivilegeEscalation,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_ssh_daemons.go
+++ b/tests/accesscontrol/tests/access_control_ssh_daemons.go
@@ -72,7 +72,7 @@ var _ = Describe("Access-control ssh-daemons,", func() {
 			tsparams.TnfNoSSHDaemonsAllowed,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -88,7 +88,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysAdminCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -171,7 +171,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysAdminCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/accesscontrol/tests/access_control_sys_ptrace.go
+++ b/tests/accesscontrol/tests/access_control_sys_ptrace.go
@@ -120,7 +120,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysPtraceCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -217,7 +217,7 @@ var _ = Describe("Access-control sys-ptrace-capability ", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameAccessControlSysPtraceCapability,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -77,7 +77,7 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameContainerDigest,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -145,7 +145,7 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 		err = globalhelper.LaunchTests(
 			tsparams.TestCaseNameContainerDigest,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -158,7 +158,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Claim report")
@@ -197,7 +197,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestCaseOperatorAffiliatedCertName+" test")
 
 		By("Verify test case status in Claim report")

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -145,7 +145,7 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial, f
 		err = globalhelper.LaunchTests(
 			tsparams.TestHelmChartCertified,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred(), "Error running "+
+		Expect(err).ToNot(HaveOccurred(), "Error running "+
 			tsparams.TestHelmChartCertified+" test")
 
 		By("Verify test case status in Claim report")

--- a/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
+++ b/tests/lifecycle/tests/lifecycle_affinity_required_pods.go
@@ -110,7 +110,7 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		By("Start lifecycle-affinity-required-pods test")
 		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed,
@@ -134,7 +134,7 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			randomReportDir,
 			randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -166,7 +166,7 @@ var _ = Describe("lifecycle-affinity-required-pods", func() {
 		By("Start lifecycle-affinity-required-pods test")
 		err = globalhelper.LaunchTests(tsparams.TnfAffinityRequiredPodsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfAffinityRequiredPodsTcName, globalparameters.TestCaseFailed,

--- a/tests/lifecycle/tests/lifecycle_container_shutdown.go
+++ b/tests/lifecycle/tests/lifecycle_container_shutdown.go
@@ -84,7 +84,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfShutdownTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -182,7 +182,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfShutdownTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -222,7 +222,7 @@ var _ = Describe("lifecycle-container-prestop", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfShutdownTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfShutdownTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_container_startup.go
+++ b/tests/lifecycle/tests/lifecycle_container_startup.go
@@ -168,7 +168,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 		By("Start lifecycle-container-poststart test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerStartUpTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -208,7 +208,7 @@ var _ = Describe("lifecycle-container-poststart", func() {
 		By("Start lifecycle-container-poststart test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerStartUpTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerStartUpTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_cpu_isolation.go
+++ b/tests/lifecycle/tests/lifecycle_cpu_isolation.go
@@ -266,7 +266,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCPUIsolationTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -301,7 +301,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCPUIsolationTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -363,7 +363,7 @@ var _ = Describe("lifecycle-cpu-isolation", Serial, func() {
 		By("Start lifecycle-cpu-isolation test")
 		err = globalhelper.LaunchTests(tsparams.TnfCPUIsolationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCPUIsolationTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_image_pull_policy.go
+++ b/tests/lifecycle/tests/lifecycle_image_pull_policy.go
@@ -214,7 +214,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfImagePullPolicyTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -242,7 +242,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfImagePullPolicyTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -270,7 +270,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfImagePullPolicyTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -313,7 +313,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfImagePullPolicyTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -354,7 +354,7 @@ var _ = Describe("lifecycle-image-pull-policy", func() {
 		By("Start lifecycle-image-pull-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfImagePullPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfImagePullPolicyTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_liveness.go
+++ b/tests/lifecycle/tests/lifecycle_liveness.go
@@ -173,7 +173,7 @@ var _ = Describe("lifecycle-liveness", func() {
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfLivenessTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -213,7 +213,7 @@ var _ = Describe("lifecycle-liveness", func() {
 		By("Start lifecycle-liveness test")
 		err = globalhelper.LaunchTests(tsparams.TnfLivenessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfLivenessTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
+++ b/tests/lifecycle/tests/lifecycle_persistent_volume_reclaim_policy.go
@@ -214,7 +214,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPersistentVolumeReclaimPolicyTcName, globalparameters.TestCaseFailed,
@@ -256,7 +256,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPersistentVolumeReclaimPolicyTcName, globalparameters.TestCaseFailed,
@@ -340,7 +340,7 @@ var _ = Describe("lifecycle-persistent-volume-reclaim-policy", Serial, func() {
 		By("Start lifecycle-persistent-volume-reclaim-policy test")
 		err = globalhelper.LaunchTests(tsparams.TnfPersistentVolumeReclaimPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPersistentVolumeReclaimPolicyTcName, globalparameters.TestCaseFailed,

--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -150,7 +150,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodHighAvailabilityTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -193,7 +193,7 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodHighAvailabilityTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -226,9 +226,9 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 		By("Start lifecycle pod-high-availability test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodHighAvailabilityTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(
 				tsparams.TnfPodHighAvailabilityTcName,
@@ -236,7 +236,6 @@ var _ = Describe("lifecycle-pod-high-availability", func() {
 				randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodHighAvailabilityTcName,
 				globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_pod_owner_type.go
+++ b/tests/lifecycle/tests/lifecycle_pod_owner_type.go
@@ -113,7 +113,7 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodOwnerTypeTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -146,7 +146,7 @@ var _ = Describe("lifecycle-pod-owner-type", func() {
 		By("Start lifecycle-pod-owner-type test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodOwnerTypeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodOwnerTypeTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -171,7 +171,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodRecreationTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -225,7 +225,7 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 		By("Start lifecycle-pod-recreation test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodRecreationTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodRecreationTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_pod_scheduling.go
+++ b/tests/lifecycle/tests/lifecycle_pod_scheduling.go
@@ -85,14 +85,13 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -114,14 +113,13 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -152,14 +150,13 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseSkipped, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodSchedulingTcName, globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -189,9 +186,9 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 		By("Start lifecycle-pod-scheduling test")
 		err = globalhelper.LaunchTests(tsparams.TnfPodSchedulingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(
 				tsparams.TnfPodSchedulingTcName,
@@ -199,7 +196,6 @@ var _ = Describe("lifecycle-pod-scheduling", func() {
 				randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(
 				tsparams.TnfPodSchedulingTcName,

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -73,7 +73,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodTolerationBypassTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -98,7 +98,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodTolerationBypassTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -123,7 +123,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodTolerationBypassTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -186,7 +186,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfPodTolerationBypassTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/lifecycle/tests/lifecycle_readiness.go
+++ b/tests/lifecycle/tests/lifecycle_readiness.go
@@ -167,7 +167,7 @@ var _ = Describe("lifecycle-readiness", func() {
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfReadinessTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -207,7 +207,7 @@ var _ = Describe("lifecycle-readiness", func() {
 		By("Start lifecycle-readiness test")
 		err = globalhelper.LaunchTests(tsparams.TnfReadinessTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfReadinessTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_startup_probe.go
+++ b/tests/lifecycle/tests/lifecycle_startup_probe.go
@@ -192,7 +192,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStartUpProbeTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -232,7 +232,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStartUpProbeTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -259,7 +259,7 @@ var _ = Describe("lifecycle-startup-probe", func() {
 		By("Start lifecycle-startup-probe test")
 		err = globalhelper.LaunchTests(tsparams.TnfStartUpProbeTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStartUpProbeTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/lifecycle/tests/lifecycle_storage_provisioner.go
+++ b/tests/lifecycle/tests/lifecycle_storage_provisioner.go
@@ -90,14 +90,13 @@ var _ = Describe("lifecycle-storage-provisioner", func() {
 		By("Start storage-provisioner test")
 		err = globalhelper.LaunchTests(tsparams.TnfStorageProvisioner,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStorageProvisioner, globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStorageProvisioner, globalparameters.TestCasePassed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -146,14 +145,13 @@ var _ = Describe("lifecycle-storage-provisioner", func() {
 		By("Start storage-provisioner test")
 		err = globalhelper.LaunchTests(tsparams.TnfStorageProvisioner,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
 
 		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().K8sClient.CoreV1()) == 1 {
-			Expect(err).ToNot(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStorageProvisioner, globalparameters.TestCasePassed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
-			Expect(err).To(HaveOccurred())
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfStorageProvisioner, globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/manageability/tests/container_port_name_format.go
+++ b/tests/manageability/tests/container_port_name_format.go
@@ -67,7 +67,7 @@ var _ = Describe("manageability-container-port-name", func() {
 		By("Start container-port-name test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerPortName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerPortName,

--- a/tests/manageability/tests/containers_image_tag.go
+++ b/tests/manageability/tests/containers_image_tag.go
@@ -65,7 +65,7 @@ var _ = Describe("manageability-containers-image-tag", func() {
 		By("Start containers-image-tag test")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerImageTag,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerImageTag,

--- a/tests/networking/tests/networking_default_network.go
+++ b/tests/networking/tests/networking_default_network.go
@@ -112,7 +112,7 @@ var _ = Describe("Networking custom namespace, custom deployment,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfDefaultNetworkTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_dpdk_cpu_pinning_exec_probe.go
+++ b/tests/networking/tests/networking_dpdk_cpu_pinning_exec_probe.go
@@ -89,7 +89,7 @@ var _ = Describe("Networking dpdk-cpu-pinning-exec-probe,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfDpdkCPUPinningExecProbe,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_dual_stack_service.go
+++ b/tests/networking/tests/networking_dual_stack_service.go
@@ -47,7 +47,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfDualStackServiceTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -68,7 +68,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfDualStackServiceTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -91,7 +91,7 @@ var _ = Describe("Networking dual-stack-service,", func() {
 			err = globalhelper.LaunchTests(
 				tsparams.TnfDualStackServiceTcName,
 				globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -357,7 +357,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -395,7 +395,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -434,7 +434,7 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfMultusIpv4TcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_network_policy_deny_all.go
+++ b/tests/networking/tests/networking_network_policy_deny_all.go
@@ -76,7 +76,7 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNetworkPolicyDenyAllTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -102,7 +102,7 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNetworkPolicyDenyAllTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -122,7 +122,7 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfNetworkPolicyDenyAllTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -231,7 +231,7 @@ var _ = Describe("Networking network-policy-deny-all,", func() {
 			err = globalhelper.LaunchTests(
 				tsparams.TnfNetworkPolicyDenyAllTcName,
 				globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_ocp_reserved_ports_usage.go
+++ b/tests/networking/tests/networking_ocp_reserved_ports_usage.go
@@ -67,7 +67,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfOcpReservedPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -110,7 +110,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfOcpReservedPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -156,7 +156,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfOcpReservedPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -211,7 +211,7 @@ var _ = Describe("Networking ocp-reserved-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfOcpReservedPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_reserved_partner_ports.go
+++ b/tests/networking/tests/networking_reserved_partner_ports.go
@@ -72,7 +72,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -115,7 +115,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -161,7 +161,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -214,7 +214,7 @@ var _ = Describe("Networking reserved-partner-ports,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfReservedPartnerPortsTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/networking/tests/networking_undeclared_container_ports_usage.go
+++ b/tests/networking/tests/networking_undeclared_container_ports_usage.go
@@ -120,7 +120,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -150,7 +150,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -211,7 +211,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -236,7 +236,7 @@ var _ = Describe("Networking undeclared-container-ports-usage,", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfUndeclaredContainerPortsUsageTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/observability/tests/container_logging.go
+++ b/tests/observability/tests/container_logging.go
@@ -239,7 +239,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerLoggingTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -260,7 +260,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerLoggingTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -290,7 +290,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerLoggingTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -309,7 +309,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerLoggingTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -340,7 +340,7 @@ var _ = Describe(tsparams.TnfContainerLoggingTcName, func() {
 		By("Start TNF " + tsparams.TnfContainerLoggingTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfContainerLoggingTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfContainerLoggingTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/observability/tests/crd_status.go
+++ b/tests/observability/tests/crd_status.go
@@ -104,7 +104,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCrdStatusTcName, globalparameters.TestCaseFailed,
@@ -135,7 +135,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCrdStatusTcName, globalparameters.TestCaseFailed,
@@ -166,7 +166,7 @@ var _ = Describe(tsparams.TnfCrdStatusTcName, Serial, func() {
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			globalhelper.GetConfiguration().General.TnfReportDir,
 			globalhelper.GetConfiguration().General.TnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfCrdStatusTcName, globalparameters.TestCaseFailed,

--- a/tests/observability/tests/pod_disruption_budget.go
+++ b/tests/observability/tests/pod_disruption_budget.go
@@ -132,7 +132,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodDisruptionBudgetTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -166,7 +166,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodDisruptionBudgetTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -200,7 +200,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodDisruptionBudgetTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -233,7 +233,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodDisruptionBudgetTcName, globalparameters.TestCaseFailed, randomReportDir)
@@ -259,7 +259,7 @@ var _ = Describe(tsparams.TnfPodDisruptionBudgetTcName, func() {
 		By("Start TNF " + tsparams.TnfPodDisruptionBudgetTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfPodDisruptionBudgetTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfPodDisruptionBudgetTcName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/observability/tests/termination_policy.go
+++ b/tests/observability/tests/termination_policy.go
@@ -187,7 +187,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTerminationMsgPolicyTcName, globalparameters.TestCaseFailed,
@@ -220,7 +220,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTerminationMsgPolicyTcName, globalparameters.TestCaseFailed,
@@ -245,7 +245,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTerminationMsgPolicyTcName, globalparameters.TestCaseFailed,
@@ -284,7 +284,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTerminationMsgPolicyTcName, globalparameters.TestCaseFailed,
@@ -317,7 +317,7 @@ var _ = Describe(tsparams.TnfTerminationMsgPolicyTcName, func() {
 		By("Start TNF " + tsparams.TnfTerminationMsgPolicyTcName + " test case")
 		err = globalhelper.LaunchTests(tsparams.TnfTerminationMsgPolicyTcName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTerminationMsgPolicyTcName, globalparameters.TestCaseFailed,

--- a/tests/performance/tests/exclusive_cpu_pools.go
+++ b/tests/performance/tests/exclusive_cpu_pools.go
@@ -81,7 +81,7 @@ var _ = Describe("performance-exclusive-cpu-pool", func() {
 		By("Start exclusive-cpu-pool test")
 		err = globalhelper.LaunchTests(tsparams.TnfExclusiveCPUPool,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfExclusiveCPUPool,

--- a/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
+++ b/tests/performance/tests/rt_exclusive_cpu_pool_scheduling_policy.go
@@ -103,7 +103,7 @@ var _ = Describe("performance-exclusive-cpu-pool-rt-scheduling-policy", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfRtExclusiveCPUPoolSchedulingPolicy,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/performance/tests/rt_isolated_cpu_pool.go
+++ b/tests/performance/tests/rt_isolated_cpu_pool.go
@@ -70,7 +70,7 @@ var _ = Describe("performance-isolated-cpu-pool-rt-scheduling-policy", Serial, f
 		err = globalhelper.LaunchTests(
 			tsparams.TnfRtIsolatedCPUPoolSchedulingPolicy,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/platformalteration/tests/platform_alteration_base_image.go
+++ b/tests/platformalteration/tests/platform_alteration_base_image.go
@@ -127,7 +127,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfBaseImageName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -160,7 +160,7 @@ var _ = Describe("platform-alteration-base-image", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfBaseImageName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_1g.go
@@ -158,7 +158,7 @@ var _ = Describe("platform-alteration-hugepages-1g-only", Serial, func() {
 		By("Start platform-alteration-hugepages-1g-only test")
 		err = globalhelper.LaunchTests(tsparams.TnfHugePages1gOnlyName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages1gOnlyName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_2m.go
@@ -138,7 +138,7 @@ var _ = Describe("platform-alteration-hugepages-2m-only", Serial, func() {
 		By("Start platform-alteration-hugepages-2m-only test")
 		err = globalhelper.LaunchTests(tsparams.TnfHugePages2mOnlyName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePages2mOnlyName, globalparameters.TestCaseFailed, randomReportDir)

--- a/tests/platformalteration/tests/platform_alteration_hugepages_config.go
+++ b/tests/platformalteration/tests/platform_alteration_hugepages_config.go
@@ -109,7 +109,7 @@ var _ = Describe("platform-alteration-hugepages-config", Serial, func() {
 		By("Start platform-alteration-hugepages-config test")
 		err = globalhelper.LaunchTests(tsparams.TnfHugePagesConfigName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfHugePagesConfigName, globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
+++ b/tests/platformalteration/tests/platform_alteration_is_redhat_release.go
@@ -102,7 +102,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfIsRedHatReleaseName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
@@ -123,7 +123,7 @@ var _ = Describe("platform-alteration-is-redhat-release", func() {
 		err = globalhelper.LaunchTests(
 			tsparams.TnfIsRedHatReleaseName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(

--- a/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
+++ b/tests/platformalteration/tests/platform_alteration_is_selinux_enforcing.go
@@ -106,7 +106,7 @@ var _ = Describe("platform-alteration-is-selinux-enforcing", func() {
 		By("Start platform-alteration-is-selinux-enforcing test")
 		err = globalhelper.LaunchTests(tsparams.TnfIsSelinuxEnforcingName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TnfIsSelinuxEnforcingName,

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -103,7 +103,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", Ordered, fu
 		By("Start platform-alteration-service-mesh-usage test")
 		err = globalhelper.LaunchTests(tsparams.TnfServiceMeshUsageName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfServiceMeshUsageName, globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
@@ -128,7 +128,7 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", Ordered, fu
 		By("Start platform-alteration-service-mesh-usage test")
 		err = globalhelper.LaunchTests(tsparams.TnfServiceMeshUsageName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfServiceMeshUsageName, globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -81,7 +81,7 @@ var _ = Describe("platform-alteration-tainted-node-kernel", Serial, func() {
 		By("Start platform-alteration-tainted-node-kernel test")
 		err = globalhelper.LaunchTests(tsparams.TnfTaintedNodeKernelName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomTnfConfigDir)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = globalhelper.ValidateIfReportsAreValid(tsparams.TnfTaintedNodeKernelName, globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The behavior of the `cnf-certification-test` binary has been modified to return an error code only in case of an actual runtime error and not due to failed test cases.

Depends-On: [test-network-function/cnf-certification-test#1901](https://github.com/test-network-function/cnf-certification-test/pull/1901) 