### PR TITLE
Add new operator tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - godox
+    # - godox
     - gofmt
     - goheader
     - goimports

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -33,19 +33,20 @@ var (
 		testPodLabelPrefixName: testPodLabelValue,
 		"app":                  "test",
 	}
-	TnfTargetOperatorLabels  = fmt.Sprintf("%s: %s", "test-network-function.com/operator", "target")
-	TnfTargetCrdFilters      = []string{"charts.operatorhub.io"}
-	OperatorGroupName        = "operator-test-operator-group"
-	OperatorLabel            = map[string]string{"test-network-function.com/operator": "target"}
-	CertifiedOperatorGroup   = "certified-operators"
-	CommunityOperatorGroup   = "community-operators"
-	OperatorSourceNamespace  = "openshift-marketplace"
-	OperatorPrefixCloudbees  = "cloudbees-ci"
-	OperatorPrefixAnchore    = "anchore-engine"
-	OperatorPrefixQuay       = "quay-operator"
-	OperatorPrefixKiali      = "kiali-operator"
-	OperatorPrefixOpenvino   = "openvino-operator"
-	SubscriptionNameOpenvino = "ovms-operator-subscription"
+	TnfTargetOperatorLabels      = fmt.Sprintf("%s: %s", "test-network-function.com/operator", "target")
+	TnfTargetCrdFilters          = []string{"charts.operatorhub.io"}
+	OperatorGroupName            = "operator-test-operator-group"
+	OperatorLabel                = map[string]string{"test-network-function.com/operator": "target"}
+	CertifiedOperatorGroup       = "certified-operators"
+	CommunityOperatorGroup       = "community-operators"
+	OperatorSourceNamespace      = "openshift-marketplace"
+	OperatorPrefixCloudbees      = "cloudbees-ci"
+	OperatorPrefixAnchore        = "anchore-engine"
+	OperatorPrefixQuay           = "quay-operator"
+	OperatorPrefixKiali          = "kiali-operator"
+	OperatorPrefixOpenvino       = "openvino-operator"
+	CertifiedOperatorPrefixNginx = "nginx-ingress-operator"
+	SubscriptionNameOpenvino     = "ovms-operator-subscription"
 )
 
 const (

--- a/tests/operator/tests/operator_common.go
+++ b/tests/operator/tests/operator_common.go
@@ -1,0 +1,38 @@
+package operator
+
+import (
+	"log"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/operator/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/operator/parameters"
+)
+
+func waitUntilOperatorIsReady(csvPrefix, namespace string) error {
+	var err error
+
+	var csv *v1alpha1.ClusterServiceVersion
+
+	Eventually(func() bool {
+		csv, err = tshelper.GetCsvByPrefix(csvPrefix, namespace)
+		if csv != nil && csv.Status.Phase != v1alpha1.CSVPhaseNone {
+			return csv.Status.Phase != "InstallReady" &&
+				csv.Status.Phase != "Deleting" &&
+				csv.Status.Phase != "Replacing" &&
+				csv.Status.Phase != "Unknown"
+		}
+
+		if err != nil {
+			log.Printf("Error getting csv: %s", err)
+
+			return false
+		}
+
+		return false
+	}, tsparams.Timeout, tsparams.PollingInterval).Should(Equal(true),
+		csvPrefix+" is not ready.")
+
+	return err
+}

--- a/tests/operator/tests/operator_non_root.go
+++ b/tests/operator/tests/operator_non_root.go
@@ -1,0 +1,92 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/operator/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/operator/parameters"
+)
+
+var _ = Describe("Operator pods non-root", func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, randomReportDir, randomTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.OperatorNamespace)
+
+		By("Define TNF config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{tsparams.TnfTargetOperatorLabels},
+			[]string{},
+			tsparams.TnfTargetCrdFilters, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomTnfConfigDir, tsparams.Timeout)
+	})
+
+	It("Operator pods should not run as root", func() {
+		// Deploy an operator that runs as root
+		By("Deploy operator group")
+		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
+		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+
+		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
+		// nginx-ingress-operator: in certified-operators group and version is certified
+		err = tshelper.DeployOperatorSubscription(
+			tsparams.CertifiedOperatorPrefixNginx,
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+			" is not ready")
+
+		By("Label operator")
+		Eventually(func() error {
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixNginx,
+				randomNamespace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Assert that the manager pod is not running as root")
+		controllerPod, err := globalhelper.GetControllerPodFromOperator(randomNamespace, tsparams.CertifiedOperatorPrefixNginx)
+		Expect(err).ToNot(HaveOccurred(), "Error getting controller pod")
+
+		By(fmt.Sprintf("Checking if pod %s is running as root", controllerPod.Name))
+		Expect(controllerPod.Spec.SecurityContext).ToNot(BeNil())
+		Expect(*controllerPod.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+
+		// TODO: Run the actual tests
+	})
+
+	It("Operator pods should not run as root [negative]", func() {
+		// Deploy an operator that runs as root
+
+		// TODO: Find an operator that runs as root
+	})
+})

--- a/tests/operator/tests/operator_pod_automount_token.go
+++ b/tests/operator/tests/operator_pod_automount_token.go
@@ -1,0 +1,98 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/operator/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/operator/parameters"
+)
+
+var _ = Describe("Operator pods automount token", func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, randomReportDir, randomTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.OperatorNamespace)
+
+		By("Define TNF config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{tsparams.TnfTargetOperatorLabels},
+			[]string{},
+			tsparams.TnfTargetCrdFilters, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deploy operator group")
+		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomTnfConfigDir, tsparams.Timeout)
+	})
+
+	It("Operator pods should not have automount token", func() {
+		// Deploy an operator that does not have automount token
+		By("Deploy operator group")
+		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
+		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+
+		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
+		// nginx-ingress-operator: in certified-operators group and version is certified
+		err = tshelper.DeployOperatorSubscription(
+			tsparams.CertifiedOperatorPrefixNginx,
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+			" is not ready")
+
+		By("Label operator")
+		Eventually(func() error {
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixNginx,
+				randomNamespace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Assert that the manager pod has automount token nil or false")
+		controllerPod, err := globalhelper.GetControllerPodFromOperator(randomNamespace, tsparams.CertifiedOperatorPrefixNginx)
+		Expect(err).ToNot(HaveOccurred(), "Error getting controller pod")
+
+		By(fmt.Sprintf("Checking if pod %s has automount token nil or false", controllerPod.Name))
+		if controllerPod.Spec.AutomountServiceAccountToken != nil {
+			Expect(*controllerPod.Spec.AutomountServiceAccountToken).To(BeFalse())
+		} else {
+			Expect(controllerPod.Spec.AutomountServiceAccountToken).To(BeNil())
+		}
+
+		// TODO: Run the actual tests
+	})
+
+	It("Operator pods have automount token [negative]", func() {
+		// Deploy an operator that explicitly has automount token
+		// TODO: Find an operator that has automount token set explicitly
+	})
+})

