### PR TITLE
Deploy certified-operators catalogsource automatically

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -93,6 +93,10 @@ var _ = SynchronizedBeforeSuite(func() {
 		err = globalhelper.CreateCommunityOperatorsCatalogSource()
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create certified-operators catalog source")
+		err = globalhelper.DeployRHCertifiedOperatorSource("")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Check if catalog sources are available")
 		err = globalhelper.ValidateCatalogSources()
 		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")

--- a/tests/globalhelper/operator.go
+++ b/tests/globalhelper/operator.go
@@ -99,6 +99,18 @@ func ApproveInstallPlan(namespace string, plan *v1alpha1.InstallPlan) error {
 }
 
 func DeployRHCertifiedOperatorSource(ocpVersion string) error {
+	// if the ocpVersion is empty, we will use have to look up the version
+	ocpVersionToUse := ocpVersion
+
+	if ocpVersion == "" {
+		o, err := GetClusterVersion()
+		if err != nil {
+			return fmt.Errorf("unable to get OCP version: %w", err)
+		}
+
+		ocpVersionToUse = o[:4]
+	}
+
 	err := GetAPIClient().Create(context.TODO(),
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -107,7 +119,7 @@ func DeployRHCertifiedOperatorSource(ocpVersion string) error {
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType:  "grpc",
-				Image:       "registry.redhat.io/redhat/certified-operator-index:v" + ocpVersion,
+				Image:       "registry.redhat.io/redhat/certified-operator-index:v" + ocpVersionToUse,
 				DisplayName: "redhat-certified",
 				Publisher:   "Redhat",
 				Secrets:     []string{"redhat-registry-secret", "redhat-connect-registry-secret"},

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -37,6 +37,10 @@ var _ = SynchronizedBeforeSuite(func() {
 		err := globalhelper.CreateCommunityOperatorsCatalogSource()
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create certified-operators catalog source")
+		err = globalhelper.DeployRHCertifiedOperatorSource("")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Check if catalog sources are available")
 		err = globalhelper.ValidateCatalogSources()
 		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")


### PR DESCRIPTION
In the `affiliatedcertification` and `operator` suites, automatically apply the certified-operator catalog source.