### PR TITLE
Add openshift-marketplace cleanup script

### DIFF
--- a/scripts/clean-marketplace.sh
+++ b/scripts/clean-marketplace.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Set the namespace
+NAMESPACE="openshift-marketplace"
+
+# Get the list of pods in the namespace
+PODS=$(kubectl get pods -n "$NAMESPACE" -o name)
+
+# Delete each pod
+for pod in $PODS; do
+	kubectl delete "$pod" -n "$NAMESPACE"
+done


### PR DESCRIPTION
Adds a simple script to clean up the `openshift-marketplace` namespace.

I will use this script in our nightlies to help smooth out errors seen such as: 
https://github.com/test-network-function/cnf-certification-test/actions/runs/8776950576 