### PR TITLE
Update operator versions

### DIFF
--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -59,7 +59,7 @@ var (
 	CertifiedOperatorPrefixCockroachCertified = "cockroach-operator"
 	CertifiedOperatorFullCockroachCertified   = "cockroach-operator.v2.13.0"
 	CertifiedOperatorPrefixNginx              = "nginx-ingress-operator"
-	CertifiedOperatorFullNginx                = "nginx-ingress-operator.v2.2.0"
+	CertifiedOperatorFullNginx                = "nginx-ingress-operator.v2.2.1"
 	UncertifiedOperatorPrefixSriov            = "sriov-fec"
 	UncertifiedOperatorFullSriov              = "sriov-fec.v1.2.1"
 )


### PR DESCRIPTION
`nginx-ingress-operator` has a new version v2.2.1