### PR TITLE
Skip tainted node test when only single node

### DIFF
--- a/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
+++ b/tests/platformalteration/tests/platform_alteration_tainted_node_kernel.go
@@ -56,6 +56,10 @@ var _ = Describe("platform-alteration-tainted-node-kernel", Serial, func() {
 			Skip("Tainting a node not support on Kind cluster, skipping...")
 		}
 
+		if globalhelper.GetNumberOfNodes(globalhelper.GetAPIClient().CoreV1Interface) == 1 {
+			Skip("There is only one node in the cluster, skipping...")
+		}
+
 		By("Define daemonSet")
 		daemonSet := daemonset.DefineDaemonSet(randomNamespace, globalhelper.GetConfiguration().General.TestImage,
 			tsparams.TnfTargetPodLabels, tsparams.TestDaemonSetName)


### PR DESCRIPTION
We shouldn't restart the only node in the cluster during this test.  Applicable to CRC, SNO, etc.