### PR TITLE
Add 'use_binary' option

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,8 @@ general:
   verification_log_level: 4
   test_image: quay.io/testnetworkfunction/cnf-test-partner
   tnf_entry_point_script: run-tnf-container.sh
+  tnf_entry_point_binary: certsuite
+  use_binary: false
   tnf_config_dir: /tmp/tnf_config
   tnf_report_dir: /tmp/tnf_report
   docker_config_dir: /home/runner/.docker

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -11,8 +11,73 @@ import (
 	"github.com/golang/glog"
 )
 
-// LaunchTests stats tests based on given parameters.
-func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, configDir string) error {
+func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir string, configDir string) error {
+	// check that the binary exists and is executable in the tnf repo path
+	_, err := os.Stat(fmt.Sprintf("%s/%s", GetConfiguration().General.TnfRepoPath, GetConfiguration().General.TnfEntryPointBinary))
+	if err != nil {
+		glog.V(5).Info(fmt.Sprintf("binary does not exist: %s. "+
+			"Please run `make build-certsuite-tool` in the cnf-certification-test repo.", err))
+
+		return fmt.Errorf("binary does not exist: %w", err)
+	}
+
+	// disable the zip file creation
+	err = os.Setenv("TNF_OMIT_ARTIFACTS_ZIP_FILE", "true")
+	if err != nil {
+		return fmt.Errorf("failed to set TNF_OMIT_ARTIFACTS_ZIP_FILE: %w", err)
+	}
+
+	// enable the collector
+	err = os.Setenv("TNF_ENABLE_DATA_COLLECTION", "true")
+	if err != nil {
+		return fmt.Errorf("failed to set TNF_ENABLE_DATA_COLLECTION: %w", err)
+	}
+
+	// populate the arguments for the binary
+	testArgs := []string{
+		"run",
+		"--config-file", configDir + "/" + globalparameters.DefaultTnfConfigFileName,
+		"--output-dir", reportDir,
+		"--label-filter", testCaseName,
+	}
+
+	cmd := exec.Command(fmt.Sprintf("%s/%s", GetConfiguration().General.TnfRepoPath, GetConfiguration().General.TnfEntryPointBinary))
+	cmd.Args = append(cmd.Args, testArgs...)
+
+	fmt.Printf("cmd: %s\n", cmd.String())
+
+	debugTnf, err := GetConfiguration().DebugTnf()
+	if err != nil {
+		return fmt.Errorf("failed to set env var TNF_LOG_LEVEL: %w", err)
+	}
+
+	if debugTnf {
+		outfile := GetConfiguration().CreateLogFile(getTestSuiteName(testCaseName), tcNameForReport)
+
+		defer outfile.Close()
+
+		_, err = outfile.WriteString(fmt.Sprintf("Running test: %s\n", tcNameForReport))
+		if err != nil {
+			return fmt.Errorf("failed to write to debug file: %w", err)
+		}
+
+		cmd.Stdout = outfile
+		cmd.Stderr = outfile
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("failed to run tc: %s, err: %w, cmd: %s",
+			testCaseName, err, cmd.String())
+	}
+
+	CopyClaimFileToTcFolder(testCaseName, tcNameForReport, reportDir)
+
+	return err
+}
+
+func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir string, configDir string) error {
+	// use the container to run the tests
 	containerEngine := GetConfiguration().General.ContainerEngine
 	glog.V(5).Info(fmt.Sprintf("Selected Container engine:%s", containerEngine))
 
@@ -75,6 +140,16 @@ func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, 
 	CopyClaimFileToTcFolder(testCaseName, tcNameForReport, reportDir)
 
 	return err
+}
+
+// LaunchTests stats tests based on given parameters.
+func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, configDir string) error {
+	// check if the `USE_BINARY` flag is set, if so, run the binary version of the tests
+	if GetConfiguration().General.UseBinary == "true" {
+		return launchTestsViaBinary(testCaseName, tcNameForReport, reportDir, configDir)
+	}
+
+	return launchTestsViaImage(testCaseName, tcNameForReport, reportDir, configDir)
 }
 
 func getTestSuiteName(testCaseName string) string {

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -32,12 +32,14 @@ type Config struct {
 		TnfConfigDir          string `yaml:"tnf_config_dir" envconfig:"TNF_CONFIG_DIR"`
 		TnfRepoPath           string `envconfig:"TNF_REPO_PATH"`
 		TnfEntryPointScript   string `yaml:"tnf_entry_point_script" envconfig:"TNF_ENTRY_POINT_SCRIPT"`
+		TnfEntryPointBinary   string `yaml:"tnf_entry_point_binary" envconfig:"TNF_ENTRY_POINT_BINARY"`
 		TnfReportDir          string `yaml:"tnf_report_dir" envconfig:"TNF_REPORT_DIR"`
 		DockerConfigDir       string `yaml:"docker_config_dir" envconfig:"DOCKER_CONFIG_DIR"`
 		TnfImage              string `yaml:"tnf_image" envconfig:"TNF_IMAGE"`
 		TnfImageTag           string `yaml:"tnf_image_tag" envconfig:"TNF_IMAGE_TAG"`
 		DisableIntrusiveTests string `yaml:"disable_intrusive_tests" envconfig:"DISABLE_INTRUSIVE_TESTS"`
 		ContainerEngine       string `default:"docker" yaml:"container_engine" envconfig:"CONTAINER_ENGINE"`
+		UseBinary             string `default:"false" yaml:"use_binary" envconfig:"USE_BINARY"`
 	} `yaml:"general"`
 }
 


### PR DESCRIPTION
Modified `LaunchTests()` func to either run against the binary or the image depending on the config.  Default path is still the image.