### PR TITLE
Add 'Serial' label to high availability tests

### DIFF
--- a/tests/lifecycle/tests/lifecycle_pod_high_availability.go
+++ b/tests/lifecycle/tests/lifecycle_pod_high_availability.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/lifecycle/parameters"
 )
 
-var _ = Describe("lifecycle-pod-high-availability", func() {
+var _ = Describe("lifecycle-pod-high-availability", Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomTnfConfigDir string


### PR DESCRIPTION
I'm not exactly sure why this wasn't there in the first place to be honest.