### PR TITLE
Add 10 minute timeout for waiting for all pods to be ready

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Wait for all pods to be ready
         run: ./scripts/wait-for-all-pods-running.sh
         working-directory: cnf-certification-test-partner
+        timeout-minutes: 10
 
       - name: Clone the cnf-certification-test repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/2078