### PR TITLE
Switch expected output for no labels

### DIFF
--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -252,7 +252,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 	})
 
 	// 46698
-	It("no operators are labeled for testing [skip]", func() {
+	It("no operators are labeled for testing [negative]", func() {
 		By("Start test")
 		err := globalhelper.LaunchTests(
 			tsparams.TestCaseOperatorAffiliatedCertName,
@@ -263,7 +263,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.TestCaseOperatorAffiliatedCertName,
-			globalparameters.TestCaseSkipped, randomReportDir)
+			globalparameters.TestCaseFailed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred(), "Error validating test reports")
 	})
 


### PR DESCRIPTION
Follow up to #706 with another test case that is now expected failed due to: https://github.com/test-network-function/cnf-certification-test/pull/1871