### PR TITLE
Use specific certified image

### DIFF
--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -43,7 +43,7 @@ var (
 	ContainerNameOnlyCockroachDB        = "cockroachdb/cockroach;;;"
 	ContainerRepoOnlyRedHatRegistry     = ";registry.connect.redhat.com;;"
 	CertifiedContainerURLNodeJs         = "registry.access.redhat.com/ubi8/nodejs-12:latest"
-	CertifiedContainerURLCockroachDB    = "registry.connect.redhat.com/cockroachdb/cockroach:latest"
+	CertifiedContainerURLCockroachDB    = "registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17" // 'latest' tag is not available
 	UncertifiedContainerURLCnfTest      = "quay.io/testnetworkfunction/cnf-test-partner:latest"
 
 	TestCaseOperatorAffiliatedCertName        = "affiliated-certification-operator-is-certified"


### PR DESCRIPTION
Looks like the `cockroachdb` image is no longer tagging 'latest' images.

https://catalog.redhat.com/software/containers/cockroachdb/cockroach/596691854b339a3561489ac2?architecture=amd64&container-tabs=gti&image=6601dced1d7d6222ddd1412f