### PR TITLE
Update nodejs image

### DIFF
--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -42,7 +42,7 @@ var (
 	EmptyFieldsContainer                = ";;;"
 	ContainerNameOnlyCockroachDB        = "cockroachdb/cockroach;;;"
 	ContainerRepoOnlyRedHatRegistry     = ";registry.connect.redhat.com;;"
-	CertifiedContainerURLNodeJs         = "registry.access.redhat.com/ubi8/nodejs-12:latest"
+	CertifiedContainerURLNodeJs         = "registry.access.redhat.com/ubi9/nodejs-20:latest"
 	CertifiedContainerURLCockroachDB    = "registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17" // 'latest' tag is not available
 	UncertifiedContainerURLCnfTest      = "quay.io/testnetworkfunction/cnf-test-partner:latest"
 


### PR DESCRIPTION
https://catalog.redhat.com/software/containers/ubi9/nodejs-20/64770ac7a835530172eee6a9?architecture=amd64&image=6613b34207b0db9d49c5e6cb&container-tabs=gti

The old version, nodejs-12, doesn't seem to exist anymore.