--- a/tests/operator/tests/operator_read_only_filesystem.go
+++ b/tests/operator/tests/operator_read_only_filesystem.go
@@ -1,0 +1,98 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/operator/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/operator/parameters"
+)
+
+var _ = Describe("Operator pods read only filesystem", func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, randomReportDir, randomTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.OperatorNamespace)
+
+		By("Define TNF config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{tsparams.TnfTargetOperatorLabels},
+			[]string{},
+			tsparams.TnfTargetCrdFilters, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deploy operator group")
+		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomTnfConfigDir, tsparams.Timeout)
+	})
+
+	It("Operator pods should have read-only filesystem", func() {
+		// Deploy an operator that has read-only filesystem
+		// TODO: Find an operator that has a read-only filesystem
+		// TODO: Run the actual tests
+	})
+
+	It("Operator pods should not have read-only filesystem [negative]", func() {
+		// Deploy an operator that has read-only filesystem
+		By("Deploy operator group")
+		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
+		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+
+		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
+		// nginx-ingress-operator: in certified-operators group and version is certified
+		err = tshelper.DeployOperatorSubscription(
+			tsparams.CertifiedOperatorPrefixNginx,
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+			" is not ready")
+
+		By("Label operator")
+		Eventually(func() error {
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixNginx,
+				randomNamespace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Assert that the manager pod has read-only filesystem")
+		controllerPod, err := globalhelper.GetControllerPodFromOperator(randomNamespace, tsparams.CertifiedOperatorPrefixNginx)
+		Expect(err).ToNot(HaveOccurred(), "Error getting controller pod")
+
+		By(fmt.Sprintf("Checking if pod %s does not have read only filesystem", controllerPod.Name))
+		for _, container := range controllerPod.Spec.Containers {
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(container.SecurityContext.ReadOnlyRootFilesystem).To(BeNil())
+		}
+
+		// TODO: Run the actual tests
+	})
+})

