### PR TITLE
Adjust skipped to failed expected affilated-certification

### DIFF
--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -151,7 +151,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 			By("Verify test case status in Claim report")
 			err = globalhelper.ValidateIfReportsAreValid(
 				tsparams.TestCaseOperatorAffiliatedCertName,
-				globalparameters.TestCaseSkipped, randomReportDir)
+				globalparameters.TestCaseFailed, randomReportDir)
 			Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TestCaseOperatorAffiliatedCertName,
-			globalparameters.TestCaseSkipped, randomReportDir)
+			globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
 
@@ -213,7 +213,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TestCaseOperatorAffiliatedCertName,
-			globalparameters.TestCaseSkipped, randomReportDir)
+			globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
 
@@ -247,7 +247,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TestCaseOperatorAffiliatedCertName,
-			globalparameters.TestCaseSkipped, randomReportDir)
+			globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
 


### PR DESCRIPTION
#665 changed these to skipped, however there has been a change upstream (see PR [here](https://github.com/test-network-function/cnf-certification-test/pull/1901)) in the test suite which now just marks items as `failed` instead of `skipped` if not ran which is the expected result.

These only fail on OCP so that seems to be when this broke.