### PR TITLE
Re-enable catalog source precheck

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -88,11 +88,11 @@ var _ = SynchronizedBeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	// if !globalhelper.IsKindCluster() {
-	// 	By("Check if catalog sources are available")
-	// 	err = globalhelper.ValidateCatalogSources()
-	// 	Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
-	// }
+	if !globalhelper.IsKindCluster() {
+		By("Check if catalog sources are available")
+		err = globalhelper.ValidateCatalogSources()
+		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
+	}
 }, func() {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {

--- a/tests/globalhelper/catalogsources.go
+++ b/tests/globalhelper/catalogsources.go
@@ -17,7 +17,7 @@ func ValidateCatalogSources() error {
 }
 
 func validateCatalogSources(opclient v1alpha1typed.OperatorsV1alpha1Interface) error {
-	validCatalogSources := []string{"certified-operators", "community-operators", "redhat-operators", "redhat-marketplace"}
+	validCatalogSources := []string{"certified-operators", "community-operators"}
 
 	catalogSources, err := opclient.CatalogSources(CatalogSourceNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -48,11 +48,11 @@ var _ = SynchronizedBeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Safeguard against running the operator tests on a cluster without catalog sources
-	// if !globalhelper.IsKindCluster() {
-	// 	By("Check if catalog sources are available")
-	// 	err = globalhelper.ValidateCatalogSources()
-	// 	Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
-	// }
+	if !globalhelper.IsKindCluster() {
+		By("Check if catalog sources are available")
+		err = globalhelper.ValidateCatalogSources()
+		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
+	}
 }, func() {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {


### PR DESCRIPTION
Reverts #751 

I also removed the check for the `"redhat-operators", "redhat-marketplace"` catalog sources because they don't seem to be relevant to the passing of the operator or affiliated suite test cases.