--- a/tests/operator/tests/operator_run_as_userid.go
+++ b/tests/operator/tests/operator_run_as_userid.go
@@ -1,0 +1,94 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/test-network-function/cnfcert-tests-verification/tests/globalhelper"
+	tshelper "github.com/test-network-function/cnfcert-tests-verification/tests/operator/helper"
+	tsparams "github.com/test-network-function/cnfcert-tests-verification/tests/operator/parameters"
+)
+
+var _ = Describe("Operator pods have runAs userid", func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomTnfConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and TNF config directories
+		randomNamespace, randomReportDir, randomTnfConfigDir = globalhelper.BeforeEachSetupWithRandomNamespace(
+			tsparams.OperatorNamespace)
+
+		By("Define TNF config file")
+		err := globalhelper.DefineTnfConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{tsparams.TnfTargetOperatorLabels},
+			[]string{},
+			tsparams.TnfTargetCrdFilters, randomTnfConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomTnfConfigDir, tsparams.Timeout)
+	})
+
+	It("Operator pods should have runAs userid", func() {
+		// Deploy an operator that has runAs userid
+		By("Deploy operator group")
+		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
+		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+
+		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
+		// nginx-ingress-operator: in certified-operators group and version is certified
+		err = tshelper.DeployOperatorSubscription(
+			tsparams.CertifiedOperatorPrefixNginx,
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+			" is not ready")
+
+		By("Label operator")
+		Eventually(func() error {
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixNginx,
+				randomNamespace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Assert that the manager pod has runAs userid")
+		controllerPod, err := globalhelper.GetControllerPodFromOperator(randomNamespace, tsparams.CertifiedOperatorPrefixNginx)
+		Expect(err).ToNot(HaveOccurred(), "Error getting controller pod")
+
+		for _, container := range controllerPod.Spec.Containers {
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(container.SecurityContext.RunAsUser).ToNot(BeNil())
+			Expect(*container.SecurityContext.RunAsUser).ToNot(Equal(0))
+		}
+
+		// TODO: Run the actual tests
+	})
+
+	It("Operator pods do not have runAs userid [negative]", func() {
+		// Deploy an operator that has runAs userid
+
+		// TODO: Find an operator that does not have runAs userid
+	})
+})


### PR DESCRIPTION
Based on changes coming from: https://github.com/test-network-function/cnf-certification-test/pull/1967 

Adds 4 files for tests corresponding to the new operator tests being added above.  These `It()` blocks essentially setup the scenario for the tests to run, then do some assertions to see that that operators being deployed are actually being deployed with the correct configuration prior to kicking the tests off.

We do this for all of the other tests although this is in a backwards order where the tests have not been added to the test suite yet.