### PR TITLE
Temporarily limit procs to 4

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,7 @@ fi
 PFLAG=""
 if [[ ${ENABLE_PARALLEL} == "true" ]]; then
 	echo "Running tests in parallel"
-	PFLAG="-p"
+	PFLAG="-procs=4"
 fi
 
 # Allow for flake retries


### PR DESCRIPTION
I'm not entirely sure what's going on quite yet on the self-hosted runners, but it seems that we are maybe overloading the runner box kicking off the QE tests.  I'm going to temporarily limit the procs to 4 threads to see if it makes it more stable.